### PR TITLE
fix: board pass — pads, endless lanes, HUD survival, move styles

### DIFF
--- a/ArtSource/design-components/Lane.dc.html
+++ b/ArtSource/design-components/Lane.dc.html
@@ -187,12 +187,15 @@ class Component extends DCLogic {
       trainKind: this.props.train === 'passenger' ? 'passenger' : 'freight',
       showTrain: !this.props.bare,
       pads: this.props.bare ? [] : (spread(Math.ceil(w / 210), 210, 30)),
-      bays: spread(Math.max(3, Math.round(w / 176)), 176, 40),
+      // bare strips are the surface only: a baked bay slot became a phantom
+      // landing pad every 8 cells, and baked lamps became phantom obstructions
+      // (owner device report, 2026-08-30)
+      bays: this.props.bare ? [] : spread(Math.max(3, Math.round(w / 176)), 176, 40),
       trees: this.props.bare ? [] : spread(Math.max(1, Math.round(w / 520)), 520, 110),
       benches: this.props.bare ? [] : spread(Math.max(1, Math.round(w / 520)), 520, 370),
       bushes: this.props.bare ? [] : spread(Math.max(1, Math.round(w / 520)), 520, 240),
-      planters: spread(Math.max(2, Math.round(w / 480)), 480, 420).map((p, i) => ({...p, plant: PLANTS[i % PLANTS.length]})),
-      lamps: spread(Math.max(2, Math.round(w / 480)), 480, 180)
+      planters: this.props.bare ? [] : spread(Math.max(2, Math.round(w / 480)), 480, 420).map((p, i) => ({...p, plant: PLANTS[i % PLANTS.length]})),
+      lamps: this.props.bare ? [] : spread(Math.max(2, Math.round(w / 480)), 480, 180)
     };
   }
 }

--- a/Assets/Art/Sprites/extracted/lane-concrete.png
+++ b/Assets/Art/Sprites/extracted/lane-concrete.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:05d2b62051f06b36f1bd71e4907e534fe0d65b2c7102c5a08170f5a4479d3259
-size 2393
+oid sha256:20efdde7475c8750bdbe0ef0a77eef84c5386b2a05c34272c0a80ee83a5fc8e9
+size 1333

--- a/Assets/Art/Sprites/extracted/lane-goal.png
+++ b/Assets/Art/Sprites/extracted/lane-goal.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:45418382aee92543bfed09eb29878acdf08d7057430d14ec990c3ba1e1d56c46
-size 3586
+oid sha256:341727e452ef582ae1eed44204934a6d16a58b246a057f6cf94fdbd82591ffc4
+size 2632

--- a/Assets/Scripts/Runtime/Sim/GameSim.cs
+++ b/Assets/Scripts/Runtime/Sim/GameSim.cs
@@ -99,6 +99,10 @@ namespace FrogAcross.Sim
 
         public int InstanceCount(int row, int train) => _instanceCounts[row][train];
 
+        /// <summary>Wrap period of a row, in cells. The view repeats traffic at
+        /// this pitch so lanes read as endless however wide the camera is.</summary>
+        public float LoopCells(int row) => _loop[row];
+
         /// <summary>
         /// Train-warning query (#50): true when any warn-lead object in the row
         /// is on the board now or will be within its warnLeadTicks. Pure tick

--- a/Assets/Scripts/Runtime/UI/GameHud.cs
+++ b/Assets/Scripts/Runtime/UI/GameHud.cs
@@ -19,10 +19,20 @@ namespace FrogAcross.UI
 
         private Text _moveLabel;
         private Text _timer;
