### PR TITLE
M7: Release readiness (agent-executable slice)

### DIFF
--- a/.github/workflows/play-promote.yml
+++ b/.github/workflows/play-promote.yml
@@ -1,0 +1,56 @@
+# Promote the newest release between Play testing tracks (#69).
+# Same AAB lineage — this MOVES a version, it never builds one. The service
+# account is deliberately restricted to testing tracks; production promotion
+# stays a human act in the Console (#70).
+name: Play track promote
+on:
+  workflow_dispatch:
+    inputs:
+      from_track:
+        description: 'Source track'
+        default: 'internal'
+        required: true
+      to_track:
+        description: 'Target track (testing tracks only — the SA cannot touch production)'
+        default: 'alpha'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/auth@v2
+        id: auth
+        with:
+          credentials_json: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/androidpublisher
+      - name: Promote release
+        env:
+          TOKEN: ${{ steps.auth.outputs.access_token }}
+          PKG: com.honestarcade.frogacross
+          FROM: ${{ inputs.from_track }}
+          TO: ${{ inputs.to_track }}
+        run: |
+          set -euo pipefail
+          api="https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$PKG"
+          auth=(-H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json")
+
+          edit=$(curl -sf "${auth[@]}" -X POST "$api/edits" | jq -r .id)
+          src=$(curl -sf "${auth[@]}" "$api/edits/$edit/tracks/$FROM")
+          echo "source track: $src"
+          codes=$(echo "$src" | jq '[.releases[] | select(.status=="completed") | .versionCodes[]] | map(tonumber) | sort | reverse | .[0:1]')
+          [ "$codes" != "[]" ] || { echo "no completed release on $FROM"; exit 1; }
+
+          body=$(jq -n --argjson codes "$codes" '{releases:[{versionCodes:$codes, status:"completed"}]}')
+          curl -sf "${auth[@]}" -X PUT -d "$body" "$api/edits/$edit/tracks/$TO" > /dev/null
+          curl -sf "${auth[@]}" -X POST "$api/edits/$edit:commit" > /dev/null
+
+          {
+            printf '## Promoted on Play\n\n'
+            printf -- '- versionCode(s): %s\n' "$(echo "$codes" | jq -cr .)"
+            printf -- '- %s → %s\n' "$FROM" "$TO"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,13 @@ jobs:
           androidKeystorePass: ${{ secrets.FROG_KEYSTORE_PASS }}
           androidKeyaliasName: ${{ secrets.FROG_KEY_ALIAS }}
           androidKeyaliasPass: ${{ secrets.FROG_KEY_PASS }}
+      # #35: locate the symbols package + R8 mapping the build emitted
+      - name: Locate debug artifacts
+        id: dbg
+        run: |
+          ls -la build/Android/ || true
+          echo "symbols=$(ls build/Android/*.symbols.zip 2>/dev/null | head -1)" >> "$GITHUB_OUTPUT"
+          echo "mapping=$(ls build/Android/mapping.txt 2>/dev/null | head -1)" >> "$GITHUB_OUTPUT"
       - name: Upload to Play internal track
         uses: r0adkll/upload-google-play@v1
         with:
@@ -64,6 +71,8 @@ jobs:
           releaseFiles: build/Android/*.aab
           track: internal
           status: completed
+          debugSymbols: ${{ steps.dbg.outputs.symbols }}
+          mappingFile: ${{ steps.dbg.outputs.mapping }}
       - name: Summary
         run: |
           {
@@ -71,4 +80,5 @@ jobs:
             printf -- '- Version: **%s** (versionCode %s)\n' "${{ steps.ver.outputs.name }}" "${{ steps.ver.outputs.code }}"
             printf -- '- Package: com.honestarcade.frogacross\n'
             printf -- '- Console: https://play.google.com/console → Frog Across → Internal testing\n'
+            printf -- '- Symbols: %s · Mapping: %s\n' "${{ steps.dbg.outputs.symbols }}" "${{ steps.dbg.outputs.mapping }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.n8/decisions.md
+++ b/.n8/decisions.md
@@ -212,3 +212,12 @@ When `/n8-replan` processes an ad-hoc entry it appends `— reconciled by /n8-re
 ### M6 execution (2026-08-28)
 
 - **#66 blocked (needs-owner-action):** owner audio files not yet supplied. Concrete asset list posted on the issue (13 SFX + 1–2 music loops + license terms per file). Engine (#65) complete — swap is a file drop; gameplay-music question resolves implicitly by what the owner provides.
+
+### M7 execution (2026-08-28)
+
+- **#35 symbols API:** EditorUserBuildSettings.androidCreateSymbols is obsolete in 6000.5 — used UnityEditor.Android.UserBuildSettings.DebugSymbols (level=SymbolTable, format=Zip). SymbolTable (public) level: readable Play crash stacks at a fraction of full-debug size.
+- **#35 R8 mapping:** enabled minifyRelease (also shrinks the AAB); Unity buries mapping.txt in Library/Bee — BuildScript copies the freshest one next to the AAB post-build; release.yml resolves both artifacts and passes them to upload-google-play. Proof deferred to the v0.2.0 tag run (also seeds #69's closed track).
+- **#67 screenshots are editor captures of the real game** (real level data, shipped BoardView renderer, player state = solver proof-line replayed 2/3): the "release build" key link is satisfiable more literally by on-device captures once v0.2.0 is installed — offered to the owner at verify, not blocking the draft listing.
+- **#67 surfaced two real BoardView bugs, fixed (Rule 1 + regression test):** (a) bay-fill character sprite was unscaled — raw sprites are ~4 world units wide, so a filled bay rendered a giant frog (BayFill_FitsInsideItsCell pins the fix); (b) side covers used the tiled bank texture (banding) and were only 14 units wide — wide phones would see board internals; now flat #16321F, 40 units.
+- **#68 privacy policy hosting (delegated):** GitHub Pages from main/docs (enabled 2026-08-28) — https://honestarcade.github.io/HonestFrogAcross/privacy. The repo is public and open source is part of the store pitch, so Pages fits; no separate infrastructure.
+- **#69 promotion runs in CI, not locally:** the Play service-account key exists only as a GitHub secret (by design — no local key material). Added play-promote.yml (workflow_dispatch, internal→alpha default) using the androidpublisher REST API; the SA remains testing-tracks-only, so production promotion (#70) stays a human Console act.

--- a/.n8/memory/play-console.md
+++ b/.n8/memory/play-console.md
@@ -13,3 +13,52 @@ metadata:
 - **Personal-account constraint (affects M7):** production access requires a closed test with ≥12 testers continuously opted-in for 14 days. Recorded in the M7 milestone description; recruit testers at M7 start.
 - **Service account for CI (#24):** not yet created — record its identity here when it exists.
 - Never store credentials in this file — identifiers and constraints only.
+
+## Data-safety form — prepared answers (#68, drafted 2026-08-28)
+
+Ground truth: the AAB contains no INTERNET permission (enforced by
+NoNetworkGuardTests + the final-AAB byte scan on every build). The app cannot
+transmit anything. Answer the form exactly like this:
+
+1. "Does your app collect or share any of the required user data types?" → **No**
+2. "Is all of the user data collected by your app encrypted in transit?" → question does not appear once "No" is selected
+3. "Do you provide a way for users to request that their data is deleted?" → question does not appear once "No" is selected
+4. Preview shows: "No data collected · No data shared" → **Submit**
+
+Privacy policy URL (required even for no-data apps):
+**https://honestarcade.github.io/HonestFrogAcross/privacy**
+(GitHub Pages from main/docs — enabled 2026-08-28; content: no data collected,
+no network access, contact support@honestarcade.app)
+
+## Content rating (IARC) — prepared answers (#68)
+
+- Category: **Game**
+- Email: support@honestarcade.app
+- Violence: cartoon character can be "defeated" by hazards (vehicle contact,
+  water) with a brief cartoon splat/sink — answer **Yes** to "mild cartoon or
+  fantasy violence", **No** to realistic violence, gore, or violence toward
+  defenseless characters.
+- Sexuality / nudity: **No**
+- Language / profanity: **No**
+- Controlled substances (drugs/alcohol/tobacco): **No**
+- Gambling (real or simulated): **No**
+- User interaction / online features: **No** (no chat, no UGC, no multiplayer)
+- Shares location: **No**
+- Digital purchases: **No**
+- Expected outcome: **Everyone / PEGI 3** (mild cartoon peril)
+- Record the issued rating certificate id here when it arrives: ☐
+
+## Closed test (#69) — machinery + monitoring plan
+
+- Track: Play Console "Closed testing" (API track `alpha`), build promoted
+  from internal — same AAB lineage, no side-channel builds.
+- Owner recruits ≥12 testers (friends/family, Android), enters their emails
+  in the track's email list, distributes the opt-in link (Console shows it
+  under Closed testing → Testers → "Copy link").
+- Gate math: production access needs **≥12 testers opted in continuously for
+  14 days**. A dip below 12 RESTARTS the day it dips. Aim for 15+ so one
+  dropout doesn't reset the clock.
+- Monitoring cadence: owner checks the Console tester count **daily**
+  (calendar reminder recommended); log here:
+  - Start date (first day ≥12 opted in): ☐
+  - Daily count log: ☐

--- a/ArtSource/store/feature-graphic-1024x500.png
+++ b/ArtSource/store/feature-graphic-1024x500.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d38a3cd21fa754c247041b9d610987ec9c0eeec73d408bdb38eeeb6aca0c5b4a
+size 40333

--- a/ArtSource/store/icon-512.png
+++ b/ArtSource/store/icon-512.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b5ae5d69f0b46b43d118c1fe0dfd847750ed22b360e9a7818e7401e583f5cac
+size 20934

--- a/ArtSource/store/listing-copy.md
+++ b/ArtSource/store/listing-copy.md
@@ -1,0 +1,63 @@
+# Play listing copy — drafts for owner approval (#67)
+
+Player-visible name everywhere: **Frog Across** (spaced).
+
+## App name (30 chars max)
+
+> Frog Across
+
+## Short description (80 chars max)
+
+> Hop across 100 levels of traffic, rivers and gators. No ads. No tracking.
+
+(76 chars.)
+
+## Full description (4000 chars max)
+
+> **Swipe. Hop. Survive.**
+>
+> Frog Across is a classic lane-crossing arcade game, rebuilt honestly for
+> modern phones. Guide your character across roads, rivers, swamps, train
+> tracks, bike lanes and moving walkways — one hop at a time — and fill every
+> lily bay to clear the level.
+>
+> **100 levels, one clean difficulty curve.** Every level is proven completable
+> before it ships — no impossible boards, ever. New hazards arrive one at a
+> time: master the roads, then ride the logs, then learn which alligators
+> tolerate a passenger (closed mouths only — and stay off the head).
+>
+> **Controls that respect your thumbs.** Swipe to hop in any direction; a
+> clean 45° swipe hops two squares at once. A quick tap hops forward. Prefer
+> taps? Switch to tap regions in Settings and steer with screen zones instead.
+>
+> **Chase the medals.** The clock only runs while you play. Beat each level's
+> bronze, silver and gold times — gold is always earnable, on every level, in
+> every control scheme.
+>
+> **Six characters.** Same speed, different moves — pick a hopper or a stepper.
+>
+> **The Honest Arcade promise:**
+> • No ads.
+> • No tracking, no analytics — the app can't even reach the internet, and the
+>   build fails if anything tries.
+> • No purchases. The whole game, up front.
+> • Open source — see exactly what you're running:
+>   github.com/honestarcade/HonestFrogAcross
+>
+> Your progress stays on your device. Nothing to sign up for, nothing to sell.
+> Just the road, the river, and you.
+
+## Asset inventory
+
+- `screenshots/01…07-*.png` — 1920×1080 landscape, captured from the real
+  game (real level data through the shipped renderer, player state from the
+  solver's proof line). Suggested Console order: 01, 02, 04, 05, 06, 07.
+- `feature-graphic-1024x500.png` — brand navy, frog mark, two-tone lockup.
+- `icon-512.png` — Play hi-res icon from the brand kit.
+
+## Owner steps
+
+1. Approve or edit this copy (a comment on #67 records approval).
+2. Console → Store presence → Main store listing: paste name/descriptions,
+   upload icon-512, feature graphic, and the screenshot set.
+3. Save and run the listing completeness check.

--- a/ArtSource/store/screenshots/01-teaching-road.png
+++ b/ArtSource/store/screenshots/01-teaching-road.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94b2e3edf256cfc25e32bc02cfeda0e41cfe4fafbf97fc10436a481d3bdf3b76
+size 878741

--- a/ArtSource/store/screenshots/02-river.png
+++ b/ArtSource/store/screenshots/02-river.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18ed8308e026f7cfb538a30a0144431e0e8faba4ff51ec5f4fd5a2c92698830a
+size 532458

--- a/ArtSource/store/screenshots/03-swamp.png
+++ b/ArtSource/store/screenshots/03-swamp.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f34aae4818ffcb23299978e2d9466631d0e0f1bcc41aa638fb121d60b4d13a76
+size 662515

--- a/ArtSource/store/screenshots/04-tracks.png
+++ b/ArtSource/store/screenshots/04-tracks.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4688c6eb66f1bafdf2cba7bec42d6939b43be024b1bc28946540959de1a01e8
+size 569120

--- a/ArtSource/store/screenshots/05-bike-lane.png
+++ b/ArtSource/store/screenshots/05-bike-lane.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b5623923deb548b52da0f792959bd7ace66662adfb3c3f15ad74ed7bcede7c5
+size 714226

--- a/ArtSource/store/screenshots/06-walkway.png
+++ b/ArtSource/store/screenshots/06-walkway.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:945e408d424e8aaaab629ebbac78957b8760ffc514b369863b18f84e1fb41d1e
+size 563131

--- a/ArtSource/store/screenshots/07-endgame.png
+++ b/ArtSource/store/screenshots/07-endgame.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1babafa06657237e98b33fe742051928890296e12f69e50682b7c7a4f83895f9
+size 664250

--- a/Assets/Scripts/Editor/Art/StoreCapture.cs
+++ b/Assets/Scripts/Editor/Art/StoreCapture.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.IO;
+using FrogAcross.Editor.Solver;
+using FrogAcross.Levels;
+using FrogAcross.Pieces;
+using FrogAcross.Sim;
+using FrogAcross.View;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+namespace FrogAcross.Editor.Art
+{
+    /// <summary>
+    /// #67: Play-listing screenshots from the REAL game — real level data, the
+    /// shipped BoardView renderer, and a player state reached by replaying the
+    /// solver's own proof-line two-thirds of the way. 1920×1080 landscape.
+    /// </summary>
+    public static class StoreCapture
+    {
+        public const string OutFolder = "ArtSource/store/screenshots";
+
+        private static readonly (string id, string tag)[] Shots =
+        {
+            ("level-003", "teaching-road"),
+            ("level-015", "river"),
+            ("level-025", "swamp"),
+            ("level-035", "tracks"),
+            ("level-045", "bike-lane"),
+            ("level-055", "walkway"),
+            ("level-090", "endgame"),
+        };
+
+        [MenuItem("FrogAcross/Art/Capture store screenshots")]
+        public static void CaptureAll()
+        {
+            int n = 1;
+            foreach (var (id, tag) in Shots)
+            {
+                Capture(id, $"{OutFolder}/{n:D2}-{tag}.png");
+                n++;
+            }
+            Debug.Log($"[StoreCapture] {Shots.Length} screenshots written to {OutFolder}");
+        }
+
+        private static void Capture(string levelId, string outPath)
+        {
+            // NewScene purges loaded assets — the registry must load after it
+            EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            var level = LevelLoader.LoadFromResources(levelId, PieceRegistry.Load());
+            var sim = new GameSim(level);
+
+            // replay the solver's proven line 2/3 through: an authentic mid-run state
+            var solve = LevelSolver.Solve(level, allowDiagonals: false, 250_000, 10_800);
+            if (solve.Solved && solve.Script.Count > 2)
+            {
+                var script = solve.Script;
+                long endTick = script[script.Count * 2 / 3].tick;
+                int si = 0;
+                while (sim.State.Tick < endTick && !sim.State.Completed)
+                {
+                    while (si < script.Count && script[si].tick == sim.State.Tick)
+                        sim.EnqueueMove(script[si++].move);
+                    sim.Tick();
+                }
+            }
+
+            var boardGo = new GameObject("board");
+            var view = boardGo.AddComponent<BoardView>();
+            view.Bind(sim);
+            view.Render(sim.State.Tick);
+
+            var camGo = new GameObject("cam");
+            var cam = camGo.AddComponent<Camera>();
+            cam.orthographic = true;
+            cam.clearFlags = CameraClearFlags.SolidColor;
+            cam.backgroundColor = new Color(0.02f, 0.157f, 0.373f); // brand navy
+            float cx = (level.Columns - 1) / 2f;
+            float cy = -(level.Rows.Count - 1) / 2f;
+            // fit height with a slim margin; 16:9 width follows
+            cam.orthographicSize = level.Rows.Count / 2f + 0.6f;
+            camGo.transform.SetPositionAndRotation(new Vector3(cx, cy, -10f), Quaternion.identity);
+
+            var rt = new RenderTexture(1920, 1080, 24);
+            cam.targetTexture = rt;
+            cam.Render();
+            RenderTexture.active = rt;
+            var tex = new Texture2D(rt.width, rt.height, TextureFormat.RGB24, false);
+            tex.ReadPixels(new Rect(0, 0, rt.width, rt.height), 0, 0);
+            tex.Apply();
+            cam.targetTexture = null;
+            RenderTexture.active = null;
+            Directory.CreateDirectory(Path.GetDirectoryName(outPath)!);
+            File.WriteAllBytes(outPath, tex.EncodeToPNG());
+            Debug.Log($"[StoreCapture] {outPath} ({levelId} @ tick {sim.State.Tick})");
+        }
+    }
+}

--- a/Assets/Scripts/Editor/Art/StoreCapture.cs.meta
+++ b/Assets/Scripts/Editor/Art/StoreCapture.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8daf1ddea44f643efa549c1a531129a5

--- a/Assets/Scripts/Editor/Build/BuildScript.cs
+++ b/Assets/Scripts/Editor/Build/BuildScript.cs
@@ -42,6 +42,11 @@ namespace FrogAcross.Editor.Build
             // Invariant 1 (no network): never force the INTERNET permission.
             PlayerSettings.Android.forceInternetPermission = false;
 
+            // #35: R8 minification on release builds — produces the mapping
+            // file Play wants for readable crash reports (and shrinks the AAB).
+            PlayerSettings.Android.minifyRelease = true;
+            PlayerSettings.Android.minifyDebug = false;
+
             AssetDatabase.SaveAssets();
             Debug.Log("[BuildScript] Baseline settings applied.");
         }
@@ -202,6 +207,11 @@ namespace FrogAcross.Editor.Build
             string dir = Path.GetDirectoryName(outputPath);
             if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
 
+            // #35: emit a symbols package (symbol tables are enough for
+            // readable Play crash/ANR stacks, at a fraction of full-debug size)
+            UnityEditor.Android.UserBuildSettings.DebugSymbols.level = Unity.Android.Types.DebugSymbolLevel.SymbolTable;
+            UnityEditor.Android.UserBuildSettings.DebugSymbols.format = Unity.Android.Types.DebugSymbolFormat.Zip;
+
             var options = new BuildPlayerOptions
             {
                 scenes = scenes,
@@ -217,8 +227,30 @@ namespace FrogAcross.Editor.Build
                 return false;
             }
 
+            CollectMappingFile(outputPath);
             Debug.Log($"[BuildScript] AAB built: {outputPath} ({report.summary.totalSize} bytes).");
             return true;
+        }
+
+        /// <summary>
+        /// #35: Unity leaves the R8 mapping.txt deep in the gradle work tree —
+        /// copy the freshest one next to the AAB so CI can upload it to Play.
+        /// </summary>
+        private static void CollectMappingFile(string outputPath)
+        {
+            const string gradleRoot = "Library/Bee";
+            if (!Directory.Exists(gradleRoot)) return;
+            var mapping = Directory.GetFiles(gradleRoot, "mapping.txt", SearchOption.AllDirectories)
+                .OrderByDescending(File.GetLastWriteTimeUtc)
+                .FirstOrDefault();
+            if (mapping == null)
+            {
+                Debug.Log("[BuildScript] No R8 mapping.txt found (minification may be off for this variant).");
+                return;
+            }
+            string dest = Path.Combine(Path.GetDirectoryName(outputPath) ?? ".", "mapping.txt");
+            File.Copy(mapping, dest, overwrite: true);
+            Debug.Log($"[BuildScript] R8 mapping collected: {dest}");
         }
 
         private static void Fail(string message)

--- a/Assets/Scripts/Runtime/View/BoardView.cs
+++ b/Assets/Scripts/Runtime/View/BoardView.cs
@@ -73,7 +73,9 @@ namespace FrogAcross.View
 
                         var fill = NewSprite($"bay-fill-{b}", _character.sprites[0], -0.05f);
                         fill.transform.position = new Vector3(b, -r, 0.04f);
-                        fill.transform.localScale = Vector3.one * 0.8f;
+                        // cell-fit like the player — raw character sprites are ~4 units wide
+                        fill.transform.localScale = Vector3.one
+                            * (0.8f / Mathf.Max(0.1f, _character.sprites[0].bounds.size.x));
                         fill.enabled = false;
                         _bayFills.Add(fill);
                     }
@@ -95,12 +97,12 @@ namespace FrogAcross.View
             // hides them beyond the board edges.
             foreach (int side in new[] { -1, +1 })
             {
-                var cover = NewSprite($"cover-{side}", null, -0.55f);
-                cover.sprite = SpriteOf(level.Rows[level.BankRow].Kind, 0);
-                cover.drawMode = SpriteDrawMode.Tiled;
-                cover.size = new Vector2(14f, level.Rows.Count + 4f);
+                // flat surround (design: solid #16321F), wide enough for any
+                // phone aspect — the tiled bank texture used to band through
+                var cover = NewSprite($"cover-{side}", SolidSprite(), -0.55f);
                 cover.color = new Color(0.086f, 0.196f, 0.121f); // #16321F surround
-                float cx = side < 0 ? -0.5f - 7f : level.Columns - 0.5f + 7f;
+                cover.transform.localScale = new Vector3(40f, level.Rows.Count + 8f, 1f);
+                float cx = side < 0 ? -0.5f - 20f : level.Columns - 0.5f + 20f;
                 cover.transform.position = new Vector3(cx, -(level.Rows.Count - 1) / 2f, -0.55f);
             }
 
@@ -216,6 +218,16 @@ namespace FrogAcross.View
 
         private Sprite SpriteOf(PieceDef def, int i) =>
             def.sprites != null && def.sprites.Length > i ? def.sprites[i] : null;
+
+        private static Sprite _solid;
+
+        private static Sprite SolidSprite()
+        {
+            if (_solid == null)
+                _solid = Sprite.Create(Texture2D.whiteTexture,
+                    new Rect(0, 0, 4, 4), new Vector2(0.5f, 0.5f), 4f);
+            return _solid;
+        }
 
         private SpriteRenderer NewSprite(string name, Sprite sprite, float z)
         {

--- a/Assets/Tests/PlayMode/BoardViewTests.cs
+++ b/Assets/Tests/PlayMode/BoardViewTests.cs
@@ -78,5 +78,22 @@ namespace FrogAcross.Tests.PlayMode
             Assert.AreEqual(simA.Level.Columns + 2f, strip.size.x, 1e-3f, "tiled strip spans the board + margins");
             yield return null;
         }
+
+        [UnityTest]
+        public IEnumerator BayFill_FitsInsideItsCell()
+        {
+            // regression (#67 screenshots): raw character sprites are ~4 world
+            // units wide — an unscaled bay fill dwarfed the goal row
+            var (sim, view) = Spawn();
+            foreach (int b in sim.Level.BayColumns)
+            {
+                var fill = view.transform.Find($"bay-fill-{b}");
+                var sr = fill.GetComponent<UnityEngine.SpriteRenderer>();
+                float worldWidth = sr.sprite.bounds.size.x * fill.localScale.x;
+                Assert.LessOrEqual(worldWidth, 1f, $"bay-fill-{b} must fit its cell");
+                Assert.Greater(worldWidth, 0.3f, $"bay-fill-{b} should be visible");
+            }
+            yield return null;
+        }
     }
 }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -293,7 +293,7 @@ PlayerSettings:
     height: 180
     banner: {fileID: 0}
   androidGamepadSupportLevel: 0
-  AndroidMinifyRelease: 0
+  AndroidMinifyRelease: 1
   AndroidMinifyDebug: 0
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,25 @@
+# Frog Across — Privacy Policy
+
+**Effective date: 2026-08-28**
+
+Frog Across (package `com.honestarcade.frogacross`), published by Honest
+Arcade, collects **no data**. None.
+
+- The app has **no network access**. The Android package does not request the
+  INTERNET permission, so it is technically incapable of sending anything
+  anywhere. This is enforced by an automated check on every build and you can
+  verify it yourself: the app is open source at
+  <https://github.com/honestarcade/HonestFrogAcross>.
+- No personal information, identifiers, usage analytics, crash reports,
+  advertising IDs, or diagnostics are collected, stored, shared, or sold —
+  by us or by any third party. There are no third-party SDKs.
+- Your progress (unlocked levels, medals, best times, settings) is saved
+  **only on your device** and never leaves it. Uninstalling the app deletes it.
+- The app shows no ads and contains no purchases.
+- Children's privacy: since no data is collected from anyone, no data is
+  collected from children.
+
+Because nothing is collected, there is nothing for you to request a copy of
+or ask us to delete — but questions are always welcome.
+
+**Contact:** support@honestarcade.app


### PR DESCRIPTION
The agent-executable slice of the release milestone:

- **#35** — release builds now emit and upload debug symbols (SymbolTable zip) and the R8 mapping (minification on); proof rides the v0.2.0 tag after this merges.
- **#67** — Play-listing assets from the real game: 7 solver-replay screenshots at 1920×1080, feature graphic, hi-res icon, and drafted listing copy awaiting owner approval. The captures surfaced and fixed two real BoardView bugs (unscaled bay-fill sprite; textured, too-narrow side covers) with a regression test.
- **#68/#69 groundwork** — privacy policy page (GitHub Pages enabled: honestarcade.github.io/HonestFrogAcross/privacy after this merges), archived data-safety + IARC answers, closed-test gate math, and a testing-tracks-only promotion workflow.

Owner-gated stories (#67 approval, #68 forms, #69 testers, #70 launch) stay open with needs-owner-action.

Test totals: EditMode 139/139, PlayMode 16/16.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeAv87tQK1G7qsTHK3dPc