### PR TITLE
chore: roadmap state (decisions, invariants, deployment config)

### DIFF
--- a/.n8/config.yml
+++ b/.n8/config.yml
@@ -8,3 +8,20 @@ visibility: public
 context7: installed
 security_findings: issues
 areas: [gameplay, content, project, ci, docs]
+design_source: "claude.ai/design project f3f74fad-a926-4ae3-986b-fd6531c21085 (Frog Across Mobile Game) — screens, sprite specs, lane rules"
+platforms:
+  v1: android            # landscape-only; iOS explicitly deferred to post-v1 (epic #1)
+deployment:
+  dev: Unity editor + local device builds (signed AAB buildable locally)
+  stage: Google Play internal testing track, uploaded automatically by CI on tag
+  production: Google Play production, promoted from internal track (M7)
+  notes: GameCI (game-ci/unity-builder) on GitHub Actions; iOS/App Store deferred to post-v1
+ci:
+  provider: github-actions
+  on_pr: [editmode-tests, playmode-tests, android-build, analyzers, invariant-guards]
+  release: "tag -> signed AAB -> Google Play internal track (fastlane or Play Developer API)"
+  secrets_needed: [UNITY_LICENSE, android-keystore, play-service-account-json]
+levels:
+  authoring: generator + hand-tuning; schema + solvability validation in CI
+audio:
+  assets: owner-supplied (needs-owner-action); system built against placeholders

--- a/.n8/decisions.md
+++ b/.n8/decisions.md
@@ -23,3 +23,23 @@ Changes made **outside** the n8SDLC commands that deviate from planned issues ge
 When `/n8-replan` processes an ad-hoc entry it appends `— reconciled by /n8-replan <date>`.
 
 ---
+
+## /n8-roadmap — 2026-08-27
+
+- **Decision:** v1 targets Android only; iOS/App Store deferred to the post-v1 backlog epic (#1).
+  **Why:** Design specifies landscape Android; owner chose Android-first when asked.
+  **Issue:** #1
+- **Decision:** Fully automated store upload — tag → signed AAB → Google Play internal track via CI.
+  **Why:** Owner chose it over release-artifact-only; requires UNITY_LICENSE, keystore, and Play service-account secrets (owner actions in M0/M1).
+  **Issue:** #3
+- **Decision:** v1 content is ship-critical only: death/retry and level-complete/medal overlay get designed-as-built; runway/helipad lanes and "still to catalogue" pieces go to the backlog epic.
+  **Why:** The design flags these as unbuilt; owner confirmed the split.
+  **Issue:** #1, #7
+- **Decision:** 100 levels come from a generator + hand-tuning, with schema/solvability validation in CI.
+  **Why:** Hand-authoring 100 boards is prohibitive; owner confirmed.
+  **Issue:** #10
+- **Decision:** Audio assets are owner-supplied; the audio system is built against placeholders so only the final swap blocks.
+  **Why:** No audio exists in the design project; owner chose to supply their own.
+  **Issue:** #11
+- **Decision:** Four project invariants recorded in CLAUDE.md (no-network/no-ads, data-driven levels, piece object model, determinism), with executable guards planned into M0/M2/CI.
+  **Why:** Derived from the design's own statements (no ads/tracking, on-device only) and the owner's stated extensibility requirements; owner confirmed all four.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 2D Unity game (Unity 6000.5.10f1, Universal Render Pipeline 2D, Input System). Binary assets go through Git LFS (`.gitattributes`); serialization is Force Text — keep it that way so diffs work.
 
+## Project invariants
+
+Load-bearing constraints no story may breach without an explicit conversation with the owner. Changing one is plan drift by definition: log it as an ad-hoc ledger entry in `.n8/decisions.md` and suggest `/n8-replan`.
+
+1. **No ads, no tracking, no analytics, no network calls** — all player data stays on-device. *(test-enforced: guard test fails the build if network permissions or ads/analytics packages appear)*
+2. **Levels are pure data (JSON)** — adding a level requires zero code changes. *(test-enforced: schema validation; levels load with no code registration)*
+3. **Every game piece is a data-defined object type** (characters, lane types, lane objects, obstructions) — new pieces slot in without rewriting systems. *(honor-system, checked by audits)*
+4. **Deterministic levels** — a level plays identically every run (seeded, fixed traffic patterns). *(test-enforced: replay/determinism guard test)*
+
 ## n8SDLC project
 
 This project is managed by the n8SDLC workflow (GitHub Issues = the plan; `/n8-stat` shows where things stand). If a change made in this session deviates from what planned issues assume — different library, provider, architecture, dropped/added scope, or amending a declared invariant below — do two things before finishing:


### PR DESCRIPTION
Records the /n8-roadmap run: deployment/CI answers in .n8/config.yml, four project invariants in CLAUDE.md, and the decision log. Epics #2–#12 + backlog #1 and milestones M0–M8 were created on GitHub as part of the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeAv87tQK1G7qsTHK3dPc