+        private GameObject _canvasGo;
+
+        /// <summary>Corner buttons: bigger than a normal tap target, because
+        /// they are pressed mid-run with a thumb (owner, 2026-08-30).</summary>
+        public const float ButtonSize = 148f;
 
         public void Build(float goldSeconds)
         {
+            // Rebuilt per level: the gold target on the chip belongs to the
+            // level being played, and a rebuild is how the HUD comes back after
+            // a restart.
+            if (_canvasGo != null) Destroy(_canvasGo);
             var canvas = UiKit.Canvas(transform, "hud", 50);
+            _canvasGo = canvas.gameObject;
             var safeGo = new GameObject("safe-area");
             safeGo.transform.SetParent(canvas.transform, false);
             var safe = safeGo.AddComponent<RectTransform>();
@@ -30,24 +40,30 @@ namespace FrogAcross.UI
             safe.offsetMin = safe.offsetMax = Vector2.zero;
             safeGo.AddComponent<SafeArea>();
 
+            // The HUD kept the design's raw sizes through the type-scale pass,
+            // so it stayed phone-tiny while every other screen doubled (owner:
+            // "timer is too small", 2026-08-30).
             var movePill = UiKit.Panel(safe, "move-pill", new Color(0.02f, 0.078f, 0.157f, 0.72f), UiKit.PillRadius);
             movePill.rectTransform.anchorMin = movePill.rectTransform.anchorMax = new Vector2(0f, 1f);
-            movePill.rectTransform.sizeDelta = new Vector2(380, 66);
-            movePill.rectTransform.anchoredPosition = new Vector2(UiKit.EdgePad + 190, -80);
-            _moveLabel = UiKit.Label(movePill.transform, "SWIPE ▲ FORWARD", 24, UiKit.TextBlue, Vector2.zero, new Vector2(370, 38));
+            movePill.rectTransform.sizeDelta = new Vector2(560, 96);
+            movePill.rectTransform.anchoredPosition = new Vector2(UiKit.EdgePad + 280, -(UiKit.EdgePad + 48));
+            _moveLabel = UiKit.Label(movePill.transform, "SWIPE ▲ FORWARD", UiKit.Caption, UiKit.TextBlue,
+                Vector2.zero, new Vector2(540, 56));
 
             var timePill = UiKit.Panel(safe, "time-pill", new Color(0.02f, 0.078f, 0.157f, 0.72f), UiKit.PillRadius);
             timePill.rectTransform.anchorMin = timePill.rectTransform.anchorMax = new Vector2(1f, 1f);
-            timePill.rectTransform.sizeDelta = new Vector2(400, 66);
-            timePill.rectTransform.anchoredPosition = new Vector2(-(UiKit.EdgePad + 420), -80);
-            _timer = UiKit.Label(timePill.transform, "0.0", 34, UiKit.White, new Vector2(-90, 0), new Vector2(170, 42));
+            timePill.rectTransform.sizeDelta = new Vector2(600, 96);
+            timePill.rectTransform.anchoredPosition = new Vector2(-(UiKit.EdgePad + 300), -(UiKit.EdgePad + 48));
+            _timer = UiKit.Label(timePill.transform, "0.0", UiKit.Title, UiKit.White,
+                new Vector2(-130, 0), new Vector2(280, 78));
             var dot = UiKit.Panel(timePill.transform, "gold-dot", UiKit.Gold, UiKit.PillRadius);
-            dot.rectTransform.sizeDelta = new Vector2(18, 18);
-            dot.rectTransform.anchoredPosition = new Vector2(38, 0);
-            UiKit.Label(timePill.transform, $"{goldSeconds:0.0}s", 24, UiKit.TextBlue, new Vector2(120, 0), new Vector2(140, 32));
+            dot.rectTransform.sizeDelta = new Vector2(26, 26);
+            dot.rectTransform.anchoredPosition = new Vector2(58, 0);
+            UiKit.Label(timePill.transform, $"{goldSeconds:0.0}s", UiKit.Caption, UiKit.TextBlue,
+                new Vector2(180, 0), new Vector2(200, 44));
 
             // corner buttons (owner amendment): dialogs freeze the sim
-            var restart = UiKit.Button(safe, "↻", Vector2.zero, new Vector2(UiKit.TapTarget, UiKit.TapTarget), () =>
+            var restart = UiKit.Button(safe, "↻", Vector2.zero, new Vector2(ButtonSize, ButtonSize), () =>
             {
                 if (FreezeGate != null && !FreezeGate()) return;
                 SetFrozen?.Invoke(true);
@@ -55,20 +71,33 @@ namespace FrogAcross.UI
                     "Bays and the clock reset — this attempt is abandoned.",
                     "Restart", () => { SetFrozen?.Invoke(false); OnRestartConfirmed?.Invoke(); },
                     () => SetFrozen?.Invoke(false));
-            }, fontSize: 36);
-            restart.image.rectTransform.anchorMin = restart.image.rectTransform.anchorMax = new Vector2(1f, 1f);
-            restart.image.rectTransform.anchoredPosition = new Vector2(-(UiKit.EdgePad + 130), -80);
+            }, fontSize: UiKit.Title);
+            CornerChrome(restart);
+            // lower right, thumb-height (owner, 2026-08-30)
+            restart.image.rectTransform.anchorMin = restart.image.rectTransform.anchorMax = new Vector2(1f, 0f);
+            restart.image.rectTransform.anchoredPosition =
+                new Vector2(-(UiKit.EdgePad + ButtonSize * 1.5f + 24f), UiKit.EdgePad + ButtonSize / 2f);
 
-            var menu = UiKit.Button(safe, "≡", Vector2.zero, new Vector2(UiKit.TapTarget, UiKit.TapTarget), () =>
+            var menu = UiKit.Button(safe, "≡", Vector2.zero, new Vector2(ButtonSize, ButtonSize), () =>
             {
                 if (FreezeGate != null && !FreezeGate()) return;
                 SetFrozen?.Invoke(true);
                 ConfirmDialog.Show(transform, "Quit to menu?", Copy.Get("quitConfirm"),
                     "Quit", () => { SetFrozen?.Invoke(false); OnQuitConfirmed?.Invoke(); },
                     () => SetFrozen?.Invoke(false));
-            }, fontSize: 36);
-            menu.image.rectTransform.anchorMin = menu.image.rectTransform.anchorMax = new Vector2(1f, 1f);
-            menu.image.rectTransform.anchoredPosition = new Vector2(-(UiKit.EdgePad + 24), -80);
+            }, fontSize: UiKit.Title);
+            CornerChrome(menu);
+            menu.image.rectTransform.anchorMin = menu.image.rectTransform.anchorMax = new Vector2(1f, 0f);
+            menu.image.rectTransform.anchoredPosition =
+                new Vector2(-(UiKit.EdgePad + ButtonSize / 2f), UiKit.EdgePad + ButtonSize / 2f);
+        }
+
+        /// <summary>Same dark chip as the HUD pills: 10%-white over a bright
+        /// board read as a disabled control.</summary>
+        private static void CornerChrome(Button b)
+        {
+            b.image.color = new Color(0.02f, 0.078f, 0.157f, 0.82f);
+            foreach (var t in b.GetComponentsInChildren<Text>()) t.color = UiKit.Mint;
         }
 
         public void Tick(GameSim sim)

--- a/Assets/Scripts/Runtime/View/BoardView.cs
+++ b/Assets/Scripts/Runtime/View/BoardView.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using FrogAcross.Levels;
 using FrogAcross.Pieces;
 using FrogAcross.Sim;
+using FrogAcross.UI;
 using UnityEngine;
 
 namespace FrogAcross.View
@@ -19,26 +20,48 @@ namespace FrogAcross.View
         public GameSim Sim { get; private set; }
         public CharacterDef Character => _character;
 
-        private readonly List<SpriteRenderer[]> _objects = new();
+        // [row][flat instance][wrap copy] — copy 0 is the object's true
+        // position, the rest repeat it a whole loop away so a lane never ends
+        private readonly List<List<List<SpriteRenderer>>> _objects = new();
         private readonly List<int[]> _trainStart = new();
         private readonly List<SpriteRenderer> _bayFills = new();
+        private readonly List<SpriteRenderer> _bayMarks = new();
         private readonly List<SpriteRenderer> _strips = new();
+        private readonly List<GameObject> _spawned = new();
         private SpriteRenderer _player;
         private CharacterDef _character;
