### PR TITLE
feat: spaced player-visible name (Frog Across)

### DIFF
--- a/.n8/decisions.md
+++ b/.n8/decisions.md
@@ -117,3 +117,9 @@ When `/n8-replan` processes an ad-hoc entry it appends `— reconciled by /n8-re
 - **Decision:** FROG_KEY_PASS set equal to FROG_KEYSTORE_PASS in the credentials file (with an explanatory note), keystore kept as PKCS12.
   **Why:** keytool's default PKCS12 format uses a single password for store and key — the separately-generated key password was silently ignored at creation and Gradle signing failed with "final block not properly padded". PKCS12 is the modern format; JKS (which supports split passwords) is deprecated.
   **Issue:** #19
+
+## Ad-hoc — 2026-08-28
+
+- **Change:** Player-visible name is "Frog Across" (spaced) everywhere — launcher label, runtime constant, and the Play Console app entry the owner created. The design's logo lockup renders "FrogAcross" one-word with a two-tone split.
+  **Why:** Owner decision during Play Console app creation ("update to use the spaced version anywhere the user sees").
+  **Affects:** M4 (screens epic #8 — menu/loading logo copy must read "Frog Across" or restyle the lockup; its "copy matches the design" AC carries this override), M7 (store assets/listing already spaced). Repo/package/internal identifiers stay unspaced (com.honestarcade.frogacross is immutable).

--- a/Assets/Scripts/Editor/Build/BuildScript.cs
+++ b/Assets/Scripts/Editor/Build/BuildScript.cs
@@ -20,7 +20,7 @@ namespace FrogAcross.Editor.Build
         [MenuItem("FrogAcross/Build/Apply Baseline Settings")]
         public static void ApplyBaselineSettings()
         {
-            PlayerSettings.productName = "FrogAcross";
+            PlayerSettings.productName = "Frog Across"; // spaced everywhere player-visible (owner decision 2026-08-28)
             PlayerSettings.companyName = "Honest Arcade";
             PlayerSettings.SetApplicationIdentifier(NamedBuildTarget.Android, PackageId);
             PlayerSettings.bundleVersion = "0.1.0";

--- a/Assets/Scripts/Runtime/AppInfo.cs
+++ b/Assets/Scripts/Runtime/AppInfo.cs
@@ -3,7 +3,7 @@ namespace FrogAcross
     /// <summary>Build-independent app constants.</summary>
     public static class AppInfo
     {
-        public const string ProductName = "FrogAcross";
+        public const string ProductName = "Frog Across";
         public const string Company = "Honest Arcade";
     }
 }

--- a/Assets/Tests/EditMode/PlayerSettingsTests.cs
+++ b/Assets/Tests/EditMode/PlayerSettingsTests.cs
@@ -18,7 +18,7 @@ namespace FrogAcross.Tests.EditMode
         [Test]
         public void ProductAndCompany_MatchBrand()
         {
-            Assert.AreEqual("FrogAcross", PlayerSettings.productName);
+            Assert.AreEqual("Frog Across", PlayerSettings.productName);
             Assert.AreEqual("Honest Arcade", PlayerSettings.companyName);
         }
 

--- a/Assets/Tests/EditMode/SmokeTests.cs
+++ b/Assets/Tests/EditMode/SmokeTests.cs
@@ -8,7 +8,7 @@ namespace FrogAcross.Tests.EditMode
         [Test]
         public void RuntimeAssembly_IsReachable()
         {
-            Assert.AreEqual("FrogAcross", AppInfo.ProductName);
+            Assert.AreEqual("Frog Across", AppInfo.ProductName);
         }
     }
 }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -13,7 +13,7 @@ PlayerSettings:
   useOnDemandResources: 0
   accelerometerFrequency: 60
   companyName: Honest Arcade
-  productName: FrogAcross
+  productName: Frog Across
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}


### PR DESCRIPTION
Owner decision during Play Console app creation: the game's name is "Frog Across" everywhere a player sees it. Launcher label + runtime constant + test pins; ad-hoc ledger entry flags the M4 design-lockup implication (also commented on epic #8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeAv87tQK1G7qsTHK3dPc