### PR TITLE
chore: tap-region scheme ledger amendment

### DIFF
--- a/.n8/decisions.md
+++ b/.n8/decisions.md
@@ -169,3 +169,9 @@ When `/n8-replan` processes an ad-hoc entry it appends `— reconciled by /n8-re
 - **Change:** Tap-to-advance added: a clear tap counts as a forward swipe (one forward hop, same queue/legality rules); dead zone between tap ceiling and swipe threshold does nothing.
   **Why:** Owner scope decision during planning review — faster forward movement ergonomics.
   **Affects:** M2 #41 (amended directly — body/AC/tests updated pre-execution) and M4 #58 (controls copy rider commented). No other stories assume tap-does-nothing. Reconciled at source — reconciled by /n8-plan 2026-08-28.
+
+## Ad-hoc — 2026-08-28
+
+- **Change:** Tap-region control scheme added as a settings option (#74, new M2 story): four zones (left/right thirds, middle-column top/bottom) move the character; no diagonals in this mode; Settings (#59) gains the scheme selector + a "Show regions" one-tap-dismiss preview; regions raycast BEHIND all UI. Consequences worked through the plan: gameplay HUD gains Restart + Main-menu buttons with confirm dialogs (#60), **all confirm dialogs freeze the sim/clock** ("no pause" now means "no dedicated pause screen" — freezing is consistent with OS-suspend), restart = fresh attempt (bays cleared, clock rearmed), solver gains a diagonal-free mode (#43) and medal calibration uses diagonal-free min-times (#63) so tap-region players can earn gold.
+  **Why:** Owner scope additions during planning review (accessibility/ergonomics + quick restart).
+  **Affects:** #74 (new), #43 #55 #58 #59 #60 #63 (amended via comments, pre-execution). Reconciled at source — reconciled by /n8-plan 2026-08-28.


### PR DESCRIPTION
Ad-hoc ledger for the owner's tap-region control scheme + HUD buttons additions, reconciled at source (#74 created; #43/#55/#58/#59/#60/#63 amended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeAv87tQK1G7qsTHK3dPc