+
+        // Hop/step animation (view-only: the sim moves the player in one tick).
+        private long _hopStartTick = long.MinValue;
+        private Vector2 _hopFrom;
+        private Vector2 _lastDrawnCell;
 
         public void Bind(GameSim sim, CharacterDef character = null)
         {
             Sim = sim;
             _character = character != null ? character : PieceRegistry.Load().defaultCharacter;
             BuildStatic();
+            _lastDrawnCell = new Vector2(sim.State.PlayerX, -sim.State.PlayerRow);
+            _hopStartTick = long.MinValue;
+            sim.OnHop += _ =>
+            {
+                _hopFrom = _lastDrawnCell;      // where the frog was drawn last frame
+                _hopStartTick = sim.State.Tick; // the tick the sim teleported it
+            };
         }
 
         private void BuildStatic()
         {
-            foreach (Transform child in transform) Destroy(child.gameObject);
+            // Only our own sprites: this component shares its GameObject with
+            // the HUD and the completion overlay, and clearing every child
+            // deleted them on restart (owner: "buttons and timer disappear if
+            // restart level and don't show up again", 2026-08-30).
+            foreach (var go in _spawned) if (go != null) Destroy(go);
+            _spawned.Clear();
             _objects.Clear();
             _trainStart.Clear();
             _bayFills.Clear();
+            _bayMarks.Clear();
             _strips.Clear();
 
             var level = Sim.Level;
@@ -55,21 +78,46 @@ namespace FrogAcross.View
                 foreach (var ob in row.Obstructions)
                 {
                     var s = NewSprite($"ob-{ob.Def.id}", SpriteOf(ob.Def, 0), -0.05f);
-                    // props sit on the tile, overhanging upward like the design
-                    float h = s.sprite.bounds.size.y;
-                    s.transform.position = new Vector3(ob.Column, -r + (h - 1f) / 2f, 0.05f - r * 0.001f);
+                    // An obstruction blocks exactly one cell, so it is drawn
+                    // inside exactly one cell. The raw art is bigger than that
+                    // — a planter is 1.28x1.04 cells, a tree 1.24 tall — and
+                    // drawing it unscaled put it across the lane line and into
+                    // the neighbouring columns (owner: "obstructions sometimes
+                    // appear between lanes", 2026-08-30).
+                    var b = s.sprite.bounds.size;
+                    float fit = CellFit / Mathf.Max(0.01f, Mathf.Max(b.x, b.y));
+                    s.transform.localScale = Vector3.one * fit;
+                    // stand it on the tile rather than centring it in the air
+                    float bottom = -r - 0.5f + 0.03f + b.y * fit / 2f;
+                    s.transform.position = new Vector3(ob.Column, bottom, 0.05f - r * 0.001f);
                 }
 
                 if (row.Kind.semantics == LaneSemantics.Goal)
                 {
                     foreach (int b in level.BayColumns)
                     {
-                        var bay = NewSprite($"bay-{b}", null, -0.1f);
-                        bay.sprite = SpriteOf(row.Kind, 0);
-                        bay.drawMode = SpriteDrawMode.Tiled;
-                        bay.size = new Vector2(0.95f, 0.75f);
-                        bay.color = new Color(0.04f, 0.19f, 0.10f);
+                        // A landing pad reads as a slot to aim at: a dark grey
+                        // rounded pad carrying the Frog Across mark, not the
+                        // near-black tinted lane tile it used to be (owner,
+                        // 2026-08-30).
+                        var shadow = NewSprite($"bay-shadow-{b}", UiKit.Rounded(PadRadius), -0.12f);
+                        shadow.drawMode = SpriteDrawMode.Sliced;
+                        shadow.size = new Vector2(PadSize.x, PadSize.y);
+                        shadow.color = PadShadow;
+                        shadow.transform.position = new Vector3(b, -r - 0.045f, 0.12f);
+
+                        var bay = NewSprite($"bay-{b}", UiKit.Rounded(PadRadius), -0.1f);
+                        bay.drawMode = SpriteDrawMode.Sliced;
+                        bay.size = PadSize;
+                        bay.color = PadGrey;
                         bay.transform.position = new Vector3(b, -r, 0.1f);
+
+                        var mark = NewSprite($"bay-mark-{b}", UiKit.Logo, -0.08f);
+                        if (mark.sprite != null)
+                            mark.transform.localScale = Vector3.one
+                                * (0.46f / Mathf.Max(0.1f, mark.sprite.bounds.size.x));
+                        mark.transform.position = new Vector3(b, -r, 0.08f);
+                        _bayMarks.Add(mark);
 
                         var fill = NewSprite($"bay-fill-{b}", _character.sprites[0], -0.05f);
                         fill.transform.position = new Vector3(b, -r, 0.04f);
@@ -81,15 +129,18 @@ namespace FrogAcross.View
                     }
                 }
 
-                var rends = new List<SpriteRenderer>();
+                var rends = new List<List<SpriteRenderer>>();
                 var starts = new int[row.Trains.Count];
                 for (int t = 0; t < row.Trains.Count; t++)
                 {
                     starts[t] = rends.Count;
                     for (int k = 0; k < Sim.InstanceCount(r, t); k++)
-                        rends.Add(NewSprite($"obj-{row.Trains[t].Def.id}-{k}", null, -0.02f - r * 0.001f));
+                        rends.Add(new List<SpriteRenderer>
+                        {
+                            NewSprite($"obj-{row.Trains[t].Def.id}-{k}", null, -0.02f - r * 0.001f),
+                        });
                 }
-                _objects.Add(rends.ToArray());
+                _objects.Add(rends);
                 _trainStart.Add(starts);
             }
 
@@ -118,38 +169,55 @@ namespace FrogAcross.View
             var level = Sim.Level;
             long tick = Sim.State.Tick;
 
