### PR TITLE
fix: tap-regions preview closes on a tap anywhere

### DIFF
--- a/Assets/Scripts/Runtime/UI/SettingsScreen.cs
+++ b/Assets/Scripts/Runtime/UI/SettingsScreen.cs
@@ -106,11 +106,11 @@ namespace FrogAcross.UI
             UiKit.Toggle(row.transform, new Vector2(330, 0), get(), set);
         }
 
-        /// <summary>Full-screen preview of the four tap zones; one tap dismisses (#74/#59 amendment).</summary>
+        /// <summary>Full-screen preview of the four tap zones; one tap anywhere dismisses (#74/#59 amendment).</summary>
         public static void ShowRegionsPreview(Transform parent)
         {
             var canvas = UiKit.Canvas(parent, "regions-preview", 200);
-            var scrim = UiKit.Stretch(UiKit.Fill(canvas.transform, "scrim", UiKit.NavyDeep));
+            UiKit.Stretch(UiKit.Fill(canvas.transform, "scrim", UiKit.NavyDeep));
 
             void Zone(Vector2 aMin, Vector2 aMax, string arrow, string label, Color zoneColor)
             {
@@ -127,10 +127,20 @@ namespace FrogAcross.UI
             Zone(new Vector2(side, 0.5f), new Vector2(1f - side, 1f), "▲", "Forward", UiKit.Hex("6FB4FF"));
             Zone(new Vector2(side, 0f), new Vector2(1f - side, 0.5f), "▼", "Back", UiKit.Hex("B48CFF"));
 
-            var dismiss = scrim.gameObject.AddComponent<Button>();
+            // Nothing in the preview is interactive, so the dismiss surface is a
+            // transparent sheet laid over the whole thing — last child, so it
+            // wins every raycast no matter what the zones draw. The old version
+            // put the Button on the scrim underneath and only cleared Images,
+            // leaving the 600-wide zone captions as raycast targets: they
+            // covered the narrow side zones end to end, so taps near the edges
+            // hit a caption and did nothing (owner: "closing it is spotty",
+            // 2026-08-30).
+            foreach (var g in canvas.GetComponentsInChildren<Graphic>(true)) g.raycastTarget = false;
+            var sheet = UiKit.Stretch(UiKit.Fill(canvas.transform, "dismiss", new Color(0f, 0f, 0f, 0f)));
+            sheet.raycastTarget = true;
+            var dismiss = sheet.gameObject.AddComponent<Button>();
+            dismiss.transition = Selectable.Transition.None; // nothing to tint
             dismiss.onClick.AddListener(() => Object.Destroy(canvas.gameObject));
-            foreach (var img in canvas.GetComponentsInChildren<Image>())
-                if (img != scrim) img.raycastTarget = false; // one tap anywhere dismisses
         }
 
         private static void ConfirmReset(AppShell shell)

--- a/Assets/Scripts/Runtime/UI/UiKit.cs
+++ b/Assets/Scripts/Runtime/UI/UiKit.cs
@@ -152,6 +152,11 @@ namespace FrogAcross.UI
             t.alignment = align;
             t.horizontalOverflow = HorizontalWrapMode.Wrap;
             t.verticalOverflow = VerticalWrapMode.Overflow;
+            // Text is decoration, never a tap target: a label's box is 600 wide
+            // by default and would otherwise sit on top of whatever it labels
+            // and swallow the tap (owner: the regions overlay closed only in
+            // places, 2026-08-30). Buttons block with their own Image.
+            t.raycastTarget = false;
             var rt = t.rectTransform;
             rt.anchorMin = rt.anchorMax = new Vector2(0.5f, 0.5f);
             rt.sizeDelta = sizeDelta ?? new Vector2(600, size + 14);

--- a/Assets/Tests/PlayMode/ShellNavigationTests.cs
+++ b/Assets/Tests/PlayMode/ShellNavigationTests.cs
@@ -1,8 +1,10 @@
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using FrogAcross.UI;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using UnityEngine.UI;
@@ -126,6 +128,50 @@ namespace FrogAcross.Tests.PlayMode
                 .GetComponentInChildren<ScrollRect>(true);
             Assert.That(rebuilt.verticalNormalizedPosition, Is.EqualTo(0.25f).Within(0.05f),
                 "the rebuilt screen keeps your place");
+        }
+
+        [UnityTest]
+        public IEnumerator RegionsPreview_ClosesOnATapAnywhere()
+        {
+            // owner: "opening the regions overlay works, however closing it is
+            // spotty… tapping towards the center works, but not the edges" —
+            // the zone captions were raycast targets sitting over the scrim,
+            // and a 600-wide caption covers a 20%-wide side zone completely
+            SceneManager.LoadScene("Shell");
+            yield return null;
+            var shell = Object.FindAnyObjectByType<AppShell>();
+            yield return Wait1_3;
+
+            SettingsScreen.ShowRegionsPreview(shell.transform);
+            yield return null;
+            Canvas.ForceUpdateCanvases();
+            yield return null;
+            Assert.That(GameObject.Find("regions-preview"), Is.Not.Null, "the preview opened");
+
+            var events = EventSystem.current;
+            var hits = new List<RaycastResult>();
+            for (int ix = 0; ix <= 10; ix++)
+            for (int iy = 0; iy <= 10; iy++)
+            {
+                var point = new Vector2(
+                    Mathf.Lerp(2f, Screen.width - 2f, ix / 10f),
+                    Mathf.Lerp(2f, Screen.height - 2f, iy / 10f));
+                hits.Clear();
+                events.RaycastAll(new PointerEventData(events) { position = point }, hits);
+                Assert.That(hits.Count, Is.GreaterThan(0), $"nothing under {point}");
+                Assert.That(hits[0].gameObject.name, Is.EqualTo("dismiss"),
+                    $"a tap at {point} must reach the dismiss sheet, not '{hits[0].gameObject.name}'");
+            }
+
+            // and the tap actually closes it — near the left edge, the corner
+            // the owner could not dismiss from
+            var edge = new Vector2(Screen.width * 0.04f, Screen.height * 0.5f);
+            hits.Clear();
+            events.RaycastAll(new PointerEventData(events) { position = edge }, hits);
+            ExecuteEvents.ExecuteHierarchy(hits[0].gameObject,
+                new PointerEventData(events) { position = edge }, ExecuteEvents.pointerClickHandler);
+            yield return null;
+            Assert.That(GameObject.Find("regions-preview"), Is.Null, "one tap closes the preview");
         }
 
         [UnityTest]


