### PR TITLE
chore: missed Runtime folder meta

### DIFF
--- a/Assets/Scripts/Runtime.meta
+++ b/Assets/Scripts/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5deee6513db02428794a6dd1bcc05c92
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Folder .meta missed by a directory-scoped git add during M0; without it CI/fresh clones regenerate a new GUID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeAv87tQK1G7qsTHK3dPc