+            (float viewLeft, float viewRight) = VisibleXRange(level);
+
             for (int r = 0; r < level.Rows.Count; r++)
             {
                 var row = level.Rows[r];
+                float loop = Sim.LoopCells(r);
+                // enough repeats to cover the camera however wide it is
+                int copies = Mathf.Clamp(
+                    Mathf.CeilToInt((viewRight - viewLeft) / Mathf.Max(1f, loop)) + 1, 1, 9);
                 for (int t = 0; t < row.Trains.Count; t++)
                 {
                     var train = row.Trains[t];
                     var def = train.Def;
                     for (int k = 0; k < Sim.InstanceCount(r, t); k++)
                     {
-                        var sr = _objects[r][_trainStart[r][t] + k];
+                        var slot = _objects[r][_trainStart[r][t] + k];
                         float left = Sim.ObjectLeftX(r, t, k, tick);
-                        sr.transform.position = new Vector3(
-                            left + def.sizeCells * 0.5f, -r, sr.transform.position.z);
-
-                        // objects live across the whole wrap loop; drawing only
-                        // the on-board slice left the full-bleed lanes empty
-                        bool visible = left + def.sizeCells > -MarginCells(level)
-                            && left < level.Columns + MarginCells(level);
-                        if (sr.enabled != visible) sr.enabled = visible;
-                        if (!visible) continue;
-
                         bool crashed = Sim.State.CrashedAt.ContainsKey(SimState.CrashKey(r, t, k));
-                        sr.sprite = SelectSprite(def, train, row.DirSign, r, t, k, tick, crashed);
-                        var color = Color.white;
-                        if (def.cycleActiveTicks > 0 && !def.inactiveKills)
-                            color.a = SpriteSelector.TurtleAlpha(def, train, tick);
-                        sr.color = color;
+                        // a wreck is a one-off at a fixed spot: repeating it
+                        // would show phantom copies of a crash that happened once
+                        int want = crashed ? 1 : copies;
 
-                        // fit sprite to the def's cell size
-                        float sw = sr.sprite != null ? sr.sprite.bounds.size.x : 1f;
-                        float scale = sw > 0f ? def.sizeCells / sw : 1f;
-                        sr.transform.localScale = Vector3.one * scale;
+                        for (int c = 0; c < slot.Count || c < want; c++)
+                        {
+                            if (c >= want)
+                            {
+                                if (c < slot.Count && slot[c].enabled) slot[c].enabled = false;
+                                continue;
+                            }
+                            var sr = Copy(slot, r, def, k, c);
+                            float x = left + WrapOffset(c) * loop;
+                            sr.transform.position = new Vector3(
+                                x + def.sizeCells * 0.5f, -r, sr.transform.position.z);
+
+                            bool visible = x + def.sizeCells > viewLeft && x < viewRight;
+                            if (sr.enabled != visible) sr.enabled = visible;
+                            if (!visible) continue;
+
+                            sr.sprite = SelectSprite(def, train, row.DirSign, r, t, k, tick, crashed);
+                            var color = Color.white;
+                            if (def.cycleActiveTicks > 0 && !def.inactiveKills)
+                                color.a = SpriteSelector.TurtleAlpha(def, train, tick);
+                            sr.color = color;
+
+                            // fit sprite to the def's cell size
+                            float sw = sr.sprite != null ? sr.sprite.bounds.size.x : 1f;
+                            float scale = sw > 0f ? def.sizeCells / sw : 1f;
+                            sr.transform.localScale = Vector3.one * scale;
+                        }
                     }
                 }
             }
@@ -169,16 +237,32 @@ namespace FrogAcross.View
             int bi = 0;
             foreach (int b in level.BayColumns)
             {
-                _bayFills[bi].enabled = Sim.State.BaysFilled.Contains(b);
+                bool filled = Sim.State.BaysFilled.Contains(b);
+                _bayFills[bi].enabled = filled;
+                if (bi < _bayMarks.Count) _bayMarks[bi].enabled = !filled;
                 bi++;
             }
 
             // player
             var s = Sim.State;
             _player.sprite = _character.sprites[SpriteSelector.CharacterIndex(s.Facing)];
-            _player.transform.position = new Vector3(s.PlayerX, -s.PlayerRow, -0.5f);
+            var cell = new Vector2(s.PlayerX, -s.PlayerRow);
+            _lastDrawnCell = cell;
+
+            // The sim moves in a single tick; the view plays the character's
+            // own move style across the hop cooldown so a frog hops and a
+            // runner runs (owner: "character should use its designated move",
+            // 2026-08-30). Purely cosmetic — the sim is already at the target.
+            float lift = 0f, squash = 1f;
+            float phase = (tickF - _hopStartTick) / SimConfig.HopCooldownTicks;
+            if (_hopStartTick != long.MinValue && phase > 0f && phase < 1f && !s.Riding)
+            {
+                cell = Vector2.Lerp(_hopFrom, cell, Mathf.SmoothStep(0f, 1f, phase));
+                (lift, squash) = SpriteSelector.MoveArc(_character.moveStyle, phase);
+            }
+            _player.transform.position = new Vector3(cell.x, cell.y + lift, -0.5f);
             float ps = 0.9f / Mathf.Max(0.1f, _player.sprite.bounds.size.x);
-            _player.transform.localScale = Vector3.one * ps;
+            _player.transform.localScale = new Vector3(ps / squash, ps * squash, 1f);
             _player.enabled = s.RespawnDelay == 0;
             _player.color = s.StunTicksLeft > 0 && (tick / 6) % 2 == 0
                 ? new Color(1f, 1f, 1f, 0.5f)   // stun feedback: flicker
@@ -223,6 +307,44 @@ namespace FrogAcross.View
             }
         }
 
