### PR TITLE
M1: CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+# The single quality gate (#23): every PR runs it directly; the release
+# pipeline consumes it via workflow_call so PRs and pre-deploy run the
+# identical checks. The M0 invariant guards and analyzer errors ride along
+# automatically — they live in the test/build path.
+name: CI
+on:
+  pull_request:
+  workflow_call:
+
+permissions:
+  contents: read
+
+# Per-ref group: superseded PR builds are waste. Tag refs are unique, so a
+# release's call of this workflow can never be cancelled by a PR push.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Tests (${{ matrix.testMode }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testMode: [EditMode, PlayMode]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: actions/cache@v4
+        with:
+          path: Library
+          key: library-test-${{ hashFiles('Packages/manifest.json', 'Packages/packages-lock.json', 'ProjectSettings/ProjectVersion.txt') }}
+          restore-keys: library-test-
+      - uses: game-ci/unity-test-runner@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          testMode: ${{ matrix.testMode }}
+          # Android editor image: our editor code compiles against
+          # UnityEditor.Android, which the base image lacks.
+          customImage: unityci/editor:ubuntu-6000.5.10f1-android-3
+          artifactsPath: test-results-${{ matrix.testMode }}
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-${{ matrix.testMode }}
+          path: test-results-${{ matrix.testMode }}
+          retention-days: 7
+
+  build:
+    name: Android build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: actions/cache@v4
+        with:
+          path: Library
+          key: library-build-${{ hashFiles('Packages/manifest.json', 'Packages/packages-lock.json', 'ProjectSettings/ProjectVersion.txt') }}
+          restore-keys: library-build-
+      - uses: game-ci/unity-builder@v5
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          targetPlatform: Android
+          androidExportType: androidAppBundle
+      # Unsigned PR artifact — sideloadable for device testing after
+      # bundletool conversion; short retention, this is a convenience.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frogacross-aab-${{ github.sha }}
+          path: build/Android
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,10 @@ jobs:
         with:
           targetPlatform: Android
           androidExportType: androidAppBundle
