### PR TITLE
fix: play-check diagnostics (with ruleset red-proof)

### DIFF
--- a/.github/workflows/play-api-check.yml
+++ b/.github/workflows/play-api-check.yml
@@ -23,9 +23,15 @@ jobs:
         run: |
           TOKEN=$(gcloud auth print-access-token)
           PKG=com.honestarcade.frogacross
-          RESP=$(curl -sf -X POST -H "Authorization: Bearer $TOKEN" \
-            "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PKG/edits") || {
-              echo "::error::Play API edit-create failed — check the service account's app permission for $PKG"; exit 1; }
+          HTTP=$(curl -s -o "$RUNNER_TEMP/resp.json" -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PKG/edits")
+          if [ "$HTTP" != "200" ]; then
+            echo "::error::Play API edit-create returned HTTP $HTTP for $PKG"
+            echo "Response body:"; cat "$RUNNER_TEMP/resp.json"
+            exit 1
+          fi
+          RESP=$(cat "$RUNNER_TEMP/resp.json")
           EDIT_ID=$(echo "$RESP" | jq -r .id)
           echo "Edit created: $EDIT_ID"
           curl -sf -X DELETE -H "Authorization: Bearer $TOKEN" \

--- a/Assets/Tests/EditMode/TempRedTest.cs
+++ b/Assets/Tests/EditMode/TempRedTest.cs
@@ -1,0 +1,8 @@
+using NUnit.Framework;
+namespace FrogAcross.Tests.EditMode
+{
+    public class TempRedTest
+    {
+        [Test] public void SynthesizedFailure_ForRulesetProof() => Assert.Fail("deliberate red for #23's merge-block proof");
+    }
+}

--- a/Assets/Tests/EditMode/TempRedTest.cs
+++ b/Assets/Tests/EditMode/TempRedTest.cs
@@ -1,8 +1,0 @@
-using NUnit.Framework;
-namespace FrogAcross.Tests.EditMode
-{
-    public class TempRedTest
-    {
-        [Test] public void SynthesizedFailure_ForRulesetProof() => Assert.Fail("deliberate red for #23's merge-block proof");
-    }
-}


### PR DESCRIPTION
Improves play-api-check error output (HTTP code + response body). First commit carries a deliberate failing test to prove the required-check ruleset blocks merging (#23's synthesized-failure AC); it gets reverted once the red run is recorded.

Refs #23 #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeAv87tQK1G7qsTHK3dPc