+        /// <summary>How much of a cell an obstruction may occupy.</summary>
+        public const float CellFit = 0.94f;
+
+        private const int PadRadius = 14;
+        private static readonly Vector2 PadSize = new Vector2(0.88f, 0.66f);
+        private static readonly Color PadGrey = new Color(0.302f, 0.329f, 0.365f);
+        private static readonly Color PadShadow = new Color(0.086f, 0.098f, 0.114f);
+
+        /// <summary>
+        /// World-X span the camera can actually see, including the board roll.
+        /// Objects are drawn across this, not across the board — the camera is
+        /// far wider than the board, so culling at the board margin let cars
+        /// appear and vanish in open view (owner: "cars spawn part way on the
+        /// screen. This should never happen, ever", 2026-08-30).
+        /// </summary>
+        private (float left, float right) VisibleXRange(LevelDefinition level)
+        {
+            var cam = Camera.main;
+            if (cam == null || !cam.orthographic)
+                return (-MarginCells(level), level.Columns + MarginCells(level));
+            float halfH = cam.orthographicSize;
+            float halfW = halfH * cam.aspect;
+            float roll = cam.transform.eulerAngles.z * Mathf.Deg2Rad;
+            float ext = Mathf.Abs(halfW * Mathf.Cos(roll)) + Mathf.Abs(halfH * Mathf.Sin(roll));
+            float cx = cam.transform.position.x;
+            return (cx - ext - 1f, cx + ext + 1f);
+        }
+
+        /// <summary>Wrap copy c sits this many loops from the real object: 0, -1, +1, -2, +2…</summary>
+        private static int WrapOffset(int c) => (c + 1) / 2 * (c % 2 == 1 ? -1 : 1);
+
+        private SpriteRenderer Copy(List<SpriteRenderer> slot, int row, LaneObjectDef def, int instance, int c)
+        {
+            while (slot.Count <= c)
+                slot.Add(NewSprite($"obj-{def.id}-{instance}-w{slot.Count}", null, -0.02f - row * 0.001f));
+            return slot[c];
+        }
+
         private Sprite SpriteOf(PieceDef def, int i) =>
             def.sprites != null && def.sprites.Length > i ? def.sprites[i] : null;
 
@@ -256,6 +378,7 @@ namespace FrogAcross.View
         {
             var go = new GameObject(name);
             go.transform.SetParent(transform, false);
+            _spawned.Add(go);
             var sr = go.AddComponent<SpriteRenderer>();
             sr.sprite = sprite;
             var pos = go.transform.position;

--- a/Assets/Scripts/Runtime/View/GameBootstrap.cs
+++ b/Assets/Scripts/Runtime/View/GameBootstrap.cs
@@ -61,7 +61,6 @@ namespace FrogAcross.View
             _hud.OnQuitConfirmed += QuitToMenu;
 
             StartLevel();
-            _hud.Build(Sim.Level.GoldSeconds);
         }
 
         public void StartLevel()
@@ -71,6 +70,8 @@ namespace FrogAcross.View
             Sim = new GameSim(LevelLoader.LoadFromResources(levelId, PieceRegistry.Load()));
             board.Bind(Sim, _character);
             FitCamera();
+            _hud.Build(Sim.Level.GoldSeconds); // per level: gold target, and it
+                                              // must survive a board rebuild
             FrogAcross.Audio.AudioDirector.Instance.Bind(Sim, Sim.Level);
             FrogAcross.Audio.AudioDirector.Instance.PlayMusic(FrogAcross.Audio.MusicSlot.Gameplay);
             Sim.OnDeath += cause => _deathFx.Play(cause,

--- a/Assets/Scripts/Runtime/View/SpriteSelector.cs
+++ b/Assets/Scripts/Runtime/View/SpriteSelector.cs
@@ -60,6 +60,28 @@ namespace FrogAcross.View
             return 0.25f; // submerged: sunken ghost under the water
         }
 
+        public const float HopHeight = 0.30f;  // apex of a hop, in cells
+        public const float StepBob = 0.10f;    // footfall bounce of a runner
+
+        /// <summary>
+        /// How a character carries itself between cells, as (lift above the
+        /// path, vertical stretch). The sim moves in one tick; this is the
+        /// view's cosmetic arc across the hop cooldown, and it is the piece's
+        /// own data (CharacterDef.moveStyle) that picks the shape — a frog
+        /// hops, a dog runs (owner, 2026-08-30).
+        /// </summary>
+        public static (float lift, float squash) MoveArc(MoveStyle style, float phase)
+        {
+            if (phase <= 0f || phase >= 1f) return (0f, 1f);
+            if (style == MoveStyle.Hop)
+            {
+                float a = Mathf.Sin(phase * Mathf.PI);      // one clean arc
+                return (a * HopHeight, 1f + a * 0.14f);     // stretched at the apex
+            }
+            float b = Mathf.Abs(Mathf.Sin(phase * Mathf.PI * 2f)); // two footfalls
+            return (b * StepBob, 1f - b * 0.06f);                  // and a squat
+        }
+
         /// <summary>Deterministic livery assignment per instance (no RNG).</summary>
         public static int LiveryFor(int row, int trainIdx, int instance, int liveryCount)
             => liveryCount <= 0 ? 0 : (row * 7 + trainIdx * 3 + instance) % liveryCount;