### PR DESCRIPTION
Closes #99

Owner, device UAT on v0.7.0: *"Opening the regions overlay works, however closing it is spotty… sometimes tapping towards the center works, but not the edges. The overlay should close on any tap anywhere on the screen."*

**Cause.** The dismiss `Button` was on the scrim *under* the zones, and the cleanup loop only cleared `raycastTarget` on `Image`s. The zone captions are `Text`, and `UiKit.Label` left `raycastTarget = true`; a caption's default box is 600 units wide — wider than a 20% side zone — so ◀/"Left" and ▶/"Right" covered those zones end to end and ate the tap. In the middle zones the caption only covers a central band, hence "edges dead, centre fine". A raycast sweep of the pre-fix panel: **39/121 grid points (32%) never reached the scrim.**

**Fix.**
- `UiKit.Label` sets `raycastTarget = false` — text is decoration, every button blocks with its own `Image`, so no tap target is lost and the same bug can't reappear behind another label.
- The preview's dismiss surface is a transparent full-screen sheet added last (topmost in the raycast), with every other graphic in that canvas explicitly non-raycast. Nothing the zones draw can shadow it.

**Test.** `RegionsPreview_ClosesOnATapAnywhere` sweeps an 11×11 grid over the panel asserting every point resolves to the dismiss sheet, then clicks near the left edge and asserts the preview is destroyed. Verified failing on the pre-fix code.

EditMode 142/142 · PlayMode 26/26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeAv87tQK1G7qsTHK3dPc