### PR TITLE
Fix Play promote auth: local JWT via gcloud

### DIFF
--- a/.github/workflows/play-promote.yml
+++ b/.github/workflows/play-promote.yml
@@ -22,15 +22,20 @@ jobs:
   promote:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/auth@v2
+      # gcloud signs the token locally — the SA needs no IAM Credentials API
+      # (same pattern as play-api-check.yml)
+      - name: Mint access token
         id: auth
-        with:
-          credentials_json: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
-          token_format: access_token
-          access_token_scopes: https://www.googleapis.com/auth/androidpublisher
+        env:
+          SA_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          printf '%s' "$SA_JSON" > "$RUNNER_TEMP/sa.json"
+          gcloud auth activate-service-account --key-file="$RUNNER_TEMP/sa.json"
+          echo "token=$(gcloud auth print-access-token --scopes=https://www.googleapis.com/auth/androidpublisher)" >> "$GITHUB_OUTPUT"
+          rm -f "$RUNNER_TEMP/sa.json"
       - name: Promote release
         env:
-          TOKEN: ${{ steps.auth.outputs.access_token }}
+          TOKEN: ${{ steps.auth.outputs.token }}
           PKG: com.honestarcade.frogacross
           FROM: ${{ inputs.from_track }}
           TO: ${{ inputs.to_track }}


### PR DESCRIPTION
google-github-actions/auth mints tokens through the IAM Credentials API, which the testing-tracks service account gets a 403 on. gcloud's activate-service-account + print-access-token signs locally — the same pattern play-api-check.yml already uses successfully.

Refs #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeAv87tQK1G7qsTHK3dPc