### PR TITLE
Device UAT round 3: type scale, flowing layouts, medal discs

### DIFF
--- a/.n8/decisions.md
+++ b/.n8/decisions.md
@@ -259,3 +259,14 @@ When `/n8-replan` processes an ad-hoc entry it appends `— reconciled by /n8-re
 - **Version string** now comes from Application.version (was a hardcoded "1.0"); the baseline bundleVersion moved to 0.4.0 and PlayerSettingsTests pins the shape, not a frozen literal.
 - **Tap regions 33% → 20%** side bands (owner ruling): forward/back get the room.
 - **UI sprite importer rule**: Resources/UI imports as a single sprite — the project's sheet defaults had sliced the logo, so the menu drew one corner of the mark.
+
+### Device UAT round 3 — fix pass (2026-08-29)
+
+- **Type scale added to UiKit** (Display/Title/Heading/Body/Caption/Micro). The design's own sizes — 12–16px inside a 958-wide mock — scale to ~26pt on our 1920 canvas, which the owner reports as unreadable on a 6.9" phone. These are roughly double that; screens now use the names, never raw numbers, so "make it bigger" is one edit rather than forty.
+- **Fixed offsets replaced with layout groups (UiKit.Column / UiKit.Row).** Three separate overlap reports (About's rules, Settings' CONTROLS vs the Interface row, Show-regions vs the stored-data card) were all the same bug: copy that wraps to a different number of lines on a different aspect while the next element sits at a hardcoded Y. Lists of copy now flow at their natural heights.
+- **The double-press back button** was screens rebuilding themselves with RebuildScreen + Push, which stacked a second copy — Back popped the duplicate and looked dead. Added AppShell.Replace(); Character and Settings use it. Regression test drives both paths.
+- **Levels grid**: GridLayoutGroup with FixedColumnCount=10 plus GridFitter, which derives cell size from the surface it actually got (a fixed cell size gave 11 columns on one aspect and 12 on another). The ScrollArea origin node needed ignoreLayout — it had been dealt the first cell, leaving an empty slot before level 1.
+- **Medals are now the disc behind the number** (owner ruling), one size on every cell, sized for three digits, with an outlined numeral so it reads on gold. The old corner dot was too small to notice.
+- **Logo**: mark to the RIGHT of the wordmark with the byline underneath (owner's explicit call; the design has the mark on the left — noted here in case they want it flipped).
+- **Region preview** dimmed to 0.10 scrim + 0.10 zones (owner asked for "something really low").
+- **About/Gameplay version** now derives from Application.version and LevelCatalog.Count instead of the hardcoded "v1.0 · 100 LEVELS" copy string.

--- a/Assets/Scripts/Runtime/UI/AppShell.cs
+++ b/Assets/Scripts/Runtime/UI/AppShell.cs
@@ -106,6 +106,18 @@ namespace FrogAcross.UI
             // at the menu root: let the OS background us (no explicit action)
         }
 
+        /// <summary>
+        /// Rebuild the screen you are already on and stay there. Screens used
+        /// to RebuildScreen + Push, which stacked a second copy of themselves —
+        /// so Back popped the duplicate and appeared to do nothing the first
+        /// time (owner: "had to hit it twice", 2026-08-29).
+        /// </summary>
+        public void Replace(string name, Func<Transform, AppShell, GameObject> builder)
+        {
+            RebuildScreen(name, builder);
+            foreach (var kv in _screens) kv.Value.SetActive(kv.Key == name);
+        }
+
         public void RebuildScreen(string name, Func<Transform, AppShell, GameObject> builder)
         {
             if (_screens.TryGetValue(name, out var old)) Destroy(old);
@@ -152,8 +164,7 @@ namespace FrogAcross.UI
             rrt.anchorMin = Vector2.zero; rrt.anchorMax = Vector2.one;
             rrt.offsetMin = rrt.offsetMax = Vector2.zero;
             UiKit.Stretch(UiKit.Fill(root.transform, "bg", UiKit.Navy));
-            UiKit.Logotype(root.transform, new Vector2(0, 40), 96);
-            UiKit.Label(root.transform, "BY HONEST ARCADE", 26, UiKit.TextDim, new Vector2(0, -110));
+            UiKit.Logotype(root.transform, new Vector2(0, 60), 116);
             var barBg = UiKit.Panel(root.transform, "bar-bg", new Color(1f, 1f, 1f, 0.12f), 8);
             barBg.rectTransform.sizeDelta = new Vector2(520, 12);
             barBg.rectTransform.anchoredPosition = new Vector2(0, -200);
@@ -176,20 +187,30 @@ namespace FrogAcross.UI
             rt.offsetMin = rt.offsetMax = Vector2.zero;
 
             // brand column left, actions right — both filling the safe area
-            UiKit.Logotype(root.transform, new Vector2(-470, 120), 110);
-            UiKit.Label(root.transform, "BY HONEST ARCADE", 28, UiKit.TextDim, new Vector2(-470, -40));
+            UiKit.Logotype(root.transform, new Vector2(-640, 250), 128);
 
             int current = Mathf.Min(Progression.HighestUnlocked, LevelCatalog.Count);
             int medals = 0;
             foreach (var r in Progression.Data.records) if (r.medal > 0) medals++;
-            var stat = UiKit.Panel(root.transform, "stat", new Color(1f, 1f, 1f, 0.06f));
-            stat.rectTransform.sizeDelta = new Vector2(620, 92);
-            stat.rectTransform.anchoredPosition = new Vector2(-470, -170);
-            UiKit.Label(stat.transform, $"Level {current} / {LevelCatalog.Count}    ·    {medals} medals",
-                32, UiKit.TextBlue, Vector2.zero, new Vector2(580, 44));
 
-            UiKit.Button(root.transform, $"Continue — Level {current}", new Vector2(450, 250),
-                new Vector2(760, 132), shell.LaunchCurrent, primary: true, fontSize: 42);
+            var levelChip = UiKit.Panel(root.transform, "chip-level", new Color(1f, 1f, 1f, 0.07f));
+            levelChip.rectTransform.sizeDelta = new Vector2(420, 96);
+            levelChip.rectTransform.anchoredPosition = new Vector2(-860, 20);
+            UiKit.Label(levelChip.transform, $"Level {current} / {LevelCatalog.Count}", UiKit.Caption,
+                UiKit.TextBlue, Vector2.zero, new Vector2(380, 44));
+            var medalChip = UiKit.Panel(root.transform, "chip-medals", new Color(1f, 1f, 1f, 0.07f));
+            medalChip.rectTransform.sizeDelta = new Vector2(330, 96);
+            medalChip.rectTransform.anchoredPosition = new Vector2(-430, 20);
+            UiKit.Label(medalChip.transform, $"{medals} medals", UiKit.Caption,
+                UiKit.TextBlue, Vector2.zero, new Vector2(290, 44));
+
+            UiKit.Label(root.transform, "SWIPE TO MOVE  ·  TAP TO HOP FORWARD", UiKit.Micro, UiKit.TextDim,
+                new Vector2(-640, -160), new Vector2(980, 44));
+            UiKit.Label(root.transform, $"v{Application.version}  ·  NO ADS  ·  NO TRACKING  ·  OPEN SOURCE",
+                UiKit.Micro, UiKit.TextDim, new Vector2(-640, -420), new Vector2(1100, 44));
+
+            UiKit.Button(root.transform, $"Continue — Level {current}", new Vector2(470, 300),
+                new Vector2(880, 160), shell.LaunchCurrent, primary: true, fontSize: UiKit.Title - 6);
             var grid = new (string label, string screen)[]
             {
                 ("Levels", "levels"), ("Character", "character"),
@@ -199,13 +220,11 @@ namespace FrogAcross.UI
             for (int i = 0; i < grid.Length; i++)
             {
                 var (label, screen) = grid[i];
-                float x = 450 + (i % 2 == 0 ? -196 : 196);
-                float y = 80 - (i / 2) * 150;
-                UiKit.Button(root.transform, label, new Vector2(x, y), new Vector2(372, 126),
-                    () => shell.Push(screen), fontSize: 30);
+                float x = 470 + (i % 2 == 0 ? -224 : 224);
+                float y = 100 - (i / 2) * 190;
+                UiKit.Button(root.transform, label, new Vector2(x, y), new Vector2(432, 160),
+                    () => shell.Push(screen), fontSize: UiKit.Heading);
             }
-            UiKit.Label(root.transform, $"v{Application.version} · NO ADS · NO TRACKING", 22, UiKit.TextDim,
-                new Vector2(-470, -350), new Vector2(700, 30));
             return root;
         }
     }

--- a/Assets/Scripts/Runtime/UI/CharacterScreen.cs
+++ b/Assets/Scripts/Runtime/UI/CharacterScreen.cs
@@ -29,8 +29,8 @@ namespace FrogAcross.UI
                 bool isSelected = def.id == selected;
                 var cell = UiKit.Panel(root.transform, $"char-{def.id}",
                     new Color(1f, 1f, 1f, isSelected ? 0.12f : 0.05f));
-                cell.rectTransform.sizeDelta = new Vector2(290, 680);
-                cell.rectTransform.anchoredPosition = new Vector2(-762 + i * 305, -150);
+                cell.rectTransform.sizeDelta = new Vector2(300, 720);
+                cell.rectTransform.anchoredPosition = new Vector2(-790 + i * 316, -150);
 
                 var spriteGo = new GameObject("preview");
                 spriteGo.transform.SetParent(cell.transform, false);
@@ -41,27 +41,27 @@ namespace FrogAcross.UI
                     : def.sprites is { Length: > 0 } ? def.sprites[0] : null;
                 img.preserveAspect = true;
                 var srt = img.rectTransform;
-                srt.sizeDelta = new Vector2(215, 215);
-                srt.anchoredPosition = new Vector2(0, 120);
+                srt.sizeDelta = new Vector2(240, 240);
+                srt.anchoredPosition = new Vector2(0, 150);
                 var bob = spriteGo.AddComponent<IdleBob>();
                 bob.hop = def.moveStyle == MoveStyle.Hop;
 
                 string shown = string.IsNullOrEmpty(def.displayName) ? def.id
                     : char.ToUpperInvariant(def.displayName[0]) + def.displayName.Substring(1);
-                var nameL = UiKit.Label(cell.transform, shown, 34, UiKit.White, new Vector2(0, -75));
+                var nameL = UiKit.Label(cell.transform, shown, UiKit.Title, UiKit.White, new Vector2(0, -96), new Vector2(300, 78));
                 nameL.fontStyle = FontStyle.Bold;
-                UiKit.Label(cell.transform, def.moveStyle == MoveStyle.Hop ? "HOP" : "STEP", 22,
-                    def.moveStyle == MoveStyle.Hop ? UiKit.Mint : UiKit.Hex("B48CFF"), new Vector2(0, -125));
+                UiKit.Label(cell.transform, def.moveStyle == MoveStyle.Hop ? "HOP" : "STEP", UiKit.Heading,
+                    def.moveStyle == MoveStyle.Hop ? UiKit.Mint : UiKit.Hex("B48CFF"), new Vector2(0, -168),
+                    new Vector2(300, 58));
                 if (isSelected)
-                    UiKit.Label(cell.transform, "✓", 38, UiKit.Mint, new Vector2(108, 295));
+                    UiKit.Label(cell.transform, "✓", 48, UiKit.Mint, new Vector2(110, 312));
 
                 var btn = cell.gameObject.AddComponent<Button>();
                 string id = def.id;
                 btn.onClick.AddListener(() =>
                 {
                     CharacterSelection.SelectedId = id;
-                    shell.RebuildScreen("character", Build);
-                    shell.Push("character");
+                    shell.Replace("character", Build); // Push here stacked a second copy
                 });
             }
             // header last: the cells used to be drawn over the back button,

--- a/Assets/Scripts/Runtime/UI/GridFitter.cs
+++ b/Assets/Scripts/Runtime/UI/GridFitter.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace FrogAcross.UI
+{
+    /// <summary>
+    /// Keeps a GridLayoutGroup at an exact column count by sizing its cells to
+    /// the surface it actually got — the panel width varies with the phone's
+    /// aspect, so a fixed cell size gave 11 columns on one device and 12 on
+    /// another (owner asked for exactly 10).
+    /// </summary>
+    [RequireComponent(typeof(GridLayoutGroup))]
+    public sealed class GridFitter : MonoBehaviour
+    {
+        public int columns = 10;
+        public float aspect = 1.25f; // cell height / cell width
+
+        private GridLayoutGroup _grid;
+        private RectTransform _rt;
+        private float _appliedWidth;
+
+        private void OnEnable()
+        {
+            _grid = GetComponent<GridLayoutGroup>();
+            _rt = (RectTransform)transform;
+            Apply();
+        }
+
+        private void OnRectTransformDimensionsChange() => Apply();
+
+        private void Apply()
+        {
+            if (_grid == null || _rt == null) return;
+            float width = _rt.rect.width;
+            if (width <= 1f || Mathf.Approximately(width, _appliedWidth)) return;
+            _appliedWidth = width;
+
+            float usable = width - _grid.padding.left - _grid.padding.right
+                - _grid.spacing.x * (columns - 1);
+            float cell = Mathf.Floor(usable / columns);
+            if (cell <= 1f) return;
+            _grid.cellSize = new Vector2(cell, Mathf.Round(cell * aspect));
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/UI/GridFitter.cs.meta
+++ b/Assets/Scripts/Runtime/UI/GridFitter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1a39c35c3dfb841f4916d8164922ed2b

--- a/Assets/Scripts/Runtime/UI/LevelCompleteOverlay.cs
+++ b/Assets/Scripts/Runtime/UI/LevelCompleteOverlay.cs
@@ -70,7 +70,7 @@ namespace FrogAcross.UI
             var panel = Panel(_root.transform, new Color(0.043f, 0.212f, 0.439f)); // #0B3670
             var pr = panel.rectTransform;
             pr.anchorMin = pr.anchorMax = new Vector2(0.5f, 0.5f);
-            pr.sizeDelta = new Vector2(1080, 620);
+            pr.sizeDelta = new Vector2(1160, 660);
 
             _title = Label(panel.transform, "Level Complete", 58, new Vector2(0, 216));
             _title.color = Color.white;
@@ -83,16 +83,17 @@ namespace FrogAcross.UI
             var dotGo = new GameObject("medal-dot");
             dotGo.transform.SetParent(panel.transform, false);
             _medalDot = dotGo.AddComponent<Image>();
+            UiKit.Round(_medalDot, UiKit.PillRadius); // a medal is a circle, not a square
             var dr = _medalDot.rectTransform;
             dr.anchorMin = dr.anchorMax = new Vector2(0.5f, 0.5f);
-            dr.sizeDelta = new Vector2(44, 44);
-            dr.anchoredPosition = new Vector2(-96, -66);
-            _medal = Label(panel.transform, "GOLD", 40, new Vector2(40, -66));
+            dr.sizeDelta = new Vector2(56, 56);
+            dr.anchoredPosition = new Vector2(-110, -70);
+            _medal = Label(panel.transform, "GOLD", 44, new Vector2(50, -70));
             _medal.color = new Color(0.62f, 0.76f, 0.93f);
 
-            Btn(panel.transform, "Next level", new Vector2(-300, -210), () => OnNext?.Invoke(), true);
+            Btn(panel.transform, "Next level", new Vector2(-352, -216), () => OnNext?.Invoke(), true);
             Btn(panel.transform, "Replay", new Vector2(0, -210), () => OnReplay?.Invoke(), false);
-            Btn(panel.transform, "Main Menu", new Vector2(300, -210), () => OnMainMenu?.Invoke(), false);
+            Btn(panel.transform, "Main Menu", new Vector2(352, -216), () => OnMainMenu?.Invoke(), false);
 
             _root.SetActive(false);
         }
@@ -144,11 +145,11 @@ namespace FrogAcross.UI
             btn.onClick.AddListener(() => onClick());
             var rt = img.rectTransform;
             rt.anchorMin = rt.anchorMax = new Vector2(0.5f, 0.5f);
-            rt.sizeDelta = new Vector2(300, 104);
+            rt.sizeDelta = new Vector2(320, 116);
             rt.anchoredPosition = pos;
-            var t = Label(go.transform, label, 34, Vector2.zero);
+            var t = Label(go.transform, label, 36, Vector2.zero);
             t.color = primary ? new Color(0.02f, 0.157f, 0.373f) : Color.white;
-            t.rectTransform.sizeDelta = new Vector2(300, 104);
+            t.rectTransform.sizeDelta = new Vector2(320, 116);
         }
     }
 }

--- a/Assets/Scripts/Runtime/UI/LevelsScreen.cs
+++ b/Assets/Scripts/Runtime/UI/LevelsScreen.cs
@@ -12,7 +12,8 @@ namespace FrogAcross.UI
     /// </summary>
     public static class LevelsScreen
     {
-        private const float CellW = 158f, CellH = 196f, Gap = 18f;
+        private const int Columns = 10;
+        private const float Gap = 20f;
 
         public static GameObject Build(Transform parent, AppShell shell)
         {
@@ -36,12 +37,16 @@ namespace FrogAcross.UI
                 bottomRightInset: new Vector2(UiKit.EdgePad, 40f));
             var surface = UiKit.ScrollContent(content);
             var grid = surface.gameObject.AddComponent<GridLayoutGroup>();
-            grid.cellSize = new Vector2(CellW, CellH);
             grid.spacing = new Vector2(Gap, Gap);
-            grid.padding = new RectOffset(0, 0, (int)Gap, (int)Gap);
+            grid.padding = new RectOffset(0, 0, 0, (int)Gap); // no dead band above row one
             grid.childAlignment = TextAnchor.UpperCenter;
+            grid.constraint = GridLayoutGroup.Constraint.FixedColumnCount;
+            grid.constraintCount = Columns;
             var fitter = surface.gameObject.AddComponent<ContentSizeFitter>();
             fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+            var gridFitter = surface.gameObject.AddComponent<GridFitter>();
+            gridFitter.columns = Columns;
+            gridFitter.aspect = 1.12f; // room for the medal disc plus the time under it
 
             for (int n = 1; n <= total; n++) BuildCell(surface, shell, n);
 
@@ -63,8 +68,8 @@ namespace FrogAcross.UI
             bar.rectTransform.anchorMin = Vector2.zero;
             bar.rectTransform.anchorMax = new Vector2(total > 0 ? done / (float)total : 0f, 1f);
             bar.rectTransform.offsetMin = bar.rectTransform.offsetMax = Vector2.zero;
-            var pct = UiKit.Label(band.transform, $"{done} / {total} COMPLETE", 22, UiKit.TextDim,
-                Vector2.zero, new Vector2(340, 30), TextAnchor.MiddleLeft);
+            var pct = UiKit.Label(band.transform, $"{done} / {total} COMPLETE", UiKit.Caption, UiKit.TextDim,
+                Vector2.zero, new Vector2(420, 42), TextAnchor.MiddleLeft);
             pct.rectTransform.anchorMin = pct.rectTransform.anchorMax = new Vector2(0f, 1f);
             pct.rectTransform.pivot = new Vector2(0f, 1f);
             pct.rectTransform.anchoredPosition = new Vector2(UiKit.EdgePad + 920f, -220f);
@@ -83,11 +88,11 @@ namespace FrogAcross.UI
             var drt = dot.rectTransform;
             drt.anchorMin = drt.anchorMax = new Vector2(1f, 1f);
             drt.pivot = new Vector2(1f, 1f);
-            drt.sizeDelta = new Vector2(26, 26);
-            drt.anchoredPosition = new Vector2(rightOffset - 172f, -96f);
+            drt.sizeDelta = new Vector2(32, 32);
+            drt.anchoredPosition = new Vector2(rightOffset - 200f, -98f);
 
-            var text = UiKit.Label(band, label, 26, UiKit.TextBlue, Vector2.zero,
-                new Vector2(150, 34), TextAnchor.MiddleLeft);
+            var text = UiKit.Label(band, label, UiKit.Caption, UiKit.TextBlue, Vector2.zero,
+                new Vector2(190, 44), TextAnchor.MiddleLeft);
             var trt = text.rectTransform;
             trt.anchorMin = trt.anchorMax = new Vector2(1f, 1f);
             trt.pivot = new Vector2(1f, 1f);
@@ -103,24 +108,32 @@ namespace FrogAcross.UI
             var cell = UiKit.Panel(parent, $"cell-{n}",
                 unlocked ? new Color(1f, 1f, 1f, 0.09f) : new Color(1f, 1f, 1f, 0.03f));
 
-            var num = UiKit.Label(cell.transform, n.ToString(), 52,
-                unlocked ? UiKit.White : new Color(1f, 1f, 1f, 0.28f), new Vector2(0, 26),
-                new Vector2(CellW - 16, 64));
+            // The medal is the disc behind the number (owner ruling): one size
+            // for every level so "1" and "100" match, wide enough for three
+            // digits, and the number is outlined so it reads on gold.
+            var disc = UiKit.Panel(cell.transform, "medal", rec != null && rec.medal > 0
+                ? rec.medal switch { 3 => UiKit.Gold, 2 => UiKit.Silver, _ => UiKit.Bronze }
+                : new Color(1f, 1f, 1f, unlocked ? 0.10f : 0.05f), UiKit.PillRadius);
+            disc.rectTransform.anchorMin = disc.rectTransform.anchorMax = new Vector2(0.5f, 1f);
+            disc.rectTransform.pivot = new Vector2(0.5f, 1f);
+            disc.rectTransform.sizeDelta = new Vector2(DiscSize, DiscSize);
+            disc.rectTransform.anchoredPosition = new Vector2(0f, -DiscTop);
+
+            bool onMedal = rec != null && rec.medal > 0;
+            var num = UiKit.Label(disc.transform, n.ToString(), UiKit.Heading,
+                onMedal ? UiKit.NavyDeep : unlocked ? UiKit.White : new Color(1f, 1f, 1f, 0.3f),
+                Vector2.zero, new Vector2(DiscSize - 8f, DiscSize * 0.62f));
             num.fontStyle = FontStyle.Bold;
+            var outline = num.gameObject.AddComponent<Outline>();
+            outline.effectColor = onMedal ? new Color(1f, 1f, 1f, 0.85f) : new Color(0f, 0f, 0f, 0.55f);
+            outline.effectDistance = new Vector2(2f, -2f);
 
             bool played = rec != null && rec.bestSeconds >= 0;
-            UiKit.Label(cell.transform, played ? $"{rec.bestSeconds:0.0}s" : "—",
-                30, played ? UiKit.TextBlue : UiKit.TextDim, new Vector2(0, -40), new Vector2(CellW - 16, 40));
-
-            if (rec != null && rec.medal > 0)
-            {
-                var dot = UiKit.Panel(cell.transform, "medal", rec.medal switch
-                {
-                    3 => UiKit.Gold, 2 => UiKit.Silver, _ => UiKit.Bronze,
-                }, UiKit.PillRadius);
-                dot.rectTransform.sizeDelta = new Vector2(26, 26);
-                dot.rectTransform.anchoredPosition = new Vector2(CellW / 2f - 26, CellH / 2f - 26);
-            }
+            var time = UiKit.Label(cell.transform, played ? $"{rec.bestSeconds:0.0}s" : "—",
+                UiKit.Caption, played ? UiKit.TextBlue : UiKit.TextDim, Vector2.zero, new Vector2(160, 44));
+            time.rectTransform.anchorMin = time.rectTransform.anchorMax = new Vector2(0.5f, 0f);
+            time.rectTransform.pivot = new Vector2(0.5f, 0f);
+            time.rectTransform.anchoredPosition = new Vector2(0f, 12f);
 
             if (unlocked)
             {
@@ -130,5 +143,9 @@ namespace FrogAcross.UI
                 btn.onClick.AddListener(() => shell.LaunchLevel(id));
             }
         }
+
+        /// <summary>Medal disc: identical on every cell, sized for three digits.</summary>
+        public const float DiscSize = 112f;
+        private const float DiscTop = 14f;
     }
 }

--- a/Assets/Scripts/Runtime/UI/SettingsScreen.cs
+++ b/Assets/Scripts/Runtime/UI/SettingsScreen.cs
@@ -23,94 +23,103 @@ namespace FrogAcross.UI
             var content = UiKit.ScrollArea(root.transform,
                 topLeftInset: new Vector2(UiKit.EdgePad, 210f),
                 bottomRightInset: new Vector2(UiKit.EdgePad, 40f));
-            UiKit.SetContentHeight(content, 1160f);
+            UiKit.SetContentHeight(content, 1500f);
 
-            // -------- sound --------
-            SoundRow(content, "All sound", "Master switch for every sound the game makes.",
-                new Vector2(-450, -90), () => SoundSettings.Master, v => SoundSettings.Master = v);
-            SoundRow(content, "Music", "Menu and gameplay music.",
-                new Vector2(-450, -230), () => SoundSettings.Music, v => SoundSettings.Music = v);
-            SoundRow(content, "Effects", "Hops, crashes, splashes, medals.",
-                new Vector2(-450, -370), () => SoundSettings.Effects, v => SoundSettings.Effects = v);
-            SoundRow(content, "Interface", "Taps and navigation.",
-                new Vector2(-450, -510), () => SoundSettings.Ui, v => SoundSettings.Ui = v);
+            // Both columns flow: sound subtitles wrap on narrow phones and the
+            // fixed offsets underneath them collided (owner: CONTROLS ran into
+            // the Interface row; Show-regions sat on the stored-data card).
+            var left = UiKit.Column(content, new Vector2(-900, -60), 820f, 26f);
+            SoundRow(left, "All sound", "Master switch for every sound the game makes.",
+                () => SoundSettings.Master, v => SoundSettings.Master = v);
+            SoundRow(left, "Music", "Menu and gameplay music.",
+                () => SoundSettings.Music, v => SoundSettings.Music = v);
+            SoundRow(left, "Effects", "Hops, crashes, splashes, medals.",
+                () => SoundSettings.Effects, v => SoundSettings.Effects = v);
+            SoundRow(left, "Interface", "Taps and navigation.",
+                () => SoundSettings.Ui, v => SoundSettings.Ui = v);
 
-            // -------- controls --------
-            UiKit.Label(content, "CONTROLS", 24, UiKit.TextDim, new Vector2(-700, -620), new Vector2(300, 32), TextAnchor.MiddleLeft);
+            UiKit.Label(left, "CONTROLS", UiKit.Caption, UiKit.TextDim,
+                Vector2.zero, new Vector2(820, 48), TextAnchor.MiddleLeft);
             bool regions = ControlSchemeSetting.Current == ControlScheme.TapRegions;
-            UiKit.Button(content, regions ? "Swipe" : "Swipe ✓", new Vector2(-620, -720), new Vector2(300, 104), () =>
+            var schemeRow = UiKit.Row(left, 124f);
+            UiKit.Button(schemeRow, regions ? "Swipe" : "Swipe ✓", Vector2.zero, new Vector2(330, 124), () =>
             {
                 ControlSchemeSetting.Current = ControlScheme.Swipe;
                 Refresh(shell);
-            }, primary: !regions, fontSize: 26);
-            UiKit.Button(content, regions ? "Tap regions ✓" : "Tap regions", new Vector2(-290, -720), new Vector2(330, 104), () =>
+            }, primary: !regions, fontSize: UiKit.Heading);
+            UiKit.Button(schemeRow, regions ? "Tap regions ✓" : "Tap regions", Vector2.zero, new Vector2(380, 124), () =>
             {
                 ControlSchemeSetting.Current = ControlScheme.TapRegions;
                 Refresh(shell);
-            }, primary: regions, fontSize: 26);
+            }, primary: regions, fontSize: UiKit.Heading);
             if (regions)
             {
-                var link = UiKit.Button(content, "Show regions", new Vector2(60, -720), new Vector2(300, 104),
-                    () => ShowRegionsPreview(shell.transform), fontSize: 26);
+                var link = UiKit.Button(left, "Show regions", Vector2.zero, new Vector2(420, 124),
+                    () => ShowRegionsPreview(shell.transform), fontSize: UiKit.Heading);
                 link.image.color = new Color(0f, 0.839f, 0.706f, 0.22f);
+                link.gameObject.AddComponent<LayoutElement>().preferredHeight = 124f;
             }
 
-            // -------- data --------
-            UiKit.Label(content, "DATA", 24, UiKit.TextDim, new Vector2(400, -60), new Vector2(300, 32), TextAnchor.MiddleLeft);
-            var dataCard = UiKit.Panel(content, "data-card", new Color(1f, 1f, 1f, 0.05f));
-            dataCard.rectTransform.sizeDelta = new Vector2(780, 330);
-            dataCard.rectTransform.anchoredPosition = new Vector2(520, -240);
-            UiKit.Label(dataCard.transform, "Progress", 32, UiKit.White, new Vector2(0, 105), new Vector2(700, 42), TextAnchor.MiddleLeft);
-            UiKit.Label(dataCard.transform, "Levels, medals, best times and settings.", 24, UiKit.TextBlue,
-                new Vector2(0, 55), new Vector2(700, 36), TextAnchor.MiddleLeft);
-            var resetBtn = UiKit.Button(dataCard.transform, "Reset all data", new Vector2(0, -70), new Vector2(700, 88),
-                () => ConfirmReset(shell), fontSize: 30);
-            resetBtn.image.color = UiKit.Danger;
+            var right = UiKit.Column(content, new Vector2(120, -60), 840f, 30f);
+            UiKit.Label(right, "DATA", UiKit.Caption, UiKit.TextDim,
+                Vector2.zero, new Vector2(840, 48), TextAnchor.MiddleLeft);
+
+            var dataCard = UiKit.Panel(right, "data-card", new Color(1f, 1f, 1f, 0.06f));
+            dataCard.gameObject.AddComponent<LayoutElement>().preferredHeight = 400f;
+            UiKit.Label(dataCard.transform, "Progress", UiKit.Heading, UiKit.White,
+                new Vector2(0, 132), new Vector2(760, 58), TextAnchor.MiddleLeft);
+            UiKit.Label(dataCard.transform, "Levels, medals, best times and settings.", UiKit.Body, UiKit.TextBlue,
+                new Vector2(0, 62), new Vector2(760, 50), TextAnchor.MiddleLeft);
+            var resetBtn = UiKit.Button(dataCard.transform, "Reset all data", new Vector2(0, -105),
+                new Vector2(760, 124), () => ConfirmReset(shell), fontSize: UiKit.Heading);
+            resetBtn.image.color = UiKit.Danger; // 20% alpha read as disabled
             foreach (var t in resetBtn.GetComponentsInChildren<Text>()) t.color = UiKit.White;
 
-            var storedCard = UiKit.Panel(content, "stored-card", new Color(1f, 1f, 1f, 0.035f));
-            storedCard.rectTransform.sizeDelta = new Vector2(780, 300);
-            storedCard.rectTransform.anchoredPosition = new Vector2(520, -610);
-            UiKit.Label(storedCard.transform, "STORED ON DEVICE ONLY", 22, UiKit.TextDim, new Vector2(0, 88), new Vector2(700, 30), TextAnchor.MiddleLeft);
-            UiKit.Label(storedCard.transform, Copy.Get("storedOnDevice"), 24, UiKit.TextBlue,
-                new Vector2(0, -24), new Vector2(700, 150), TextAnchor.UpperLeft);
+            var storedCard = UiKit.Panel(right, "stored-card", new Color(1f, 1f, 1f, 0.045f));
+            storedCard.gameObject.AddComponent<LayoutElement>().preferredHeight = 400f;
+            UiKit.Label(storedCard.transform, "STORED ON DEVICE ONLY", UiKit.Caption, UiKit.Mint,
+                new Vector2(0, 140), new Vector2(760, 44), TextAnchor.MiddleLeft);
+            UiKit.Label(storedCard.transform, Copy.Get("storedOnDevice"), UiKit.Body, UiKit.TextBlue,
+                new Vector2(0, -20), new Vector2(760, 240), TextAnchor.UpperLeft);
 
-            UiKit.Label(content, $"Frog Across v{Application.version}", 22, UiKit.TextDim, new Vector2(520, -800), new Vector2(780, 30), TextAnchor.MiddleLeft);
+            UiKit.Label(right, $"Frog Across v{Application.version}", UiKit.Caption, UiKit.TextDim,
+                Vector2.zero, new Vector2(840, 48), TextAnchor.MiddleLeft);
+
             UiKit.Header(root.transform, "Settings", shell.Back);
             return root;
         }
 
         private static void Refresh(AppShell shell)
         {
-            shell.RebuildScreen("settings", Build);
-            shell.Push("settings");
+            shell.Replace("settings", Build); // Push here stacked a second copy
         }
 
-        private static void SoundRow(Transform parent, string title, string sub, Vector2 pos,
+        private static void SoundRow(Transform parent, string title, string sub,
             System.Func<bool> get, System.Action<bool> set)
         {
             var row = UiKit.Panel(parent, $"row-{title}", new Color(1f, 1f, 1f, 0.06f));
-            row.rectTransform.sizeDelta = new Vector2(760, 124);
-            row.rectTransform.anchoredPosition = pos;
-            UiKit.Label(row.transform, title, 30, UiKit.White, new Vector2(-90, 22), new Vector2(500, 38), TextAnchor.MiddleLeft);
-            UiKit.Label(row.transform, sub, 22, UiKit.TextBlue, new Vector2(-90, -24), new Vector2(500, 32), TextAnchor.MiddleLeft);
-            UiKit.Toggle(row.transform, new Vector2(300, 0), get(), set);
+            row.gameObject.AddComponent<LayoutElement>().preferredHeight = 150f;
+            UiKit.Label(row.transform, title, UiKit.Heading, UiKit.White, new Vector2(-70, 34),
+                new Vector2(560, 56), TextAnchor.MiddleLeft);
+            UiKit.Label(row.transform, sub, UiKit.Caption, UiKit.TextBlue, new Vector2(-70, -32),
+                new Vector2(560, 48), TextAnchor.MiddleLeft);
+            UiKit.Toggle(row.transform, new Vector2(330, 0), get(), set);
         }
 
         /// <summary>Full-screen preview of the four tap zones; one tap dismisses (#74/#59 amendment).</summary>
         public static void ShowRegionsPreview(Transform parent)
         {
             var canvas = UiKit.Canvas(parent, "regions-preview", 200);
-            var scrim = UiKit.Stretch(UiKit.Fill(canvas.transform, "scrim", new Color(0f, 0f, 0f, 0.55f)));
+            var scrim = UiKit.Stretch(UiKit.Fill(canvas.transform, "scrim", new Color(0f, 0f, 0f, 0.10f)));
 
             void Zone(Vector2 aMin, Vector2 aMax, string arrow, string label)
             {
-                var z = UiKit.Fill(canvas.transform, $"zone-{label}", new Color(0f, 0.839f, 0.706f, 0.12f));
+                var z = UiKit.Fill(canvas.transform, $"zone-{label}", new Color(0f, 0.839f, 0.706f, 0.10f));
                 var rt = z.rectTransform;
                 rt.anchorMin = aMin; rt.anchorMax = aMax;
                 rt.offsetMin = new Vector2(6, 6); rt.offsetMax = new Vector2(-6, -6);
-                UiKit.Label(z.transform, arrow, 110, UiKit.Mint, new Vector2(0, 40));
-                UiKit.Label(z.transform, label, 34, UiKit.White, new Vector2(0, -80));
+                UiKit.Label(z.transform, arrow, 140, new Color(0f, 0.839f, 0.706f, 0.55f), new Vector2(0, 50));
+                UiKit.Label(z.transform, label, UiKit.Heading, new Color(1f, 1f, 1f, 0.6f), new Vector2(0, -110));
             }
             float side = TapRegionMapper.SideFraction;
             Zone(new Vector2(0f, 0f), new Vector2(side, 1f), "◀", "Left");
@@ -145,16 +154,16 @@ namespace FrogAcross.UI
             var canvas = UiKit.Canvas(parent, "confirm-dialog", 300);
             UiKit.Stretch(UiKit.Fill(canvas.transform, "scrim", new Color(0.012f, 0.055f, 0.125f, 0.78f)));
             var panel = UiKit.Panel(canvas.transform, "panel", UiKit.PanelNavy);
-            panel.rectTransform.sizeDelta = new Vector2(900, 460);
-            var t = UiKit.Label(panel.transform, title, 44, UiKit.White, new Vector2(0, 150), new Vector2(800, 58));
+            panel.rectTransform.sizeDelta = new Vector2(980, 520);
+            var t = UiKit.Label(panel.transform, title, UiKit.Title, UiKit.White, new Vector2(0, 150), new Vector2(820, 78));
             t.fontStyle = FontStyle.Bold;
-            UiKit.Label(panel.transform, body, 28, UiKit.TextBlue, new Vector2(0, 30), new Vector2(800, 160), TextAnchor.UpperLeft);
-            UiKit.Button(panel.transform, "Cancel", new Vector2(-200, -160), new Vector2(350, 96), () =>
+            UiKit.Label(panel.transform, body, UiKit.Body, UiKit.TextBlue, new Vector2(0, 20), new Vector2(800, 180), TextAnchor.UpperLeft);
+            UiKit.Button(panel.transform, "Cancel", new Vector2(-210, -170), new Vector2(370, 116), () =>
             {
                 Object.Destroy(canvas.gameObject);
                 onCancel?.Invoke();
             });
-            var confirm = UiKit.Button(panel.transform, confirmLabel, new Vector2(200, -160), new Vector2(350, 96), () =>
+            var confirm = UiKit.Button(panel.transform, confirmLabel, new Vector2(210, -170), new Vector2(370, 116), () =>
             {
                 Object.Destroy(canvas.gameObject);
                 onConfirm();

--- a/Assets/Scripts/Runtime/UI/StaticScreens.cs
+++ b/Assets/Scripts/Runtime/UI/StaticScreens.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace FrogAcross.UI
 {
@@ -41,37 +42,27 @@ namespace FrogAcross.UI
     {
         public static GameObject BuildAbout(Transform parent, AppShell shell)
         {
-            var c = Screen(parent, shell, "about", "About Frog Across", 1180f, out var root);
-            UiKit.Label(c, Copy.Get("aboutBody"), 30, UiKit.TextBlue,
-                new Vector2(-380, -110), new Vector2(1000, 190), TextAnchor.UpperLeft);
-            Card(c, "Swipe", Copy.Get("aboutSwipe"), new Vector2(-620, -330), false, 540, 250);
-            Card(c, "Diagonal 43–47°", Copy.Get("aboutDiagonal"), new Vector2(-60, -330), true, 540, 250);
+            var c = Screen(parent, shell, "about", "About Frog Across", 1900f, out var root);
 
-            string[] laneKeys = { "ruleRoad", "ruleRiver", "ruleSwamp", "ruleTracks", "ruleBike", "ruleWalkway", "ruleMedians", "ruleBays" };
-            UiKit.Label(c, "WHAT'S ON THE BOARD", 24, UiKit.TextDim, new Vector2(560, -80),
-                new Vector2(760, 32), TextAnchor.MiddleLeft);
-            for (int i = 0; i < laneKeys.Length; i++)
-                UiKit.Label(c, "· " + Copy.Get(laneKeys[i]), 25, UiKit.TextBlue,
-                    new Vector2(560, -160 - i * 116), new Vector2(760, 110), TextAnchor.UpperLeft);
+            UiKit.Label(c, Copy.Get("aboutBody"), UiKit.Body, UiKit.TextBlue,
+                new Vector2(-430, -130), new Vector2(880, 260), TextAnchor.UpperLeft);
+            Card(c, "SWIPE", Copy.Get("aboutSwipe"), new Vector2(-430, -420), false, 880, 260);
+            Card(c, "DIAGONAL 43–47°", Copy.Get("aboutDiagonal"), new Vector2(-430, -720), true, 880, 260);
+            UiKit.Label(c, $"v{Application.version}  ·  {FrogAcross.Levels.LevelCatalog.Count} LEVELS  ·  6 CHARACTERS  ·  NO ADS",
+                UiKit.Caption, UiKit.TextDim, new Vector2(-430, -900), new Vector2(880, 44), TextAnchor.MiddleLeft);
 
-            UiKit.Label(c, Copy.Get("aboutFooter"), 24, UiKit.TextDim, new Vector2(-380, -620),
-                new Vector2(1000, 34), TextAnchor.MiddleLeft);
+            BoardRules(c, new Vector2(80, -70));
             return root;
         }
 
         public static GameObject BuildGameplay(Transform parent, AppShell shell)
         {
-            var c = Screen(parent, shell, "gameplay", "Gameplay", 1480f, out var root);
-            Card(c, "THE GOAL", Copy.Get("goal"), new Vector2(-420, -180), true, 940, 270);
-            Card(c, "LEVELS & TIMING", Copy.Get("levelsTiming"), new Vector2(-420, -500), false, 940, 300);
-            Card(c, "SWIPING & TAPPING", Copy.Get("swiping"), new Vector2(-420, -850), false, 940, 340);
+            var c = Screen(parent, shell, "gameplay", "Gameplay", 2100f, out var root);
+            Card(c, "THE GOAL", Copy.Get("goal"), new Vector2(-430, -220), true, 880, 340);
+            Card(c, "LEVELS & TIMING", Copy.Get("levelsTiming"), new Vector2(-430, -620), false, 880, 400);
+            Card(c, "SWIPING & TAPPING", Copy.Get("swiping"), new Vector2(-430, -1080), false, 880, 460);
 
-            string[] laneKeys = { "ruleRoad", "ruleRiver", "ruleSwamp", "ruleTracks", "ruleBike", "ruleWalkway", "ruleMedians", "ruleBays" };
-            UiKit.Label(c, "WHAT'S ON THE BOARD", 24, UiKit.TextDim, new Vector2(560, -80),
-                new Vector2(760, 32), TextAnchor.MiddleLeft);
-            for (int i = 0; i < laneKeys.Length; i++)
-                UiKit.Label(c, "· " + Copy.Get(laneKeys[i]), 25, UiKit.TextBlue,
-                    new Vector2(560, -160 - i * 116), new Vector2(760, 110), TextAnchor.UpperLeft);
+            BoardRules(c, new Vector2(80, -70));
             return root;
         }
 
@@ -79,10 +70,10 @@ namespace FrogAcross.UI
         {
             // #91: the standard Honest Arcade studio screen (from the Honest
             // Sudoku design), landscape: promises left, support + identity right.
-            var c = Screen(parent, shell, "studio", "About Honest Arcade", 1240f, out var root);
+            var c = Screen(parent, shell, "studio", "About Honest Arcade", 1900f, out var root);
 
-            UiKit.Label(c, "OUR PROMISES", 24, UiKit.TextDim, new Vector2(-560, -70),
-                new Vector2(400, 32), TextAnchor.MiddleLeft);
+            UiKit.Label(c, "OUR PROMISES", UiKit.Caption, UiKit.TextDim, new Vector2(-600, -80),
+                new Vector2(500, 44), TextAnchor.MiddleLeft);
             var promises = new (string k, string v, Color c)[]
             {
                 ("No ads. Ever.", Copy.Get("promiseAds"), UiKit.Mint),
@@ -93,33 +84,47 @@ namespace FrogAcross.UI
                 ("Open source", Copy.Get("promiseOpenSource"), UiKit.Hex("B48CFF")),
                 ("Works offline, stays small", Copy.Get("promiseOffline"), UiKit.Mint),
             };
+            var promiseColumn = UiKit.Column(c, new Vector2(-880, -140), 940f, 22f);
             for (int i = 0; i < promises.Length; i++)
             {
-                var row = UiKit.Panel(c, $"promise-{i}", new Color(1f, 1f, 1f, 0.06f));
-                row.rectTransform.sizeDelta = new Vector2(900, 116);
-                row.rectTransform.anchoredPosition = new Vector2(-430, -190 - i * 132);
-                UiKit.Label(row.transform, "✓", 32, promises[i].c, new Vector2(-410, 0), new Vector2(50, 44));
-                var k = UiKit.Label(row.transform, promises[i].k, 29, UiKit.White, new Vector2(40, 26),
-                    new Vector2(800, 38), TextAnchor.MiddleLeft);
+                var row = UiKit.Panel(promiseColumn, $"promise-{i}", new Color(1f, 1f, 1f, 0.06f));
+                var rowLayout = row.gameObject.AddComponent<VerticalLayoutGroup>();
+                rowLayout.padding = new RectOffset(84, 32, 22, 22);
+                rowLayout.spacing = 8;
+                rowLayout.childControlHeight = true;
+                rowLayout.childControlWidth = true;
+                rowLayout.childForceExpandHeight = false;
+                var rowFitter = row.gameObject.AddComponent<ContentSizeFitter>();
+                rowFitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+                var k = UiKit.Label(row.transform, promises[i].k, UiKit.Heading, UiKit.White,
+                    Vector2.zero, new Vector2(820, 0), TextAnchor.MiddleLeft);
                 k.fontStyle = FontStyle.Bold;
-                UiKit.Label(row.transform, promises[i].v, 22, UiKit.Hex("9FC3EE"), new Vector2(40, -26),
-                    new Vector2(800, 44), TextAnchor.MiddleLeft);
+                UiKit.Label(row.transform, promises[i].v, UiKit.Caption, UiKit.Hex("9FC3EE"),
+                    Vector2.zero, new Vector2(820, 0), TextAnchor.UpperLeft);
+
+                var tick = UiKit.Label(row.transform, "✓", UiKit.Heading, promises[i].c,
+                    new Vector2(-424, 0), new Vector2(64, 64));
+                tick.rectTransform.anchorMin = tick.rectTransform.anchorMax = new Vector2(0f, 1f);
+                tick.rectTransform.pivot = new Vector2(0f, 1f);
+                tick.rectTransform.anchoredPosition = new Vector2(20, -24);
+                tick.gameObject.AddComponent<LayoutElement>().ignoreLayout = true;
             }
 
-            UiKit.Label(c, Copy.Get("studioBody"), 29, UiKit.Hex("C6DAF0"),
-                new Vector2(560, -170), new Vector2(760, 190), TextAnchor.UpperLeft);
-            UiKit.Label(c, Copy.Get("studioTagline"), 26, UiKit.Hex("7FA6D8"),
-                new Vector2(560, -330), new Vector2(760, 80), TextAnchor.UpperLeft);
+            UiKit.Label(c, Copy.Get("studioBody"), UiKit.Body, UiKit.Hex("C6DAF0"),
+                new Vector2(540, -190), new Vector2(840, 260), TextAnchor.UpperLeft);
+            UiKit.Label(c, Copy.Get("studioTagline"), UiKit.Body, UiKit.Hex("7FA6D8"),
+                new Vector2(540, -420), new Vector2(840, 100), TextAnchor.UpperLeft);
 
             var support = UiKit.Panel(c, "support-card", new Color(0f, 0.839f, 0.706f, 0.12f));
-            support.rectTransform.sizeDelta = new Vector2(780, 260);
-            support.rectTransform.anchoredPosition = new Vector2(560, -520);
-            UiKit.Label(support.transform, "SUPPORT HONEST ARCADE", 22, UiKit.Mint, new Vector2(0, 88),
-                new Vector2(700, 30), TextAnchor.MiddleLeft);
-            UiKit.Label(support.transform, Copy.Get("studioSupport"), 24, UiKit.Hex("C6DAF0"),
-                new Vector2(0, 0), new Vector2(700, 110), TextAnchor.UpperLeft);
-            var link = UiKit.Label(support.transform, "honestarcade.app/contribute →", 26, UiKit.White,
-                new Vector2(0, -88), new Vector2(700, 36), TextAnchor.MiddleLeft);
+            support.rectTransform.sizeDelta = new Vector2(860, 360);
+            support.rectTransform.anchoredPosition = new Vector2(540, -680);
+            UiKit.Label(support.transform, "SUPPORT HONEST ARCADE", UiKit.Caption, UiKit.Mint, new Vector2(0, 128),
+                new Vector2(780, 44), TextAnchor.MiddleLeft);
+            UiKit.Label(support.transform, Copy.Get("studioSupport"), UiKit.Body, UiKit.Hex("C6DAF0"),
+                new Vector2(0, 0), new Vector2(780, 160), TextAnchor.UpperLeft);
+            var link = UiKit.Label(support.transform, "honestarcade.app/contribute →", UiKit.Heading, UiKit.White,
+                new Vector2(0, -128), new Vector2(780, 52), TextAnchor.MiddleLeft);
             link.fontStyle = FontStyle.Bold;
 
             var chips = new (string text, Color c)[]
@@ -131,11 +136,23 @@ namespace FrogAcross.UI
             };
             for (int i = 0; i < chips.Length; i++)
                 Chip(c, chips[i].text, chips[i].c,
-                    new Vector2(300 + (i % 3) * 230, -700 - (i / 3) * 76));
+                    new Vector2(300 + (i % 3) * 268, -960 - (i / 3) * 92));
 
-            UiKit.Label(c, "HONESTARCADE.APP  ·  SOURCE ON GITHUB", 22, UiKit.Hex("7FA6D8"),
-                new Vector2(560, -940), new Vector2(780, 32), TextAnchor.MiddleLeft);
+            UiKit.Label(c, "HONESTARCADE.APP  ·  SOURCE ON GITHUB", UiKit.Caption, UiKit.Hex("7FA6D8"),
+                new Vector2(540, -1200), new Vector2(840, 44), TextAnchor.MiddleLeft);
             return root;
+        }
+
+        /// <summary>The lane rundown, flowed so wrapped lines never collide.</summary>
+        private static void BoardRules(Transform parent, Vector2 topLeft)
+        {
+            string[] laneKeys = { "ruleRoad", "ruleRiver", "ruleSwamp", "ruleTracks", "ruleBike", "ruleWalkway", "ruleMedians", "ruleBays" };
+            var column = UiKit.Column(parent, topLeft, 900f, 26f);
+            UiKit.Label(column, "WHAT'S ON THE BOARD", UiKit.Caption, UiKit.TextDim,
+                Vector2.zero, new Vector2(900, 44), TextAnchor.MiddleLeft);
+            foreach (var key in laneKeys)
+                UiKit.Label(column, "· " + Copy.Get(key), UiKit.Body, UiKit.TextBlue,
+                    Vector2.zero, new Vector2(900, 0), TextAnchor.UpperLeft);
         }
 
         /// <summary>
@@ -168,18 +185,18 @@ namespace FrogAcross.UI
                 : new Color(1f, 1f, 1f, 0.05f));
             card.rectTransform.sizeDelta = new Vector2(w, h);
             card.rectTransform.anchoredPosition = pos;
-            UiKit.Label(card.transform, title, 24, accent ? UiKit.Mint : UiKit.TextDim,
-                new Vector2(0, h / 2f - 38), new Vector2(w - 56, 32), TextAnchor.MiddleLeft);
-            UiKit.Label(card.transform, body, 26, UiKit.TextBlue,
-                new Vector2(0, -20), new Vector2(w - 56, h - 92), TextAnchor.UpperLeft);
+            UiKit.Label(card.transform, title, UiKit.Caption, accent ? UiKit.Mint : UiKit.TextDim,
+                new Vector2(0, h / 2f - 46), new Vector2(w - 64, 44), TextAnchor.MiddleLeft);
+            UiKit.Label(card.transform, body, UiKit.Body, UiKit.TextBlue,
+                new Vector2(0, -26), new Vector2(w - 64, h - 116), TextAnchor.UpperLeft);
         }
 
         private static void Chip(Transform parent, string text, Color color, Vector2 pos)
         {
             var chip = UiKit.Panel(parent, $"chip-{text}", new Color(color.r, color.g, color.b, 0.16f), UiKit.PillRadius);
-            chip.rectTransform.sizeDelta = new Vector2(216, 58);
+            chip.rectTransform.sizeDelta = new Vector2(252, 72);
             chip.rectTransform.anchoredPosition = pos;
-            UiKit.Label(chip.transform, text, 19, color, Vector2.zero, new Vector2(216, 58));
+            UiKit.Label(chip.transform, text, UiKit.Micro, color, Vector2.zero, new Vector2(252, 72));
         }
     }
 }

--- a/Assets/Scripts/Runtime/UI/UiKit.cs
+++ b/Assets/Scripts/Runtime/UI/UiKit.cs
@@ -27,6 +27,17 @@ namespace FrogAcross.UI
 
         public static Font DefaultFont => Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
 
+        // Type scale. The design's own sizes (12–16px in a 958-wide mock) read
+        // tiny on a real 6.9" phone, so these are roughly double the design's
+        // scaled values — the owner should never need reading glasses (device
+        // pass, 2026-08-29). Screens use these names, never raw numbers.
+        public const int Display = 120;  // menu wordmark
+        public const int Title = 64;     // screen headers
+        public const int Heading = 46;   // card titles, row titles
+        public const int Body = 40;      // paragraphs, list items
+        public const int Caption = 32;   // secondary lines
+        public const int Micro = 26;     // eyebrow labels, footers
+
         /// <summary>Corner radius in reference pixels — the design rounds everything.</summary>
         public const int Radius = 28;
         public const int PillRadius = 999;
@@ -211,6 +222,12 @@ namespace FrogAcross.UI
             rt.anchorMin = rt.anchorMax = new Vector2(0.5f, 0.5f);
             rt.anchoredPosition = pos;
 
+            // Owner ruling (2026-08-29): mark beside the wordmark — not stacked
+            // above it — with the byline directly under the words.
+            Lockup(go.transform, Vector2.zero, size);
+            // right edge of the drawn wordmark: " Across" is left-aligned from
+            // the centre and runs about 3.6em at this weight
+            float wordRight = size * 3.7f;
             if (withMark && Logo != null)
             {
                 var markGo = new GameObject("mark");
@@ -219,11 +236,13 @@ namespace FrogAcross.UI
                 mark.sprite = Logo;
                 mark.preserveAspect = true;
                 mark.raycastTarget = false;
-                float m = size * 2.3f;
+                float m = size * 1.35f;
                 mark.rectTransform.sizeDelta = new Vector2(m, m);
-                mark.rectTransform.anchoredPosition = new Vector2(0, size * 1.35f);
+                mark.rectTransform.anchoredPosition = new Vector2(wordRight + m * 0.55f, 0f);
             }
-            Lockup(go.transform, Vector2.zero, size);
+            var byline = Label(go.transform, "BY HONEST ARCADE", Mathf.RoundToInt(size * 0.26f), TextDim,
+                new Vector2(0f, -size * 0.72f), new Vector2(size * 3.4f, size * 0.4f));
+            byline.raycastTarget = false;
             return go.transform;
         }
 
@@ -335,6 +354,9 @@ namespace FrogAcross.UI
             origin.pivot = new Vector2(0.5f, 1f);
             origin.sizeDelta = Vector2.zero;
             origin.anchoredPosition = Vector2.zero;
+            // a layout group on the surface would otherwise deal this node a
+            // cell of its own (it left an empty slot before level 1)
+            originGo.AddComponent<LayoutElement>().ignoreLayout = true;
 
             var scroll = viewGo.AddComponent<ScrollRect>();
             scroll.content = content;
@@ -350,6 +372,52 @@ namespace FrogAcross.UI
         }
 
         /// <summary>Sets the scrollable height (pass the transform ScrollArea returned).</summary>
+        /// <summary>
+        /// A top-anchored column that flows its children at their natural
+        /// heights. Lists of copy vary in length, so fixed per-item offsets
+        /// collide the moment a line wraps — this is the fix for that class of
+        /// bug, not another hand-tuned constant.
+        /// </summary>
+        public static RectTransform Column(Transform parent, Vector2 topLeft, float width, float spacing = 24f)
+        {
+            var go = new GameObject("column");
+            go.transform.SetParent(parent, false);
+            var rt = go.AddComponent<RectTransform>();
+            rt.anchorMin = rt.anchorMax = new Vector2(0.5f, 0.5f);
+            rt.pivot = new Vector2(0f, 1f);
+            rt.sizeDelta = new Vector2(width, 0f);
+            rt.anchoredPosition = topLeft;
+
+            var layout = go.AddComponent<VerticalLayoutGroup>();
+            layout.spacing = spacing;
+            layout.childControlWidth = true;
+            layout.childControlHeight = true;
+            layout.childForceExpandWidth = true;
+            layout.childForceExpandHeight = false;
+            layout.childAlignment = TextAnchor.UpperLeft;
+
+            var fitter = go.AddComponent<ContentSizeFitter>();
+            fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+            return rt;
+        }
+
+        /// <summary>A horizontal band that flows its children left to right.</summary>
+        public static RectTransform Row(Transform parent, float height, float spacing = 20f)
+        {
+            var go = new GameObject("row");
+            go.transform.SetParent(parent, false);
+            var rt = go.AddComponent<RectTransform>();
+            var layout = go.AddComponent<HorizontalLayoutGroup>();
+            layout.spacing = spacing;
+            layout.childControlWidth = false;
+            layout.childControlHeight = false;
+            layout.childForceExpandWidth = false;
+            layout.childForceExpandHeight = false;
+            layout.childAlignment = TextAnchor.MiddleLeft;
+            go.AddComponent<LayoutElement>().preferredHeight = height;
+            return rt;
+        }
+
         public static void SetContentHeight(RectTransform origin, float height)
         {
             var content = ScrollContent(origin);

--- a/Assets/Tests/PlayMode/LevelsGridTests.cs
+++ b/Assets/Tests/PlayMode/LevelsGridTests.cs
@@ -63,15 +63,20 @@ namespace FrogAcross.Tests.PlayMode
 
             var cell1 = Cell(1);
             Assert.That(cell1, Is.Not.Null);
-            Assert.That(cell1.Find("medal"), Is.Not.Null, "completed level shows its medal dot");
+            Assert.That(cell1.Find("medal").GetComponent<Image>().color, Is.EqualTo(UiKit.Gold),
+                "completed level shows its medal colour behind the number");
             Assert.That(cell1.GetComponent<Button>(), Is.Not.Null, "completed level stays launchable");
             bool showsTime = false;
             foreach (var text in cell1.GetComponentsInChildren<Text>(true))
                 if (text.text == "10.0s") showsTime = true;
             Assert.That(showsTime, Is.True, "completed cell shows the best time");
 
+            // every cell carries the disc now (it is the number's backing); an
+            // unearned one is neutral rather than absent
             var cell2 = Cell(2);
-            Assert.That(cell2.Find("medal"), Is.Null, "unplayed level has no medal");
+            var disc2 = cell2.Find("medal").GetComponent<Image>();
+            Assert.That(disc2.color, Is.Not.EqualTo(UiKit.Gold).And.Not.EqualTo(UiKit.Silver)
+                .And.Not.EqualTo(UiKit.Bronze), "unplayed level shows no medal colour");
             Assert.That(cell2.GetComponent<Button>(), Is.Not.Null, "unlocked level is launchable");
 
             var cell3 = Cell(3);
@@ -112,6 +117,46 @@ namespace FrogAcross.Tests.PlayMode
             Assert.That(header.IsChildOf(scroll.content), Is.False, "header must not scroll");
             Assert.That(header.GetSiblingIndex(), Is.EqualTo(levels.childCount - 1),
                 "header renders above the grid so the back button is always tappable");
+        }
+
+        [UnityTest]
+        public IEnumerator Grid_IsTenAcross_WithMedalDiscsAndNoLeadingGap()
+        {
+            Progression.ResetAll();
+            Progression.ReportCompletion(LevelCatalog.IdFor(1), 1, 1f, 60f, 90f, 120f); // gold
+            SceneManager.LoadScene("Shell");
+            yield return null;
+            var shell = Object.FindAnyObjectByType<AppShell>();
+            yield return Wait1_3;
+            shell.RebuildScreen("levels", LevelsScreen.Build);
+            shell.Push("levels");
+            yield return null;
+            Canvas.ForceUpdateCanvases();
+            yield return null;
+
+            var levels = GameObject.Find("shell-canvas").transform.Find("safe-area/levels");
+            var grid = levels.GetComponentInChildren<GridLayoutGroup>(true);
+            Assert.That(grid.constraint, Is.EqualTo(GridLayoutGroup.Constraint.FixedColumnCount));
+            Assert.That(grid.constraintCount, Is.EqualTo(10), "owner asked for exactly ten across");
+
+            // cells one and eleven start a row each: no phantom slot before level 1
+            var cell1 = (RectTransform)grid.transform.Find("cell-1");
+            var cell10 = (RectTransform)grid.transform.Find("cell-10");
+            var cell11 = (RectTransform)grid.transform.Find("cell-11");
+            Assert.That(cell10.anchoredPosition.y, Is.EqualTo(cell1.anchoredPosition.y).Within(0.5f),
+                "levels 1-10 share the first row");
+            Assert.That(cell11.anchoredPosition.y, Is.LessThan(cell1.anchoredPosition.y),
+                "level 11 starts the second row");
+            Assert.That(cell11.anchoredPosition.x, Is.EqualTo(cell1.anchoredPosition.x).Within(0.5f),
+                "and lines up under level 1 — no leading gap");
+
+            // the medal is the disc behind the number, identical on every cell
+            var disc1 = (RectTransform)cell1.Find("medal");
+            var disc100 = (RectTransform)grid.transform.Find("cell-100").Find("medal");
+            Assert.That(disc1, Is.Not.Null, "completed level shows its medal disc");
+            Assert.That(disc1.rect.size, Is.EqualTo(disc100.rect.size), "same disc size for 1 and 100");
+            Assert.That(disc1.GetComponent<Image>().color, Is.EqualTo(UiKit.Gold), "gold level, gold disc");
+            Assert.That(disc1.GetComponentInChildren<Outline>(), Is.Not.Null, "number is outlined");
         }
 
         [UnityTest]

--- a/Assets/Tests/PlayMode/ShellNavigationTests.cs
+++ b/Assets/Tests/PlayMode/ShellNavigationTests.cs
@@ -67,6 +67,36 @@ namespace FrogAcross.Tests.PlayMode
         }
 
         [UnityTest]
+        public IEnumerator ChangingASetting_LeavesBackWorkingFirstPress()
+        {
+            // owner report: after picking a character (or a control scheme) the
+            // back button did nothing until pressed twice — the screen rebuilt
+            // itself with Push, stacking a second copy of itself
+            SceneManager.LoadScene("Shell");
+            yield return null;
+            var shell = Object.FindAnyObjectByType<AppShell>();
+            yield return Wait1_3;
+
+            shell.Push("character");
+            yield return null;
+            shell.Replace("character", CharacterScreen.Build); // what selecting does
+            yield return null;
+            Assert.That(ScreenActive("character"), Is.True, "still on the rebuilt screen");
+
+            shell.Back();
+            yield return null;
+            Assert.That(ScreenActive("menu"), Is.True, "one press returns to the menu");
+
+            shell.Push("settings");
+            yield return null;
+            shell.Replace("settings", SettingsScreen.Build);
+            yield return null;
+            shell.Back();
+            yield return null;
+            Assert.That(ScreenActive("menu"), Is.True, "same for settings");
+        }
+
+        [UnityTest]
         public IEnumerator Lockup_IsTwoToneSpacedFrogAcross()
         {
             SceneManager.LoadScene("Shell");


### PR DESCRIPTION
Round-three device feedback, with three root causes worth naming:

- **"Everything is too small" is now a one-line change.** UiKit carries a type scale (Display/Title/Heading/Body/Caption/Micro) and screens use the names. The design's own 12–16px sizes scale to ~26pt on our canvas — genuinely unreadable on a 6.9" phone — so these are roughly double.
- **Three overlap reports were one bug.** About's rules, Settings' CONTROLS colliding with the Interface row, and Show-regions sitting on the stored-data card were all copy wrapping to a different number of lines while the next element sat at a hardcoded Y. Lists now flow through layout groups (`UiKit.Column` / `UiKit.Row`).
- **The double-press back button** was screens rebuilding themselves with `Push`, stacking a second copy — `Back` popped the duplicate and looked dead. `AppShell.Replace()` fixes it; the regression test drives both the character-select and control-scheme paths.

Also: exactly 10 columns on the levels grid (a fitter derives cell size from the actual surface — a fixed size gave 11 on one aspect, 12 on another); no phantom slot before level 1 (the scroll origin was being dealt a cell); medals are now the disc *behind* the number, one size for "1" and "100", outlined numeral; overlay medal is a circle with spaced buttons; menu fills the frame with the mark right of the wordmark and the byline underneath; region overlay dimmed to 0.1; About/Gameplay version derives from the build instead of hardcoded copy.

The game board is untouched this round — you asked to leave it until the rest is settled.

Tests: EditMode 142/142, PlayMode 23/23 (new: back-stack regression, ten-column/medal-disc grid rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeAv87tQK1G7qsTHK3dPc