+          # Our own CI entry point (parses the action's standard CLI args) —
+          # avoids the injected UnityBuilderAction script, which our analyzer
+          # gate rejects (vendor code carrying UNT violations).
+          buildMethod: FrogAcross.Editor.Build.BuildScript.BuildCi
       # Unsigned PR artifact — sideloadable for device testing after
       # bundletool conversion; short retention, this is a convenience.
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/play-api-check.yml
+++ b/.github/workflows/play-api-check.yml
@@ -1,0 +1,36 @@
+# Validation for the Play service account (#24): proves the secret's JSON
+# authenticates against the Play Developer API with access to our package,
+# before the release pipeline depends on it. Dispatch manually.
+name: Play API check
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate service account
+        env:
+          PLAY_SA: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          umask 077
+          printf '%s' "$PLAY_SA" > "$RUNNER_TEMP/sa.json"
+          gcloud auth activate-service-account --key-file="$RUNNER_TEMP/sa.json"
+      - name: Create and discard an edit (proves app-scoped API access)
+        run: |
+          TOKEN=$(gcloud auth print-access-token)
+          PKG=com.honestarcade.frogacross
+          RESP=$(curl -sf -X POST -H "Authorization: Bearer $TOKEN" \
+            "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PKG/edits") || {
+              echo "::error::Play API edit-create failed — check the service account's app permission for $PKG"; exit 1; }
+          EDIT_ID=$(echo "$RESP" | jq -r .id)
+          echo "Edit created: $EDIT_ID"
+          curl -sf -X DELETE -H "Authorization: Bearer $TOKEN" \
+            "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PKG/edits/$EDIT_ID" || true
+          {
+            printf '## Play API access verified\n\n'
+            printf -- '- Service account authenticated and created (then discarded) an edit for %s\n' "$PKG"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           targetPlatform: Android
           androidExportType: androidAppBundle
+          buildMethod: FrogAcross.Editor.Build.BuildScript.BuildCi
           versioning: Custom
           version: ${{ steps.ver.outputs.name }}
           androidVersionCode: ${{ steps.ver.outputs.code }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+# Tag → signed AAB → Google Play internal track (#25).
+# The CI gate is structurally upstream: the upload job cannot run unless the
+# identical PR checks pass on the tagged commit.
+name: Release
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+# Never kill a deploy mid-flight.
+concurrency:
+  group: play-release
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+
+  ship:
+    name: Signed AAB → Play internal track
+    needs: gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: actions/cache@v4
+        with:
+          path: Library
+          key: library-build-${{ hashFiles('Packages/manifest.json', 'Packages/packages-lock.json', 'ProjectSettings/ProjectVersion.txt') }}
+          restore-keys: library-build-
+      # androidVersionCode from run_number (+100 offset clears M0's local
+      # versionCode 1) — strictly monotonic across tag runs by construction.
+      - name: Compute versions
+        id: ver
+        run: |
+          echo "name=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          echo "code=$(( ${{ github.run_number }} + 100 ))" >> "$GITHUB_OUTPUT"
+      - uses: game-ci/unity-builder@v5
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          targetPlatform: Android
+          androidExportType: androidAppBundle
+          versioning: Custom
+          version: ${{ steps.ver.outputs.name }}
+          androidVersionCode: ${{ steps.ver.outputs.code }}
+          androidKeystoreName: frogacross-upload.keystore
+          androidKeystoreBase64: ${{ secrets.FROG_KEYSTORE_B64 }}
+          androidKeystorePass: ${{ secrets.FROG_KEYSTORE_PASS }}
+          androidKeyaliasName: ${{ secrets.FROG_KEY_ALIAS }}
+          androidKeyaliasPass: ${{ secrets.FROG_KEY_PASS }}
+      - name: Upload to Play internal track
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.honestarcade.frogacross
+          releaseFiles: build/Android/*.aab
+          track: internal
+          status: completed
+      - name: Summary
+        run: |
+          {
+            printf '## Shipped to Play internal track\n\n'
+            printf -- '- Version: **%s** (versionCode %s)\n' "${{ steps.ver.outputs.name }}" "${{ steps.ver.outputs.code }}"
+            printf -- '- Package: com.honestarcade.frogacross\n'
+            printf -- '- Console: https://play.google.com/console → Frog Across → Internal testing\n'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.n8/decisions.md
+++ b/.n8/decisions.md
@@ -138,3 +138,6 @@ When `/n8-replan` processes an ad-hoc entry it appends `— reconciled by /n8-re
 - **Decision:** versionCode = github.run_number + 100 (offset clears M0's local code 1); versionName from the tag via versioning: Custom.
   **Why:** Strict monotonicity by construction; discretion granted in #25.
   **Issue:** #25
+- **Decision (Rule 3 — CI build blocker):** The analyzer gate failed the CI Android build on GameCI's own injected UnityBuilderAction script (error UNT0007 in vendor code). Fix: custom buildMethod `BuildScript.BuildCi` — our own gate-compliant entry point parsing the action's standard CLI args (verified against build.sh @ v5.0.0: -customBuildPath, -buildVersion, -androidVersionCode, androidKeystore* are passed regardless of buildMethod; with buildMethod set, no script injection occurs). Vendoring a fixed copy at their path was rejected: build.sh cp -R overwrites same-path files. Parser pinned by BuildCiArgsTests.
+  **Why:** Weakening the gate (suppressing UNT0007 globally) was the only alternative and is explicitly forbidden by the no-weakened-gates rule.
+  **Issue:** #23, #25

--- a/.n8/decisions.md
+++ b/.n8/decisions.md
@@ -123,3 +123,18 @@ When `/n8-replan` processes an ad-hoc entry it appends `— reconciled by /n8-re
 - **Change:** Player-visible name is "Frog Across" (spaced) everywhere — launcher label, runtime constant, and the Play Console app entry the owner created. The design's logo lockup renders "FrogAcross" one-word with a two-tone split.
   **Why:** Owner decision during Play Console app creation ("update to use the spaced version anywhere the user sees").
   **Affects:** M4 (screens epic #8 — menu/loading logo copy must read "Frog Across" or restyle the lockup; its "copy matches the design" AC carries this override), M7 (store assets/listing already spaced). Repo/package/internal identifiers stay unspaced (com.honestarcade.frogacross is immutable).
+
+## /n8-exec M1 — 2026-08-28
+
+- **Decision:** unity-builder pinned at v5 (plan said v4; verified stale), unity-test-runner v4 (current), upload-google-play v1 (current). Betas (builder v6-beta, test-runner v5-beta) skipped.
+  **Why:** The stories' own verify-before-writing rule; checked GameCI releases/docs live.
+  **Issue:** #23, #25
+- **Decision (within #22's discretion):** Activation approach superseded — no .alf workflow. Current GameCI procedure: local Unity Hub-generated .ulf → UNITY_LICENSE secret, plus UNITY_EMAIL/UNITY_PASSWORD. No .ulf exists on this machine (Hub entitlement licensing), so the owner step is Hub → Licenses → Add → free personal license; agent sets UNITY_LICENSE from the file; owner sets email/password secrets directly so credentials never transit the conversation. The .alf-artifact AC is vacuous under the superseded path; the proof AC (green headless run) is unchanged.
+  **Issue:** #22
+- **Decision:** Test jobs use customImage unityci/editor:ubuntu-6000.5.10f1-android-3 — our editor assemblies compile against UnityEditor.Android, absent from the base image. Image tag is a best-known pin; a pull failure on first CI run means adjusting the suffix to a published tag.
+  **Issue:** #23
+- **Decision:** Keystore GitHub secrets (FROG_KEYSTORE_B64/PASS/KEY_ALIAS/KEY_PASS) set by agent from the local M0 material per plan; release builds sign via unity-builder's androidKeystore* inputs (builder runs its own build command — our BuildScript's FROG_RELEASE gate remains the local-build gate; in CI the equivalent guarantee is structural: the ship job only signs, never uploads unsigned).
+  **Issue:** #25
+- **Decision:** versionCode = github.run_number + 100 (offset clears M0's local code 1); versionName from the tag via versioning: Custom.
+  **Why:** Strict monotonicity by construction; discretion granted in #25.
+  **Issue:** #25

--- a/.n8/memory/ci-unity-license.md
+++ b/.n8/memory/ci-unity-license.md
@@ -1,0 +1,14 @@
+---
+name: ci-unity-license
+description: How CI authenticates Unity (Personal license), failure signatures, re-activation runbook
+metadata:
+  type: project
+---
+
+# Unity licensing in CI
+
+- **License:** Unity Personal, owned by the owner's Unity account. Three repo secrets: `UNITY_LICENSE` (full contents of the `.ulf` file), `UNITY_EMAIL`, `UNITY_PASSWORD` (the Unity account credentials — GameCI requires all three for Personal licenses).
+- **Where the .ulf comes from:** Unity Hub → Settings → Licenses → Add → "Get a free personal license" writes `/Library/Application Support/Unity/Unity_lic.ulf` on macOS. Hub's newer entitlement licensing does NOT create this file until that step is done explicitly, even when the editor runs fine locally.
+- **Procedure history:** the old `.alf` activation-file workflow (game-ci/unity-request-activation-file) is superseded — do not resurrect it; current GameCI docs use the local-.ulf method (checked 2026-08-28).
+- **Failure signatures:** log lines like `[Licensing::Module] Error: Access token is unavailable` / `No valid Unity license` in the test/build step → license secret invalid or expired.
+- **Re-activation:** repeat the Hub step above (new .ulf), then `gh secret set UNITY_LICENSE < "/Library/Application Support/Unity/Unity_lic.ulf"`. Email/password secrets only change if the Unity account does.

--- a/Assets/Scripts/Editor/Build/BuildScript.cs
+++ b/Assets/Scripts/Editor/Build/BuildScript.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using UnityEditor;
@@ -111,7 +112,82 @@ namespace FrogAcross.Editor.Build
             else if (!ok) throw new BuildFailedException("[BuildScript] Build failed — see log.");
         }
 
-        private static bool BuildAabInner()
+        /// <summary>
+        /// CI entry point for game-ci/unity-builder's custom buildMethod. The
+        /// action passes its standard values as CLI args regardless of build
+        /// method (-customBuildPath, -buildVersion, -androidVersionCode, and
+        /// the androidKeystore* quartet); we parse them ourselves instead of
+        /// letting the action inject its UnityBuilderAction script — which our
+        /// analyzer gate rejects (vendor code with UNT violations) and which
+        /// cp -R would overwrite if we vendored a fixed copy at its path.
+        /// </summary>
+        public static void BuildCi()
+        {
+            var args = ParseArgs(Environment.GetCommandLineArgs());
+            EditorUserBuildSettings.buildAppBundle = true;
+
+            if (args.TryGetValue("buildVersion", out string v) && !string.IsNullOrEmpty(v))
+                PlayerSettings.bundleVersion = v;
+            if (args.TryGetValue("androidVersionCode", out string vc)
+                && int.TryParse(vc, out int code) && code > 0)
+                PlayerSettings.Android.bundleVersionCode = code;
+
+            string ks = args.GetValueOrDefault("androidKeystoreName", "");
+            string ksPass = args.GetValueOrDefault("androidKeystorePass", "");
+            string alias = args.GetValueOrDefault("androidKeyaliasName", "");
+            string aliasPass = args.GetValueOrDefault("androidKeyaliasPass", "");
+            bool signed = !string.IsNullOrEmpty(ks) && !string.IsNullOrEmpty(ksPass)
+                && !string.IsNullOrEmpty(alias) && !string.IsNullOrEmpty(aliasPass);
+            if (signed)
+            {
+                PlayerSettings.Android.useCustomKeystore = true;
+                PlayerSettings.Android.keystoreName = ks;
+                PlayerSettings.Android.keystorePass = ksPass;
+                PlayerSettings.Android.keyaliasName = alias;
+                PlayerSettings.Android.keyaliasPass = aliasPass;
+                Debug.Log($"[BuildScript] CI signing with key alias '{alias}'.");
+            }
+            else
+            {
+                PlayerSettings.Android.useCustomKeystore = false;
+                Debug.Log("[BuildScript] CI build unsigned (no keystore args).");
+            }
+
+            string outPath = args.GetValueOrDefault("customBuildPath", "");
+            if (string.IsNullOrEmpty(outPath)) outPath = OutputPath;
+
+            bool ok;
+            try
+            {
+                ok = BuildAabInner(outPath);
+            }
+            finally
+            {
+                ClearSigning();
+            }
+            if (Application.isBatchMode) EditorApplication.Exit(ok ? 0 : 1);
+            else if (!ok) throw new BuildFailedException("[BuildScript] CI build failed — see log.");
+        }
+
+        /// <summary>-key value pairs from a Unity command line (testable core).</summary>
+        public static Dictionary<string, string> ParseArgs(string[] argv)
+        {
+            var result = new Dictionary<string, string>();
+            for (int i = 0; i < argv.Length; i++)
+            {
+                if (!argv[i].StartsWith("-", StringComparison.Ordinal)) continue;
+                string key = argv[i].TrimStart('-');
+                string value = i + 1 < argv.Length && !argv[i + 1].StartsWith("-", StringComparison.Ordinal)
+                    ? argv[i + 1]
+                    : string.Empty;
+                result[key] = value;
+            }
+            return result;
+        }
+
+        private static bool BuildAabInner() => BuildAabInner(OutputPath);
+
+        private static bool BuildAabInner(string outputPath)
         {
             string[] scenes = EditorBuildSettings.scenes
                 .Where(s => s.enabled)
@@ -123,12 +199,13 @@ namespace FrogAcross.Editor.Build
                 return false;
             }
 
-            Directory.CreateDirectory(Path.GetDirectoryName(OutputPath)!);
+            string dir = Path.GetDirectoryName(outputPath);
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
 
             var options = new BuildPlayerOptions
             {
                 scenes = scenes,
-                locationPathName = OutputPath,
+                locationPathName = outputPath,
                 target = BuildTarget.Android,
                 options = BuildOptions.None,
             };
@@ -140,7 +217,7 @@ namespace FrogAcross.Editor.Build
                 return false;
             }
 
-            Debug.Log($"[BuildScript] AAB built: {OutputPath} ({report.summary.totalSize} bytes).");
+            Debug.Log($"[BuildScript] AAB built: {outputPath} ({report.summary.totalSize} bytes).");
             return true;
         }
 

--- a/Assets/Tests/EditMode/BuildCiArgsTests.cs
+++ b/Assets/Tests/EditMode/BuildCiArgsTests.cs
@@ -1,0 +1,51 @@
+using FrogAcross.Editor.Build;
+using NUnit.Framework;
+
+namespace FrogAcross.Tests.EditMode
+{
+    /// <summary>
+    /// BuildCi consumes game-ci/unity-builder's CLI args — the parser is the
+    /// contract point, so it gets pinned. Shape mirrors the action's real
+    /// invocation (dist/platforms/ubuntu/steps/build.sh @ v5.0.0).
+    /// </summary>
+    public class BuildCiArgsTests
+    {
+        [Test]
+        public void ParsesKeyValuePairs_LikeUnityBuilderInvocation()
+        {
+            var args = BuildScript.ParseArgs(new[]
+            {
+                "/opt/unity/Editor/Unity", "-quit",
+                "-customBuildPath", "/github/workspace/build/Android/Android.aab",
+                "-buildVersion", "0.2.0",
+                "-androidVersionCode", "103",
+                "-androidKeystoreName", "frogacross-upload.keystore",
+                "-androidKeystorePass", "s3cret",
+                "-androidKeyaliasName", "upload",
+                "-androidKeyaliasPass", "s3cret",
+            });
+
+            Assert.AreEqual("/github/workspace/build/Android/Android.aab", args["customBuildPath"]);
+            Assert.AreEqual("0.2.0", args["buildVersion"]);
+            Assert.AreEqual("103", args["androidVersionCode"]);
+            Assert.AreEqual("upload", args["androidKeyaliasName"]);
+        }
+
+        [Test]
+        public void FlagFollowedByFlag_YieldsEmptyValue()
+        {
+            var args = BuildScript.ParseArgs(new[] { "-quit", "-batchmode", "-buildVersion", "1.0" });
+            Assert.AreEqual(string.Empty, args["quit"]);
+            Assert.AreEqual(string.Empty, args["batchmode"]);
+            Assert.AreEqual("1.0", args["buildVersion"]);
+        }
+
+        [Test]
+        public void EmptyStringValues_ReadAsMissing()
+        {
+            // build.sh passes -androidKeystorePass "" when unset — must read as unsigned.
+            var args = BuildScript.ParseArgs(new[] { "-androidKeystorePass", "" });
+            Assert.AreEqual(string.Empty, args["androidKeystorePass"]);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/BuildCiArgsTests.cs.meta
+++ b/Assets/Tests/EditMode/BuildCiArgsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 615532d09192948a9aca39eeab126325


### PR DESCRIPTION
Executes milestone M1 (epic #3): the reusable CI gate and the tag→Play release pipeline. GameCI versions verified live (builder v5, test-runner v4, upload-google-play v1 — the plan's builder v4 pin was stale).

Story completion and Closes lines land after the license/service-account secrets exist and the runs prove green — see #22/#24 for the two owner steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeAv87tQK1G7qsTHK3dPc