### PR TITLE
Device UAT round 4: menu alignment, scrolling, self-sizing cards

### DIFF
--- a/.n8/decisions.md
+++ b/.n8/decisions.md
@@ -270,3 +270,12 @@ When `/n8-replan` processes an ad-hoc entry it appends `— reconciled by /n8-re
 - **Logo**: mark to the RIGHT of the wordmark with the byline underneath (owner's explicit call; the design has the mark on the left — noted here in case they want it flipped).
 - **Region preview** dimmed to 0.10 scrim + 0.10 zones (owner asked for "something really low").
 - **About/Gameplay version** now derives from Application.version and LevelCatalog.Count instead of the hardcoded "v1.0 · 100 LEVELS" copy string.
+
+### Device UAT round 4 — fix pass (2026-08-29)
+
+- **Menu columns are now anchored to the safe-area edges**, not offset from centre. The owner's alignment requests (pills left-aligned to the logo, promise line level with the buttons) needed a shared left edge, and fixed centre offsets would have run off a 16:9 canvas (1920 wide) even though they fit the owner's 21:9 (2340).
+- **Logotype measures its own glyphs** (Text.preferredWidth) instead of assuming an em width — the guess was short and " Across" wrapped over the button column. Mark moved to the LEFT at double size (owner ruling; this also matches the design), bottom-aligned with the byline.
+- **Scroll fixes:** ScrollArea's viewport now carries an invisible raycast surface, so a drag starting over empty background scrolls (previously only drags over a graphic worked); and AppShell.Replace captures/restores verticalNormalizedPosition, so changing a setting mid-page no longer snaps to the top.
+- **Copy cards size themselves** from a layout group instead of a fixed height — "Swiping & tapping" was spilling out of its box. Same root cause as the earlier overlap reports.
+- **Region preview is fully opaque** (owner: "take off the transparency altogether"): solid navy scrim, solid mint/blue/purple zones, dark glyphs.
+- **Support card is the link.** The whole green box opens https://honestarcade.app/contribute via Application.OpenURL. Adjacent to invariant 1, so stating it plainly: this is an OS hand-off to the browser, needs no INTERNET permission, sends no player data, and the shipped AAB still carries no network permission. The two footer link lines under the pills were removed.

--- a/Assets/Scripts/Runtime/UI/AppShell.cs
+++ b/Assets/Scripts/Runtime/UI/AppShell.cs
@@ -114,8 +114,26 @@ namespace FrogAcross.UI
         /// </summary>
         public void Replace(string name, Func<Transform, AppShell, GameObject> builder)
         {
+            // keep the reader where they were: flipping a setting halfway down
+            // the page used to snap it back to the top
+            float? scroll = null;
+            if (_screens.TryGetValue(name, out var existing) && existing != null)
+            {
+                var previous = existing.GetComponentInChildren<ScrollRect>(true);
+                if (previous != null) scroll = previous.verticalNormalizedPosition;
+            }
+
             RebuildScreen(name, builder);
             foreach (var kv in _screens) kv.Value.SetActive(kv.Key == name);
+            if (scroll.HasValue) StartCoroutine(RestoreScroll(name, scroll.Value));
+        }
+
+        private IEnumerator RestoreScroll(string name, float normalized)
+        {
+            yield return null; // let the rebuilt layout settle first
+            if (!_screens.TryGetValue(name, out var screen) || screen == null) yield break;
+            var scroll = screen.GetComponentInChildren<ScrollRect>(true);
+            if (scroll != null) scroll.verticalNormalizedPosition = normalized;
         }
 
         public void RebuildScreen(string name, Func<Transform, AppShell, GameObject> builder)
@@ -164,7 +182,7 @@ namespace FrogAcross.UI
             rrt.anchorMin = Vector2.zero; rrt.anchorMax = Vector2.one;
             rrt.offsetMin = rrt.offsetMax = Vector2.zero;
             UiKit.Stretch(UiKit.Fill(root.transform, "bg", UiKit.Navy));
-            UiKit.Logotype(root.transform, new Vector2(0, 60), 116);
+            UiKit.Logotype(root.transform, new Vector2(-560f, 60f), 116);
             var barBg = UiKit.Panel(root.transform, "bar-bg", new Color(1f, 1f, 1f, 0.12f), 8);
             barBg.rectTransform.sizeDelta = new Vector2(520, 12);
             barBg.rectTransform.anchoredPosition = new Vector2(0, -200);
@@ -178,6 +196,36 @@ namespace FrogAcross.UI
 
     internal static class MenuScreen
     {
+        /// <summary>A full-height column pinned to one safe-area edge.</summary>
+        private static Transform Side(Transform parent, bool left)
+        {
+            var go = new GameObject(left ? "brand-column" : "action-column");
+            go.transform.SetParent(parent, false);
+            var rt = go.AddComponent<RectTransform>();
+            rt.anchorMin = rt.anchorMax = new Vector2(left ? 0f : 1f, 0.5f);
+            rt.pivot = new Vector2(left ? 0f : 1f, 0.5f);
+            rt.sizeDelta = Vector2.zero;
+            rt.anchoredPosition = new Vector2(left ? UiKit.EdgePad : -UiKit.EdgePad, 0f);
+            return go.transform;
+        }
+
+        private static void RightAlign(RectTransform rt, float rightX, float centreY, Vector2 size)
+        {
+            rt.anchorMin = rt.anchorMax = new Vector2(1f, 0.5f);
+            rt.pivot = new Vector2(1f, 0.5f);
+            rt.sizeDelta = size;
+            rt.anchoredPosition = new Vector2(rightX, centreY);
+        }
+
+        /// <summary>Places a rect by its LEFT edge so a column can share one.</summary>
+        private static void LeftAlign(RectTransform rt, float leftX, float centreY, Vector2 size)
+        {
+            rt.anchorMin = rt.anchorMax = new Vector2(0f, 0.5f);
+            rt.pivot = new Vector2(0f, 0.5f);
+            rt.sizeDelta = size;
+            rt.anchoredPosition = new Vector2(leftX, centreY);
+        }
+
         public static GameObject Build(Transform parent, AppShell shell)
         {
             var root = new GameObject("menu");
@@ -186,31 +234,33 @@ namespace FrogAcross.UI
             rt.anchorMin = Vector2.zero; rt.anchorMax = Vector2.one;
             rt.offsetMin = rt.offsetMax = Vector2.zero;
 
-            // brand column left, actions right — both filling the safe area
-            UiKit.Logotype(root.transform, new Vector2(-640, 250), 128);
+            // Two columns pinned to the safe-area edges — fixed offsets from
+            // the centre would fall off a 16:9 phone, where the canvas is only
+            // 1920 wide.
+            var brand = Side(root.transform, left: true);
+            var actions = Side(root.transform, left: false);
+
+            UiKit.Logotype(brand, new Vector2(0f, 200f), 112);
 
             int current = Mathf.Min(Progression.HighestUnlocked, LevelCatalog.Count);
             int medals = 0;
             foreach (var r in Progression.Data.records) if (r.medal > 0) medals++;
 
-            var levelChip = UiKit.Panel(root.transform, "chip-level", new Color(1f, 1f, 1f, 0.07f));
-            levelChip.rectTransform.sizeDelta = new Vector2(420, 96);
-            levelChip.rectTransform.anchoredPosition = new Vector2(-860, 20);
+            var levelChip = UiKit.Panel(brand, "chip-level", new Color(1f, 1f, 1f, 0.07f));
+            LeftAlign(levelChip.rectTransform, 0f, 10f, new Vector2(440, 100));
             UiKit.Label(levelChip.transform, $"Level {current} / {LevelCatalog.Count}", UiKit.Caption,
-                UiKit.TextBlue, Vector2.zero, new Vector2(380, 44));
-            var medalChip = UiKit.Panel(root.transform, "chip-medals", new Color(1f, 1f, 1f, 0.07f));
-            medalChip.rectTransform.sizeDelta = new Vector2(330, 96);
-            medalChip.rectTransform.anchoredPosition = new Vector2(-430, 20);
+                UiKit.TextBlue, Vector2.zero, new Vector2(400, 48));
+            var medalChip = UiKit.Panel(brand, "chip-medals", new Color(1f, 1f, 1f, 0.07f));
+            LeftAlign(medalChip.rectTransform, 470f, 10f, new Vector2(340, 100));
             UiKit.Label(medalChip.transform, $"{medals} medals", UiKit.Caption,
-                UiKit.TextBlue, Vector2.zero, new Vector2(290, 44));
+                UiKit.TextBlue, Vector2.zero, new Vector2(300, 48));
 
-            UiKit.Label(root.transform, "SWIPE TO MOVE  ·  TAP TO HOP FORWARD", UiKit.Micro, UiKit.TextDim,
-                new Vector2(-640, -160), new Vector2(980, 44));
-            UiKit.Label(root.transform, $"v{Application.version}  ·  NO ADS  ·  NO TRACKING  ·  OPEN SOURCE",
-                UiKit.Micro, UiKit.TextDim, new Vector2(-640, -420), new Vector2(1100, 44));
-
-            UiKit.Button(root.transform, $"Continue — Level {current}", new Vector2(470, 300),
+            // Buttons: three rows of 160 from y=100 → the block bottom is -360,
+            // and the promise line's bottom sits level with it.
+            var continueBtn = UiKit.Button(actions, $"Continue — Level {current}", Vector2.zero,
                 new Vector2(880, 160), shell.LaunchCurrent, primary: true, fontSize: UiKit.Title - 6);
+            RightAlign(continueBtn.image.rectTransform, 0f, 300f, new Vector2(880, 160));
+
             var grid = new (string label, string screen)[]
             {
                 ("Levels", "levels"), ("Character", "character"),
@@ -220,11 +270,16 @@ namespace FrogAcross.UI
             for (int i = 0; i < grid.Length; i++)
             {
                 var (label, screen) = grid[i];
-                float x = 470 + (i % 2 == 0 ? -224 : 224);
-                float y = 100 - (i / 2) * 190;
-                UiKit.Button(root.transform, label, new Vector2(x, y), new Vector2(432, 160),
+                var btn = UiKit.Button(actions, label, Vector2.zero, new Vector2(432, 160),
                     () => shell.Push(screen), fontSize: UiKit.Heading);
+                float right = i % 2 == 0 ? -448f : 0f;
+                RightAlign(btn.image.rectTransform, right, 100f - (i / 2) * 190f, new Vector2(432, 160));
             }
+
+            var promise = UiKit.Label(brand,
+                $"v{Application.version}  ·  NO ADS  ·  NO TRACKING  ·  OPEN SOURCE",
+                UiKit.Micro, UiKit.TextDim, Vector2.zero, new Vector2(1000, 44), TextAnchor.MiddleLeft);
+            LeftAlign(promise.rectTransform, 0f, -360f + 22f, new Vector2(1000, 44));
             return root;
         }
     }

--- a/Assets/Scripts/Runtime/UI/LevelsScreen.cs
+++ b/Assets/Scripts/Runtime/UI/LevelsScreen.cs
@@ -74,8 +74,8 @@ namespace FrogAcross.UI
             pct.rectTransform.pivot = new Vector2(0f, 1f);
             pct.rectTransform.anchoredPosition = new Vector2(UiKit.EdgePad + 920f, -220f);
 
-            Legend(band.transform, "Gold", UiKit.Gold, -540f);
-            Legend(band.transform, "Silver", UiKit.Silver, -330f);
+            Legend(band.transform, "Gold", UiKit.Gold, -940f);
+            Legend(band.transform, "Silver", UiKit.Silver, -530f);
             Legend(band.transform, "Bronze", UiKit.Bronze, -110f);
 
             UiKit.Header(root.transform, "Levels", shell.Back);
@@ -88,11 +88,11 @@ namespace FrogAcross.UI
             var drt = dot.rectTransform;
             drt.anchorMin = drt.anchorMax = new Vector2(1f, 1f);
             drt.pivot = new Vector2(1f, 1f);
-            drt.sizeDelta = new Vector2(32, 32);
-            drt.anchoredPosition = new Vector2(rightOffset - 200f, -98f);
+            drt.sizeDelta = new Vector2(64, 64);
+            drt.anchoredPosition = new Vector2(rightOffset - 360f, -92f);
 
-            var text = UiKit.Label(band, label, UiKit.Caption, UiKit.TextBlue, Vector2.zero,
-                new Vector2(190, 44), TextAnchor.MiddleLeft);
+            var text = UiKit.Label(band, label, UiKit.Heading + 12, UiKit.TextBlue, Vector2.zero,
+                new Vector2(280, 76), TextAnchor.MiddleLeft);
             var trt = text.rectTransform;
             trt.anchorMin = trt.anchorMax = new Vector2(1f, 1f);
             trt.pivot = new Vector2(1f, 1f);

--- a/Assets/Scripts/Runtime/UI/SettingsScreen.cs
+++ b/Assets/Scripts/Runtime/UI/SettingsScreen.cs
@@ -110,22 +110,22 @@ namespace FrogAcross.UI
         public static void ShowRegionsPreview(Transform parent)
         {
             var canvas = UiKit.Canvas(parent, "regions-preview", 200);
-            var scrim = UiKit.Stretch(UiKit.Fill(canvas.transform, "scrim", new Color(0f, 0f, 0f, 0.10f)));
+            var scrim = UiKit.Stretch(UiKit.Fill(canvas.transform, "scrim", UiKit.NavyDeep));
 
-            void Zone(Vector2 aMin, Vector2 aMax, string arrow, string label)
+            void Zone(Vector2 aMin, Vector2 aMax, string arrow, string label, Color zoneColor)
             {
-                var z = UiKit.Fill(canvas.transform, $"zone-{label}", new Color(0f, 0.839f, 0.706f, 0.10f));
+                var z = UiKit.Fill(canvas.transform, $"zone-{label}", zoneColor); // opaque (owner ruling)
                 var rt = z.rectTransform;
                 rt.anchorMin = aMin; rt.anchorMax = aMax;
                 rt.offsetMin = new Vector2(6, 6); rt.offsetMax = new Vector2(-6, -6);
-                UiKit.Label(z.transform, arrow, 140, new Color(0f, 0.839f, 0.706f, 0.55f), new Vector2(0, 50));
-                UiKit.Label(z.transform, label, UiKit.Heading, new Color(1f, 1f, 1f, 0.6f), new Vector2(0, -110));
+                UiKit.Label(z.transform, arrow, 160, UiKit.NavyDeep, new Vector2(0, 60));
+                UiKit.Label(z.transform, label, UiKit.Title, UiKit.NavyDeep, new Vector2(0, -120));
             }
             float side = TapRegionMapper.SideFraction;
-            Zone(new Vector2(0f, 0f), new Vector2(side, 1f), "◀", "Left");
-            Zone(new Vector2(1f - side, 0f), new Vector2(1f, 1f), "▶", "Right");
-            Zone(new Vector2(side, 0.5f), new Vector2(1f - side, 1f), "▲", "Forward");
-            Zone(new Vector2(side, 0f), new Vector2(1f - side, 0.5f), "▼", "Back");
+            Zone(new Vector2(0f, 0f), new Vector2(side, 1f), "◀", "Left", UiKit.Mint);
+            Zone(new Vector2(1f - side, 0f), new Vector2(1f, 1f), "▶", "Right", UiKit.Mint);
+            Zone(new Vector2(side, 0.5f), new Vector2(1f - side, 1f), "▲", "Forward", UiKit.Hex("6FB4FF"));
+            Zone(new Vector2(side, 0f), new Vector2(1f - side, 0.5f), "▼", "Back", UiKit.Hex("B48CFF"));
 
             var dismiss = scrim.gameObject.AddComponent<Button>();
             dismiss.onClick.AddListener(() => Object.Destroy(canvas.gameObject));

--- a/Assets/Scripts/Runtime/UI/StaticScreens.cs
+++ b/Assets/Scripts/Runtime/UI/StaticScreens.cs
@@ -40,16 +40,19 @@ namespace FrogAcross.UI
     /// <summary>#58: About / Gameplay / Studio — teaching the SHIPPED rules.</summary>
     public static class StaticScreens
     {
+        public const string SupportUrl = "https://honestarcade.app/contribute";
+
         public static GameObject BuildAbout(Transform parent, AppShell shell)
         {
-            var c = Screen(parent, shell, "about", "About Frog Across", 1900f, out var root);
+            var c = Screen(parent, shell, "about", "About Frog Across", 1500f, out var root);
 
-            UiKit.Label(c, Copy.Get("aboutBody"), UiKit.Body, UiKit.TextBlue,
-                new Vector2(-430, -130), new Vector2(880, 260), TextAnchor.UpperLeft);
-            Card(c, "SWIPE", Copy.Get("aboutSwipe"), new Vector2(-430, -420), false, 880, 260);
-            Card(c, "DIAGONAL 43–47°", Copy.Get("aboutDiagonal"), new Vector2(-430, -720), true, 880, 260);
-            UiKit.Label(c, $"v{Application.version}  ·  {FrogAcross.Levels.LevelCatalog.Count} LEVELS  ·  6 CHARACTERS  ·  NO ADS",
-                UiKit.Caption, UiKit.TextDim, new Vector2(-430, -900), new Vector2(880, 44), TextAnchor.MiddleLeft);
+            var left = UiKit.Column(c, new Vector2(-880, -70), 900f, 30f);
+            UiKit.Label(left, Copy.Get("aboutBody"), UiKit.Body, UiKit.TextBlue,
+                Vector2.zero, new Vector2(900, 0), TextAnchor.UpperLeft);
+            Card(left, "SWIPE", Copy.Get("aboutSwipe"), false, 900f);
+            Card(left, "DIAGONAL 43–47°", Copy.Get("aboutDiagonal"), true, 900f);
+            UiKit.Label(left, $"v{Application.version}  ·  {FrogAcross.Levels.LevelCatalog.Count} LEVELS  ·  6 CHARACTERS  ·  NO ADS",
+                UiKit.Caption, UiKit.TextDim, Vector2.zero, new Vector2(900, 48), TextAnchor.MiddleLeft);
 
             BoardRules(c, new Vector2(80, -70));
             return root;
@@ -57,10 +60,12 @@ namespace FrogAcross.UI
 
         public static GameObject BuildGameplay(Transform parent, AppShell shell)
         {
-            var c = Screen(parent, shell, "gameplay", "Gameplay", 2100f, out var root);
-            Card(c, "THE GOAL", Copy.Get("goal"), new Vector2(-430, -220), true, 880, 340);
-            Card(c, "LEVELS & TIMING", Copy.Get("levelsTiming"), new Vector2(-430, -620), false, 880, 400);
-            Card(c, "SWIPING & TAPPING", Copy.Get("swiping"), new Vector2(-430, -1080), false, 880, 460);
+            var c = Screen(parent, shell, "gameplay", "Gameplay", 1900f, out var root);
+
+            var left = UiKit.Column(c, new Vector2(-880, -70), 900f, 30f);
+            Card(left, "THE GOAL", Copy.Get("goal"), true, 900f);
+            Card(left, "LEVELS & TIMING", Copy.Get("levelsTiming"), false, 900f);
+            Card(left, "SWIPING & TAPPING", Copy.Get("swiping"), false, 900f);
 
             BoardRules(c, new Vector2(80, -70));
             return root;
@@ -116,7 +121,13 @@ namespace FrogAcross.UI
             UiKit.Label(c, Copy.Get("studioTagline"), UiKit.Body, UiKit.Hex("7FA6D8"),
                 new Vector2(540, -420), new Vector2(840, 100), TextAnchor.UpperLeft);
 
-            var support = UiKit.Panel(c, "support-card", new Color(0f, 0.839f, 0.706f, 0.12f));
+            var support = UiKit.Panel(c, "support-card", new Color(0f, 0.839f, 0.706f, 0.14f));
+            var supportBtn = support.gameObject.AddComponent<Button>();
+            supportBtn.targetGraphic = support;
+            supportBtn.onClick.AddListener(() =>
+                FrogAcross.Audio.AudioDirector.Instance.Play(FrogAcross.Audio.GameSound.UiTap));
+            // hands off to the browser: no network access of our own (invariant 1)
+            supportBtn.onClick.AddListener(() => Application.OpenURL(SupportUrl));
             support.rectTransform.sizeDelta = new Vector2(860, 360);
             support.rectTransform.anchoredPosition = new Vector2(540, -680);
             UiKit.Label(support.transform, "SUPPORT HONEST ARCADE", UiKit.Caption, UiKit.Mint, new Vector2(0, 128),
@@ -138,8 +149,6 @@ namespace FrogAcross.UI
                 Chip(c, chips[i].text, chips[i].c,
                     new Vector2(300 + (i % 3) * 268, -960 - (i / 3) * 92));
 
-            UiKit.Label(c, "HONESTARCADE.APP  ·  SOURCE ON GITHUB", UiKit.Caption, UiKit.Hex("7FA6D8"),
-                new Vector2(540, -1200), new Vector2(840, 44), TextAnchor.MiddleLeft);
             return root;
         }
 
@@ -177,18 +186,29 @@ namespace FrogAcross.UI
             return content;
         }
 
-        private static void Card(Transform parent, string title, string body, Vector2 pos, bool accent,
-            float w = 420, float h = 170)
+        /// <summary>
+        /// A copy card that grows to whatever its text needs. Lives inside a
+        /// UiKit.Column, which sizes it from this layout's preferred height —
+        /// a fixed height let "Swiping &amp; tapping" spill out of its box.
+        /// </summary>
+        private static void Card(Transform parent, string title, string body, bool accent, float width)
         {
             var card = UiKit.Panel(parent, $"card-{title}", accent
                 ? new Color(0f, 0.839f, 0.706f, 0.12f)
-                : new Color(1f, 1f, 1f, 0.05f));
-            card.rectTransform.sizeDelta = new Vector2(w, h);
-            card.rectTransform.anchoredPosition = pos;
+                : new Color(1f, 1f, 1f, 0.06f));
+
+            var layout = card.gameObject.AddComponent<VerticalLayoutGroup>();
+            layout.padding = new RectOffset(40, 40, 32, 34);
+            layout.spacing = 16;
+            layout.childControlWidth = true;
+            layout.childControlHeight = true;
+            layout.childForceExpandWidth = true;
+            layout.childForceExpandHeight = false;
+
             UiKit.Label(card.transform, title, UiKit.Caption, accent ? UiKit.Mint : UiKit.TextDim,
-                new Vector2(0, h / 2f - 46), new Vector2(w - 64, 44), TextAnchor.MiddleLeft);
+                Vector2.zero, new Vector2(width - 80, 0), TextAnchor.MiddleLeft);
             UiKit.Label(card.transform, body, UiKit.Body, UiKit.TextBlue,
-                new Vector2(0, -26), new Vector2(w - 64, h - 116), TextAnchor.UpperLeft);
+                Vector2.zero, new Vector2(width - 80, 0), TextAnchor.UpperLeft);
         }
 
         private static void Chip(Transform parent, string text, Color color, Vector2 pos)

--- a/Assets/Scripts/Runtime/UI/UiKit.cs
+++ b/Assets/Scripts/Runtime/UI/UiKit.cs
@@ -214,36 +214,76 @@ namespace FrogAcross.UI
         /// The full logo: frog mark above the two-tone spaced wordmark
         /// ("Frog" white + " Across" mint — owner decision).
         /// </summary>
-        public static Transform Logotype(Transform parent, Vector2 pos, int size, bool withMark = true)
+        /// <summary>
+        /// The full logo, laid out from a LEFT edge so callers can align other
+        /// things to it: mark on the left (owner ruling — matches the design),
+        /// wordmark beside it, byline under the words, and the mark's bottom
+        /// level with the byline's.
+        /// Returns the block's total width.
+        /// </summary>
+        public static float Logotype(Transform parent, Vector2 leftCentre, int size, bool withMark = true)
         {
             var go = new GameObject("logotype");
             go.transform.SetParent(parent, false);
             var rt = go.AddComponent<RectTransform>();
-            rt.anchorMin = rt.anchorMax = new Vector2(0.5f, 0.5f);
-            rt.anchoredPosition = pos;
+            rt.anchorMin = rt.anchorMax = new Vector2(0f, 0.5f);
+            rt.pivot = new Vector2(0f, 0.5f);
+            rt.anchoredPosition = leftCentre;
 
-            // Owner ruling (2026-08-29): mark beside the wordmark — not stacked
-            // above it — with the byline directly under the words.
-            Lockup(go.transform, Vector2.zero, size);
-            // right edge of the drawn wordmark: " Across" is left-aligned from
-            // the centre and runs about 3.6em at this weight
-            float wordRight = size * 3.7f;
-            if (withMark && Logo != null)
+            float mark = withMark && Logo != null ? size * 2.7f : 0f; // owner: double
+            float gap = withMark && mark > 0f ? size * 0.34f : 0f;
+            float bylineY = -size * 0.72f, bylineH = size * 0.42f;
+
+            if (mark > 0f)
             {
                 var markGo = new GameObject("mark");
                 markGo.transform.SetParent(go.transform, false);
-                var mark = markGo.AddComponent<Image>();
-                mark.sprite = Logo;
-                mark.preserveAspect = true;
-                mark.raycastTarget = false;
-                float m = size * 1.35f;
-                mark.rectTransform.sizeDelta = new Vector2(m, m);
-                mark.rectTransform.anchoredPosition = new Vector2(wordRight + m * 0.55f, 0f);
+                var img = markGo.AddComponent<Image>();
+                img.sprite = Logo;
+                img.preserveAspect = true;
+                img.raycastTarget = false;
+                var mrt = img.rectTransform;
+                mrt.anchorMin = mrt.anchorMax = new Vector2(0f, 0.5f);
+                mrt.pivot = new Vector2(0f, 0.5f);
+                mrt.sizeDelta = new Vector2(mark, mark);
+                // bottom of the mark sits on the bottom of the byline
+                mrt.anchoredPosition = new Vector2(0f, bylineY - bylineH / 2f + mark / 2f);
             }
+
+            // Measure the glyphs rather than guessing an em width — the guess
+            // was short and "Across" wrapped onto the buttons.
+            float wordLeft = mark + gap;
+            var frog = Label(go.transform, "Frog", size, White, Vector2.zero,
+                new Vector2(size * 6f, size + 16), TextAnchor.MiddleLeft);
+            frog.fontStyle = FontStyle.Bold;
+            frog.horizontalOverflow = HorizontalWrapMode.Overflow;
+            float frogW = frog.preferredWidth;
+            LeftAnchor(frog.rectTransform, wordLeft, 0f, frogW);
+
+            var across = Label(go.transform, " Across", size, Mint, Vector2.zero,
+                new Vector2(size * 8f, size + 16), TextAnchor.MiddleLeft);
+            across.fontStyle = FontStyle.Bold;
+            across.horizontalOverflow = HorizontalWrapMode.Overflow;
+            float acrossW = across.preferredWidth;
+            LeftAnchor(across.rectTransform, wordLeft + frogW, 0f, acrossW);
+
             var byline = Label(go.transform, "BY HONEST ARCADE", Mathf.RoundToInt(size * 0.26f), TextDim,
-                new Vector2(0f, -size * 0.72f), new Vector2(size * 3.4f, size * 0.4f));
+                Vector2.zero, new Vector2(frogW + acrossW, bylineH), TextAnchor.MiddleLeft);
             byline.raycastTarget = false;
-            return go.transform;
+            byline.horizontalOverflow = HorizontalWrapMode.Overflow;
+            LeftAnchor(byline.rectTransform, wordLeft + size * 0.06f, bylineY, frogW + acrossW);
+
+            float width = wordLeft + frogW + acrossW;
+            rt.sizeDelta = new Vector2(width, size * 2.4f);
+            return width;
+        }
+
+        private static void LeftAnchor(RectTransform rt, float x, float y, float width)
+        {
+            rt.anchorMin = rt.anchorMax = new Vector2(0f, 0.5f);
+            rt.pivot = new Vector2(0f, 0.5f);
+            rt.sizeDelta = new Vector2(width, rt.sizeDelta.y);
+            rt.anchoredPosition = new Vector2(x, y);
         }
 
         /// <summary>The two-tone spaced wordmark alone.</summary>
@@ -333,6 +373,12 @@ namespace FrogAcross.UI
             view.offsetMin = new Vector2(bottomRightInset.x, bottomRightInset.y);
             view.offsetMax = new Vector2(-topLeftInset.x, -topLeftInset.y);
             viewGo.AddComponent<RectMask2D>();
+            // an invisible, raycastable surface: without it a drag that starts
+            // on empty background does nothing (owner: "swiping needs to work
+            // on the entire screen")
+            var catcher = viewGo.AddComponent<Image>();
+            catcher.color = new Color(0f, 0f, 0f, 0f);
+            catcher.raycastTarget = true;
 
             var contentGo = new GameObject("content");
             contentGo.transform.SetParent(viewGo.transform, false);

--- a/Assets/Tests/PlayMode/ShellNavigationTests.cs
+++ b/Assets/Tests/PlayMode/ShellNavigationTests.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Linq;
 using FrogAcross.UI;
 using NUnit.Framework;
 using UnityEngine;
@@ -94,6 +95,59 @@ namespace FrogAcross.Tests.PlayMode
             shell.Back();
             yield return null;
             Assert.That(ScreenActive("menu"), Is.True, "same for settings");
+        }
+
+        [UnityTest]
+        public IEnumerator ChangingASetting_KeepsYourPlaceInTheScroll()
+        {
+            // owner: flipping the control scheme halfway down Settings snapped
+            // the page back to the top
+            SceneManager.LoadScene("Shell");
+            yield return null;
+            var shell = Object.FindAnyObjectByType<AppShell>();
+            yield return Wait1_3;
+            shell.Push("settings");
+            yield return null;
+            Canvas.ForceUpdateCanvases();
+            yield return null;
+
+            var settings = GameObject.Find("shell-canvas").transform.Find("safe-area/settings");
+            var scroll = settings.GetComponentInChildren<ScrollRect>(true);
+            Assert.That(scroll.viewport.GetComponent<Graphic>(), Is.Not.Null,
+                "the viewport needs a raycast surface or drags over empty space do nothing");
+
+            scroll.verticalNormalizedPosition = 0.25f;
+            yield return null;
+            shell.Replace("settings", SettingsScreen.Build);
+            yield return null;
+            yield return null;
+
+            var rebuilt = GameObject.Find("shell-canvas").transform.Find("safe-area/settings")
+                .GetComponentInChildren<ScrollRect>(true);
+            Assert.That(rebuilt.verticalNormalizedPosition, Is.EqualTo(0.25f).Within(0.05f),
+                "the rebuilt screen keeps your place");
+        }
+
+        [UnityTest]
+        public IEnumerator StudioScreen_SupportBoxLinksOut_AndDropsTheFooterLinks()
+        {
+            SceneManager.LoadScene("Shell");
+            yield return null;
+            var shell = Object.FindAnyObjectByType<AppShell>();
+            yield return Wait1_3;
+            shell.Push("studio");
+            yield return null;
+
+            var studio = GameObject.Find("shell-canvas").transform.Find("safe-area/studio");
+            var support = studio.GetComponentsInChildren<Transform>(true)
+                .FirstOrDefault(t => t.name == "support-card");
+            Assert.That(support, Is.Not.Null);
+            Assert.That(support.GetComponent<Button>(), Is.Not.Null, "the whole box is the link");
+            Assert.That(StaticScreens.SupportUrl, Is.EqualTo("https://honestarcade.app/contribute"));
+
+            foreach (var text in studio.GetComponentsInChildren<Text>(true))
+                Assert.That(text.text, Does.Not.Contain("SOURCE ON GITHUB"),
+                    "the footer link lines were removed");
         }
 
         [UnityTest]


### PR DESCRIPTION
Round-four list, all of it:

1. **Menu** — mark on the left at double size, bottom-aligned with "BY HONEST ARCADE"; pills and the promise line share the logo's left edge; promise line's bottom sits level with the button block; "Swipe to move…" removed. The columns now anchor to the safe-area edges rather than fixed centre offsets, which would have run off a 16:9 canvas. The logotype also measures its own glyphs — the previous em-width guess was short and "Across" wrapped over the buttons.
2. **Levels** — medal legend at double size, dots clear of their labels.
3. **Settings** — drags anywhere scroll (the viewport had no raycast surface, so only drags over a graphic worked); changing the control scheme keeps your scroll position; the region overlay is fully opaque.
4. ✅ (no change requested)
5a. **Honest Arcade** — footer link lines removed; the whole green Support box opens honestarcade.app/contribute in the browser. Worth stating against invariant 1: this is an OS hand-off, needs no INTERNET permission, and sends no player data — the shipped AAB still has no network permission.
5b. **Gameplay** — cards size themselves to their copy, so "Swiping & tapping" no longer spills out.

The game board is still parked for its own pass.

Tests: EditMode 142/142, PlayMode 25/25 (new: scroll-position survives a rebuild, viewport is drag-catching, support box links out and the footer lines are gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeAv87tQK1G7qsTHK3dPc