### PR TITLE
fix: androidpublisher scope for Play API check

### DIFF
--- a/.github/workflows/play-api-check.yml
+++ b/.github/workflows/play-api-check.yml
@@ -21,7 +21,7 @@ jobs:
           gcloud auth activate-service-account --key-file="$RUNNER_TEMP/sa.json"
       - name: Create and discard an edit (proves app-scoped API access)
         run: |
-          TOKEN=$(gcloud auth print-access-token)
+          TOKEN=$(gcloud auth print-access-token --scopes=https://www.googleapis.com/auth/androidpublisher)
           PKG=com.honestarcade.frogacross
           HTTP=$(curl -s -o "$RUNNER_TEMP/resp.json" -w '%{http_code}' -X POST \
             -H "Authorization: Bearer $TOKEN" \


### PR DESCRIPTION
The 403 was our token's missing scope, not the service account's permissions.

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeAv87tQK1G7qsTHK3dPc