--- a/Assets/Tests/EditMode/View/SpriteSelectorTests.cs
+++ b/Assets/Tests/EditMode/View/SpriteSelectorTests.cs
@@ -10,6 +10,39 @@ namespace FrogAcross.Tests.EditMode.View
     public class SpriteSelectorTests
     {
         [Test]
+        public void MoveArc_IsTheCharactersOwnStyle()
+        {
+            // owner: "character should use its designated move when it moves.
+            // Hop or run" — CharacterDef.moveStyle was carried in the data and
+            // ignored by the view, so every creature slid flat between cells.
+            Assert.AreEqual(0f, SpriteSelector.MoveArc(MoveStyle.Hop, 0f).lift, 1e-4f, "starts on the ground");
+            Assert.AreEqual(0f, SpriteSelector.MoveArc(MoveStyle.Hop, 1f).lift, 1e-4f, "lands on the ground");
+
+            // a hop: one arc, peaking mid-move, stretched at the apex
+            var apex = SpriteSelector.MoveArc(MoveStyle.Hop, 0.5f);
+            Assert.AreEqual(SpriteSelector.HopHeight, apex.lift, 1e-3f);
+            Assert.Greater(apex.squash, 1f, "a hop stretches upward at the top");
+            for (float p = 0.05f; p < 1f; p += 0.05f)
+                Assert.LessOrEqual(SpriteSelector.MoveArc(MoveStyle.Hop, p).lift, apex.lift + 1e-4f,
+                    "a hop has a single apex");
+
+            // a run: feet stay near the ground, two footfalls per cell
+            int peaks = 0;
+            float highest = 0f;
+            for (float p = 0.02f; p < 1f; p += 0.02f)
+            {
+                float here = SpriteSelector.MoveArc(MoveStyle.Step, p).lift;
+                highest = Mathf.Max(highest, here);
+                if (here > SpriteSelector.MoveArc(MoveStyle.Step, p - 0.02f).lift
+                    && here >= SpriteSelector.MoveArc(MoveStyle.Step, p + 0.02f).lift) peaks++;
+            }
+            Assert.AreEqual(2, peaks, "a run bobs twice across the cell");
+            Assert.AreEqual(SpriteSelector.StepBob, highest, 1e-3f);
+            Assert.Less(highest, SpriteSelector.HopHeight / 2f, "a runner never hops");
+            Assert.Less(SpriteSelector.MoveArc(MoveStyle.Step, 0.25f).squash, 1f, "a runner squats, not stretches");
+        }
+
+        [Test]
         public void CharacterIndices_MapFacings()
         {
             Assert.AreEqual(0, SpriteSelector.CharacterIndex(Move.Forward));

--- a/Assets/Tests/PlayMode/BoardViewTests.cs
+++ b/Assets/Tests/PlayMode/BoardViewTests.cs
@@ -3,9 +3,11 @@ using System.Linq;
 using FrogAcross.Levels;
 using FrogAcross.Pieces;
 using FrogAcross.Sim;
+using FrogAcross.UI;
 using FrogAcross.View;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 
 namespace FrogAcross.Tests.PlayMode
@@ -19,6 +21,9 @@ namespace FrogAcross.Tests.PlayMode
         {
             if (_root != null) Object.Destroy(_root);
         }
+
+        [UnityTearDown]
+        public IEnumerator UnloadScenes() { yield return SceneCleanup.UnloadAll(); }
 
         private (GameSim sim, BoardView view) Spawn(string levelId = "dev-001")
         {
@@ -80,6 +85,143 @@ namespace FrogAcross.Tests.PlayMode
                 "tiled strip runs past the board on both sides");
             Assert.Greater(strip.size.x, simA.Level.Columns + 2f, "wider than the old board-plus-margin strip");
             yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator Obstructions_StayInsideTheirOwnCell()
+        {
+            // owner: "obstructions sometimes appear between lanes… level ten
+            // with the flower pots". The raw planter art is 1.28 x 1.04 cells
+            // and was drawn unscaled, so it crossed the lane line and both
+            // neighbouring columns.
+            var (sim, view) = Spawn("level-010");
+            yield return null;
+            int checkedProps = 0;
+            for (int r = 0; r < sim.Level.Rows.Count; r++)
+            foreach (var ob in sim.Level.Rows[r].Obstructions)
+            {
+                var t = view.transform.Find($"ob-{ob.Def.id}");
+                Assert.That(t, Is.Not.Null, $"row {r}: {ob.Def.id} not drawn");
+                var sr = t.GetComponent<UnityEngine.SpriteRenderer>();
+                var size = sr.sprite.bounds.size * t.localScale.x;
+                Assert.That(size.x, Is.LessThanOrEqualTo(1f), $"{ob.Def.id} is wider than its cell");
+                Assert.That(size.y, Is.LessThanOrEqualTo(1f), $"{ob.Def.id} is taller than its cell");
+                Assert.That(t.position.y + size.y / 2f, Is.LessThanOrEqualTo(-r + 0.5f + 1e-3f),
+                    $"{ob.Def.id} pokes into the lane above");
+                Assert.That(t.position.y - size.y / 2f, Is.GreaterThanOrEqualTo(-r - 0.5f - 1e-3f),
+                    $"{ob.Def.id} pokes into the lane below");
+                checkedProps++;
+            }
+            Assert.That(checkedProps, Is.GreaterThan(0), "level-010 has obstructions to check");
+        }
+
+        [UnityTest]
+        public IEnumerator LandingPads_AreGreyPadsCarryingTheMark()
+        {
+            // owner: "landing pads are black, they should be dark grey with the
+            // frogger logo on them"
+            var (sim, view) = Spawn();
+            yield return null;
+            foreach (int b in sim.Level.BayColumns)
+            {
+                var pad = view.transform.Find($"bay-{b}").GetComponent<UnityEngine.SpriteRenderer>();
+                Assert.That(pad.drawMode, Is.EqualTo(UnityEngine.SpriteDrawMode.Sliced), "rounded pad");
+                float grey = (pad.color.r + pad.color.g + pad.color.b) / 3f;
+                Assert.That(grey, Is.GreaterThan(0.15f), $"bay-{b} is still nearly black");
+                Assert.That(Mathf.Max(pad.color.r, pad.color.g, pad.color.b)
+                    - Mathf.Min(pad.color.r, pad.color.g, pad.color.b), Is.LessThan(0.12f),
+                    $"bay-{b} should read as grey, not tinted");
+
+                var mark = view.transform.Find($"bay-mark-{b}");
+                Assert.That(mark, Is.Not.Null, $"bay-{b} carries the Frog Across mark");
+                Assert.That(mark.GetComponent<UnityEngine.SpriteRenderer>().sprite, Is.Not.Null);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator TrafficNeverAppearsOrVanishesInView()
+        {
+            // owner: "cars/trucks/other objects spawn part way on the screen.
+            // This should never happen, ever… same for disappearing." The
+            // camera is far wider than the board, so culling objects at the
+            // board margin popped them in and out in plain sight.
+            AppShell.PendingLevelId = "level-090"; // tall board: the more rows,
+            // the wider the fitted camera, and the further past the board margin
+            // it sees (a 5-row level hid the bug behind its own zoom)
+            SceneManager.LoadScene("Game");
+            yield return null;
+            yield return null;
+            var boot = Object.FindAnyObjectByType<GameBootstrap>();
+            var cam = Camera.main;
+            cam.aspect = 3120f / 1440f; // the owner's panel: the widest we ship to
+            boot.SendMessage("FitCamera");
+            var view = Object.FindAnyObjectByType<BoardView>();
+
+            // the rolled frame, in world X
+            float halfH = cam.orthographicSize, halfW = halfH * cam.aspect;
+            float roll = Mathf.Abs(GameBootstrap.BoardRollDegrees) * Mathf.Deg2Rad;
+            float ext = halfW * Mathf.Cos(roll) + halfH * Mathf.Sin(roll);
+            float camX = cam.transform.position.x;
+            float left = camX - ext, right = camX + ext;
+
+            // Each ROW wraps at its own margin (a car lane's is 3 cells, a
+            // freight lane's is 10), while the camera reaches ~20 — so a car
+            // hit its wrap point in open view and jumped to the far side.
+            Assert.That(right, Is.GreaterThan(boot.Sim.Level.Columns + 3f),
+                "this level must be one where the camera sees past a car lane's wrap");
+
+            // Continuity: whatever is drawn fully on screen must still be drawn
+            // within one frame of travel of where it was. Wrapping is allowed
+            // to move any single sprite — what may not happen is the traffic
+            // itself appearing or vanishing mid-screen.
+            const float maxStep = 0.35f; // 3 ticks of the fastest lane, plus slack
+            var previous = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<float>>();
+            int continuityChecks = 0;
+            for (int frame = 0; frame < 150; frame++)
+            {
+                for (int i = 0; i < 3; i++) boot.Sim.Tick();
+                view.Render(boot.Sim.State.Tick);
+
+                var current = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<float>>();
+                var onScreen = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<float>>();
+                foreach (Transform child in view.transform)
+                {
+                    if (!child.name.StartsWith("obj-")) continue;
+                    var sr = child.GetComponent<UnityEngine.SpriteRenderer>();
+                    if (!sr.enabled) continue;
+                    // copies of one object share a key: "obj-car-2-w1" -> "obj-car-2"
+                    int w = child.name.LastIndexOf("-w", System.StringComparison.Ordinal);
+                    string key = w > 0 ? child.name.Substring(0, w) : child.name;
+                    float half = sr.sprite != null
+                        ? sr.sprite.bounds.size.x * child.localScale.x / 2f : 0.5f;
+                    if (!current.TryGetValue(key, out var list))
+                        current[key] = list = new System.Collections.Generic.List<float>();
+                    list.Add(child.position.x);
+                    if (child.position.x - half > left + 0.5f && child.position.x + half < right - 0.5f)
+                    {
+                        if (!onScreen.TryGetValue(key, out var vis))
+                            onScreen[key] = vis = new System.Collections.Generic.List<float>();
+                        vis.Add(child.position.x);
+                    }
+                }
+
+                foreach (var kv in previous)
+                {
+                    if (!current.TryGetValue(kv.Key, out var now)) now = new System.Collections.Generic.List<float>();
+                    foreach (float was in kv.Value)
+                    {
+                        float best = float.MaxValue;
+                        foreach (float x in now) best = Mathf.Min(best, Mathf.Abs(x - was));
+                        Assert.That(best, Is.LessThan(maxStep),
+                            $"frame {frame}: {kv.Key} was drawn at x={was:0.00} on screen and " +
+                            $"nothing of it is within {maxStep} of there now — it popped out of view");
+                        continuityChecks++;
+                    }
+                }
+                previous = onScreen;
+                yield return null;
+            }
+            Assert.That(continuityChecks, Is.GreaterThan(500), "sanity: traffic was actually rendered");
         }
 
         [UnityTest]

--- a/Assets/Tests/PlayMode/GameSceneTests.cs
+++ b/Assets/Tests/PlayMode/GameSceneTests.cs
@@ -52,6 +52,80 @@ namespace FrogAcross.Tests.PlayMode
         }
 
         [UnityTest]
+        public IEnumerator TheCharacterAnimatesBetweenCells()
+        {
+            // The sim moves in a single tick; the view has to carry the frog
+            // across the gap, or a move reads as a teleport (owner: "character
+            // should use its designated move when it moves"). Shape per style
+            // is covered by SpriteSelectorTests.MoveArc_IsTheCharactersOwnStyle.
+            CharacterSelection.SelectedId = "frog";
+            yield return LoadGame("dev-road");
+            var boot = Object.FindAnyObjectByType<GameBootstrap>();
+            var board = Object.FindAnyObjectByType<BoardView>();
+            var player = board.transform.Find("player");
+            float row = player.position.y;      // the bank row's line
+            float startX = player.position.x;
+
+            // Drive the frames ourselves: batchmode runs the game loop in
+            // coarse steps that can swallow a 150ms move whole.
+            boot.Frozen = true;
+            boot.Sim.EnqueueMove(Move.Right);   // sideways along the bank: always safe
+            boot.Sim.Tick();                    // the move executes on this tick
+            long hopTick = boot.Sim.State.Tick;
+
+            bool betweenCells = false, leftTheGround = false;
+            for (int i = 0; i <= SimConfig.HopCooldownTicks * 2; i++)
+            {
+                board.Render(hopTick + i * 0.5f);
+                float dx = player.position.x - startX;
+                if (dx > 0.15f && dx < 0.85f) betweenCells = true;
+                if (player.position.y > row + 0.05f) leftTheGround = true;
+            }
+
+            Assert.That(betweenCells, Is.True, "the character was never drawn between the two cells");
+            Assert.That(leftTheGround, Is.True, "the character never left the row line — no move style played");
+            board.Render(hopTick + SimConfig.HopCooldownTicks);
+            Assert.That(player.position.x - startX, Is.EqualTo(1f).Within(0.01f), "and it lands on the next cell");
+            Assert.That(player.position.y, Is.EqualTo(row).Within(0.01f), "back on the ground when it lands");
+        }
+
+        [UnityTest]
+        public IEnumerator Hud_SurvivesRestartingAndAdvancingLevels()
+        {
+            // owner: "buttons and timer disappear if restart level and don't
+            // show up again. Sometimes also happens when progressing levels" —
+            // BoardView cleared every child of its GameObject on rebuild, and
+            // the HUD canvas is one of them.
+            yield return LoadGame("dev-road");
+            var boot = Object.FindAnyObjectByType<GameBootstrap>();
+
+            for (int round = 0; round < 3; round++)
+            {
+                boot.StartLevel();      // what Replay does
+                yield return null;
+                yield return null;
+
+                var hud = GameObject.Find("hud");
+                Assert.That(hud, Is.Not.Null, $"round {round}: the HUD canvas is gone");
+                int buttons = hud.GetComponentsInChildren<UnityEngine.UI.Button>(true).Length;
+                Assert.That(buttons, Is.EqualTo(2), $"round {round}: restart and menu buttons");
+                Assert.That(hud.GetComponentsInChildren<UnityEngine.UI.Text>(true).Length,
+                    Is.GreaterThan(2), $"round {round}: timer and labels");
+                Assert.That(Object.FindObjectsByType<GameHud>(FindObjectsInactive.Include).Length,
+                    Is.EqualTo(1), "exactly one HUD, never a stack of them");
+            }
+
+            // and the timer still ticks against the rebuilt HUD
+            boot.Sim.EnqueueMove(Move.Forward);
+            yield return Wait0_4;
+            var timer = GameObject.Find("hud").GetComponentsInChildren<UnityEngine.UI.Text>(true);
+            bool running = false;
+            foreach (var t in timer)
+                if (float.TryParse(t.text, out float v) && v > 0f) running = true;
+            Assert.That(running, Is.True, "the rebuilt timer is live");
+        }
+
+        [UnityTest]
         public IEnumerator SelectedCharacter_IsTheOneOnTheBoard()
         {
             CharacterSelection.SelectedId = "cat";

--- a/Assets/Tests/PlayMode/UiCaptureTests.cs
+++ b/Assets/Tests/PlayMode/UiCaptureTests.cs
@@ -110,6 +110,7 @@ namespace FrogAcross.Tests.PlayMode
         {
             yield return CaptureBoard("level-001", "board");
             yield return CaptureBoard("level-090", "board-tall");
+            yield return CaptureBoard("level-010", "board-props"); // obstructions
         }
 
         private static IEnumerator CaptureBoard(string levelId, string name)
@@ -142,6 +143,19 @@ namespace FrogAcross.Tests.PlayMode
                 Assert.That(Mathf.Abs(local.x), Is.LessThanOrEqualTo(halfW + 0.001f),
                     $"{levelId}: corner {corner} falls outside the rolled frame horizontally");
             }
+            // composite the HUD over the board: overlay canvases don't render
+            // into a RenderTexture, so borrow the board camera for the shot
+            var hud = GameObject.Find("hud");
+            Canvas hudCanvas = hud != null ? hud.GetComponent<Canvas>() : null;
+            if (hudCanvas != null)
+            {
+                hudCanvas.renderMode = RenderMode.ScreenSpaceCamera;
+                hudCanvas.worldCamera = cam;
+                hudCanvas.planeDistance = 1f;
+                Canvas.ForceUpdateCanvases();
+                yield return null;
+            }
+
             cam.Render();
             RenderTexture.active = rt;
             var tex = new Texture2D(3120, 1440, TextureFormat.RGB24, false);


### PR DESCRIPTION
Closes #101

The owner's first pass over the game board. Nine reports, five causes.

| # | Report | Cause |
|---|---|---|
| 1, 2 | Pads black; other "obstructions" on the pad bank | `lane-goal.png` had two **bay slots baked into the tiled strip** — a phantom black pad every 8 cells |
| 9 | Props between lanes | Planter art is **1.28 × 1.04 cells**, drawn unscaled with an upward overhang; plus a lamp baked into `lane-concrete.png` |
| 4 | Timer/buttons gone after restart | `BoardView.BuildStatic` destroyed **every child of its GameObject** — the HUD canvas is one |
| 5, 6 | Traffic appears/vanishes mid-screen | Objects culled at the **board margin** (3 cells for a car lane) while the camera reaches **~20** |
| 8 | Wrong move style | `CharacterDef.moveStyle` was in the data and **never read** |
| 3, 7 | HUD too small | The HUD kept the design's raw sizes through the type-scale pass |

### Fixes
- **Lane art.** `Lane.dc.html` gated vehicles/logs/trees/benches on `bare` but not `bays`, `planters` or `lamps`. Gated, re-extracted: exactly `lane-goal.png` and `lane-concrete.png` change, the other 279 sprites come back byte-identical. Same class as #86.
- **Pads.** A dark grey rounded pad per bay carrying the Frog Across mark; the mark hides as the bay fills.
- **Obstructions** are contained to the one cell they block and stood on the tile.
- **HUD.** BoardView destroys only its own sprites; the HUD is rebuilt per level (its gold chip was stuck on level one's target). Timer on the type scale, corner buttons 148px in the lower right on a solid chip.
- **Traffic.** The view repeats each object a whole loop either side, enough copies to cover the camera. The sim is untouched — rows tile their loop exactly, so the repeat is seamless and determinism is unaffected.
- **Move styles.** `SpriteSelector.MoveArc(style, phase)` — one apex with a stretch for a hop, two footfalls with a squat for a run — played across the hop cooldown.

### Guards
Traffic continuity over 150 frames on a tall board (**fails with a 9.47-cell jump** without the repeats); obstructions inside their cell on level-010; pads grey and marked; the HUD surviving three rebuilds with a live timer; `MoveArc`'s shape per style; the character leaving the row line mid-move. Board captures now composite the HUD and include a level with props.

EditMode **143/143** · PlayMode **31/31**.

### One thing left with you
No shipped level has an obstruction on its goal row — the black slots on the pad bank were the baked art. If you also want the row *below* the pads clear (11 of the 100 levels put props there), that's level data: a regeneration plus a medal recalibration pass. Say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeAv87tQK1G7qsTHK3dPc