### PR TITLE
fix: size boards to the screen so the whole board is playable

### DIFF
--- a/Assets/GameData/GeneratorParams/curve.asset
+++ b/Assets/GameData/GeneratorParams/curve.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
     - road
     middleRowsStartEnd: {x: 3, y: 3}
     bayCountStartEnd: {x: 1, y: 1}
-    columnsRange: {x: 9, y: 10}
+    columnsRange: {x: 14, y: 15}
     deadlySpeedStart: {x: 1, y: 1.2}
     deadlySpeedEnd: {x: 1, y: 1.2}
     waterSpeedStart: {x: 0.9, y: 1.2}
@@ -39,7 +39,9 @@ MonoBehaviour:
     spacingSlackEnd: {x: 3.5, y: 4.5}
     obstructionChanceStart: 0
     obstructionChanceEnd: 0
-    maxSolverMoves: 7
+    maxSolverMoves: 11
+    bayWindow: 3
+    maxSolverSeconds: 8
   - label: teaching-road
     startLevel: 2
     endLevel: 10
@@ -51,7 +53,7 @@ MonoBehaviour:
     - road
     middleRowsStartEnd: {x: 5, y: 6}
     bayCountStartEnd: {x: 2, y: 3}
-    columnsRange: {x: 9, y: 11}
+    columnsRange: {x: 20, y: 23}
     deadlySpeedStart: {x: 1, y: 1.3}
     deadlySpeedEnd: {x: 1.4, y: 1.8}
     waterSpeedStart: {x: 0.9, y: 1.2}
@@ -65,6 +67,8 @@ MonoBehaviour:
     obstructionChanceStart: 0
     obstructionChanceEnd: 0.08
     maxSolverMoves: 0
+    bayWindow: 0
+    maxSolverSeconds: 14
   - label: river
     startLevel: 11
     endLevel: 20
@@ -77,7 +81,7 @@ MonoBehaviour:
     - river
     middleRowsStartEnd: {x: 5, y: 7}
     bayCountStartEnd: {x: 2, y: 3}
-    columnsRange: {x: 9, y: 11}
+    columnsRange: {x: 20, y: 26}
     deadlySpeedStart: {x: 1.3, y: 1.8}
     deadlySpeedEnd: {x: 1.5, y: 2.1}
     waterSpeedStart: {x: 0.9, y: 1.2}
@@ -91,6 +95,8 @@ MonoBehaviour:
     obstructionChanceStart: 0.06
     obstructionChanceEnd: 0.1
     maxSolverMoves: 0
+    bayWindow: 0
+    maxSolverSeconds: 20
   - label: swamp
     startLevel: 21
     endLevel: 30
@@ -104,7 +110,7 @@ MonoBehaviour:
     - swamp
     middleRowsStartEnd: {x: 6, y: 7}
     bayCountStartEnd: {x: 2, y: 3}
-    columnsRange: {x: 9, y: 12}
+    columnsRange: {x: 23, y: 26}
     deadlySpeedStart: {x: 1.4, y: 1.9}
     deadlySpeedEnd: {x: 1.6, y: 2.2}
     waterSpeedStart: {x: 1, y: 1.4}
@@ -118,6 +124,8 @@ MonoBehaviour:
     obstructionChanceStart: 0.08
     obstructionChanceEnd: 0.12
     maxSolverMoves: 0
+    bayWindow: 0
+    maxSolverSeconds: 22
   - label: tracks
     startLevel: 31
     endLevel: 40
@@ -132,7 +140,7 @@ MonoBehaviour:
     - tracks
     middleRowsStartEnd: {x: 6, y: 8}
     bayCountStartEnd: {x: 2, y: 4}
-    columnsRange: {x: 10, y: 12}
+    columnsRange: {x: 23, y: 29}
     deadlySpeedStart: {x: 1.5, y: 2}
     deadlySpeedEnd: {x: 1.7, y: 2.4}
     waterSpeedStart: {x: 1, y: 1.5}
@@ -146,6 +154,8 @@ MonoBehaviour:
     obstructionChanceStart: 0.1
     obstructionChanceEnd: 0.14
     maxSolverMoves: 0
+    bayWindow: 0
+    maxSolverSeconds: 24
   - label: bike
     startLevel: 41
     endLevel: 50
@@ -162,7 +172,7 @@ MonoBehaviour:
     - bike
     middleRowsStartEnd: {x: 7, y: 8}
     bayCountStartEnd: {x: 3, y: 4}
-    columnsRange: {x: 10, y: 12}
+    columnsRange: {x: 26, y: 29}
     deadlySpeedStart: {x: 1.6, y: 2.2}
     deadlySpeedEnd: {x: 1.8, y: 2.5}
     waterSpeedStart: {x: 1.1, y: 1.6}
@@ -176,6 +186,8 @@ MonoBehaviour:
     obstructionChanceStart: 0.12
     obstructionChanceEnd: 0.16
     maxSolverMoves: 0
+    bayWindow: 0
+    maxSolverSeconds: 26
   - label: walkway
     startLevel: 51
     endLevel: 60
@@ -193,7 +205,7 @@ MonoBehaviour:
     - walkway
     middleRowsStartEnd: {x: 7, y: 9}
     bayCountStartEnd: {x: 3, y: 4}
-    columnsRange: {x: 10, y: 13}
+    columnsRange: {x: 26, y: 32}
     deadlySpeedStart: {x: 1.7, y: 2.3}
     deadlySpeedEnd: {x: 1.9, y: 2.6}
     waterSpeedStart: {x: 1.1, y: 1.7}
@@ -207,6 +219,8 @@ MonoBehaviour:
     obstructionChanceStart: 0.14
     obstructionChanceEnd: 0.18
     maxSolverMoves: 0
+    bayWindow: 0
+    maxSolverSeconds: 28
   - label: combination-1
     startLevel: 61
     endLevel: 80
@@ -222,7 +236,7 @@ MonoBehaviour:
     requiredKinds: []
     middleRowsStartEnd: {x: 8, y: 9}
     bayCountStartEnd: {x: 3, y: 5}
-    columnsRange: {x: 11, y: 13}
+    columnsRange: {x: 29, y: 32}
     deadlySpeedStart: {x: 1.9, y: 2.6}
     deadlySpeedEnd: {x: 2.1, y: 2.9}
     waterSpeedStart: {x: 1.2, y: 1.8}
@@ -236,6 +250,8 @@ MonoBehaviour:
     obstructionChanceStart: 0.16
     obstructionChanceEnd: 0.2
     maxSolverMoves: 0
+    bayWindow: 0
+    maxSolverSeconds: 30
   - label: combination-2
     startLevel: 81
     endLevel: 100
@@ -249,8 +265,8 @@ MonoBehaviour:
     - concrete
     requiredKinds: []
     middleRowsStartEnd: {x: 9, y: 10}
-    bayCountStartEnd: {x: 4, y: 5}
-    columnsRange: {x: 11, y: 13}
+    bayCountStartEnd: {x: 5, y: 5}
+    columnsRange: {x: 32, y: 35}
     deadlySpeedStart: {x: 2.1, y: 2.8}
     deadlySpeedEnd: {x: 2.3, y: 3.2}
     waterSpeedStart: {x: 1.3, y: 1.9}
@@ -264,3 +280,5 @@ MonoBehaviour:
     obstructionChanceStart: 0.18
     obstructionChanceEnd: 0.24
     maxSolverMoves: 0
+    bayWindow: 0
+    maxSolverSeconds: 36

--- a/Assets/Resources/Levels/level-001.json
+++ b/Assets/Resources/Levels/level-001.json
@@ -1,15 +1,15 @@
 {
     "id": "level-001",
     "name": "level-001",
-    "columns": 9,
+    "columns": 14,
     "medal": {
         "gold": 4.099999904632568,
         "silver": 5.900000095367432,
         "bronze": 8.600000381469727
     },
-    "startColumn": 3,
+    "startColumn": 9,
     "bays": [
-        1
+        7
     ],
     "rows": [
         {
@@ -20,23 +20,17 @@
             "obstructions": []
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.0,
-            "objects": [
-                {
-                    "pieceId": "bus",
-                    "offset": 8.800000190734864,
-                    "spacing": 17.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "convertible",
-                    "offset": 0.30000001192092898,
-                    "spacing": 17.0,
-                    "phase": 0
-                }
-            ],
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
             "obstructions": []
         },
         {
@@ -46,22 +40,14 @@
             "objects": [
                 {
                     "pieceId": "bus",
-                    "offset": 14.579999923706055,
-                    "spacing": 8.5,
+                    "offset": 17.06999969482422,
+                    "spacing": 22.0,
                     "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "left",
-            "speed": 1.059999942779541,
-            "objects": [
+                },
                 {
                     "pieceId": "car",
-                    "offset": 12.100000381469727,
-                    "spacing": 7.5,
+                    "offset": 6.070000171661377,
+                    "spacing": 22.0,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-002.json
+++ b/Assets/Resources/Levels/level-002.json
@@ -1,13 +1,13 @@
 {
     "id": "level-002",
     "name": "level-002",
-    "columns": 11,
+    "columns": 22,
     "medal": {
-        "gold": 13.800000190734864,
-        "silver": 20.0,
-        "bronze": 28.899999618530275
+        "gold": 18.600000381469728,
+        "silver": 26.899999618530275,
+        "bronze": 39.0
     },
-    "startColumn": 2,
+    "startColumn": 12,
     "bays": [
         5,
         6
@@ -36,19 +36,19 @@
         },
         {
             "kind": "road",
-            "dir": "right",
-            "speed": 1.0099999904632569,
+            "dir": "left",
+            "speed": 1.2000000476837159,
             "objects": [
                 {
-                    "pieceId": "car",
-                    "offset": 8.210000038146973,
-                    "spacing": 17.0,
+                    "pieceId": "truck",
+                    "offset": 15.949999809265137,
+                    "spacing": 32.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "car",
-                    "offset": 16.709999084472658,
-                    "spacing": 17.0,
+                    "pieceId": "convertible",
+                    "offset": 31.950000762939454,
+                    "spacing": 32.0,
                     "phase": 0
                 }
             ],
@@ -62,10 +62,23 @@
             "obstructions": []
         },
         {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
+            "kind": "road",
+            "dir": "right",
+            "speed": 1.0499999523162842,
+            "objects": [
+                {
+                    "pieceId": "convertible",
+                    "offset": 12.109999656677246,
+                    "spacing": 32.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "truck",
+                    "offset": 28.110000610351564,
+                    "spacing": 32.0,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-003.json
+++ b/Assets/Resources/Levels/level-003.json
@@ -1,16 +1,16 @@
 {
     "id": "level-003",
     "name": "level-003",
-    "columns": 9,
+    "columns": 22,
     "medal": {
-        "gold": 17.0,
-        "silver": 24.600000381469728,
-        "bronze": 35.599998474121097
+        "gold": 14.600000381469727,
+        "silver": 21.100000381469728,
+        "bronze": 30.600000381469728
     },
-    "startColumn": 1,
+    "startColumn": 3,
     "bays": [
         6,
-        7
+        8
     ],
     "rows": [
         {
@@ -21,31 +21,23 @@
             "obstructions": []
         },
         {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": []
-        },
-        {
             "kind": "road",
-            "dir": "right",
-            "speed": 1.2899999618530274,
+            "dir": "left",
+            "speed": 1.2200000286102296,
             "objects": [
                 {
-                    "pieceId": "convertible",
-                    "offset": 3.5999999046325685,
-                    "spacing": 7.5,
+                    "pieceId": "truck",
+                    "offset": 20.84000015258789,
+                    "spacing": 32.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 4.840000152587891,
+                    "spacing": 32.0,
                     "phase": 0
                 }
             ],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
             "obstructions": []
         },
         {
@@ -58,15 +50,42 @@
         {
             "kind": "road",
             "dir": "left",
-            "speed": 1.149999976158142,
+            "speed": 1.2100000381469727,
             "objects": [
                 {
+                    "pieceId": "bus",
+                    "offset": 25.209999084472658,
+                    "spacing": 30.0,
+                    "phase": 0
+                },
+                {
                     "pieceId": "convertible",
-                    "offset": 13.710000038146973,
-                    "spacing": 7.5,
+                    "offset": 10.210000038146973,
+                    "spacing": 30.0,
                     "phase": 0
                 }
             ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 1.2699999809265137,
+            "objects": [
+                {
+                    "pieceId": "truck",
+                    "offset": 25.600000381469728,
+                    "spacing": 10.670000076293946,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-004.json
+++ b/Assets/Resources/Levels/level-004.json
@@ -1,16 +1,16 @@
 {
     "id": "level-004",
     "name": "level-004",
-    "columns": 10,
+    "columns": 22,
     "medal": {
-        "gold": 14.600000381469727,
-        "silver": 21.100000381469728,
-        "bronze": 30.600000381469728
+        "gold": 19.399999618530275,
+        "silver": 28.100000381469728,
+        "bronze": 40.70000076293945
     },
-    "startColumn": 2,
+    "startColumn": 11,
     "bays": [
-        1,
-        9
+        6,
+        20
     ],
     "rows": [
         {
@@ -27,24 +27,17 @@
             "objects": [
                 {
                     "pieceId": "car",
-                    "offset": 0.5400000214576721,
-                    "spacing": 16.0,
+                    "offset": 0.9399999976158142,
+                    "spacing": 14.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "convertible",
-                    "offset": 8.539999961853028,
-                    "spacing": 16.0,
+                    "offset": 7.940000057220459,
+                    "spacing": 14.0,
                     "phase": 0
                 }
             ],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
             "obstructions": []
         },
         {
@@ -56,19 +49,13 @@
         },
         {
             "kind": "road",
-            "dir": "right",
-            "speed": 1.1799999475479127,
+            "dir": "left",
+            "speed": 1.3600000143051148,
             "objects": [
                 {
-                    "pieceId": "bus",
-                    "offset": 3.700000047683716,
-                    "spacing": 20.0,
-                    "phase": 0
-                },
-                {
                     "pieceId": "truck",
-                    "offset": 13.699999809265137,
-                    "spacing": 20.0,
+                    "offset": 5.929999828338623,
+                    "spacing": 10.670000076293946,
                     "phase": 0
                 }
             ],
@@ -79,6 +66,20 @@
             "dir": "",
             "speed": 0.0,
             "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 1.340000033378601,
+            "objects": [
+                {
+                    "pieceId": "bus",
+                    "offset": 27.709999084472658,
+                    "spacing": 10.0,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-005.json
+++ b/Assets/Resources/Levels/level-005.json
@@ -1,16 +1,16 @@
 {
     "id": "level-005",
     "name": "level-005",
-    "columns": 11,
+    "columns": 23,
     "medal": {
-        "gold": 12.199999809265137,
-        "silver": 17.600000381469728,
-        "bronze": 25.5
+        "gold": 26.600000381469728,
+        "silver": 38.5,
+        "bronze": 55.79999923706055
     },
-    "startColumn": 1,
+    "startColumn": 9,
     "bays": [
-        3,
-        4
+        19,
+        22
     ],
     "rows": [
         {
@@ -27,14 +27,14 @@
             "objects": [
                 {
                     "pieceId": "car",
-                    "offset": 13.34000015258789,
-                    "spacing": 17.0,
+                    "offset": 22.760000228881837,
+                    "spacing": 14.5,
                     "phase": 0
                 },
                 {
                     "pieceId": "car",
-                    "offset": 4.840000152587891,
-                    "spacing": 17.0,
+                    "offset": 1.0099999904632569,
+                    "spacing": 14.5,
                     "phase": 0
                 }
             ],
@@ -47,8 +47,8 @@
             "objects": [
                 {
                     "pieceId": "convertible",
-                    "offset": 7.699999809265137,
-                    "spacing": 8.5,
+                    "offset": 13.140000343322754,
+                    "spacing": 7.25,
                     "phase": 0
                 }
             ],
@@ -69,10 +69,23 @@
             "obstructions": []
         },
         {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
+            "kind": "road",
+            "dir": "left",
+            "speed": 1.2999999523162842,
+            "objects": [
+                {
+                    "pieceId": "convertible",
+                    "offset": 3.6700000762939455,
+                    "spacing": 14.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "convertible",
+                    "offset": 10.920000076293946,
+                    "spacing": 14.5,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-006.json
+++ b/Assets/Resources/Levels/level-006.json
@@ -1,16 +1,16 @@
 {
     "id": "level-006",
     "name": "level-006",
-    "columns": 10,
+    "columns": 21,
     "medal": {
-        "gold": 12.199999809265137,
-        "silver": 17.600000381469728,
-        "bronze": 25.5
+        "gold": 21.799999237060548,
+        "silver": 31.600000381469728,
+        "bronze": 45.70000076293945
     },
-    "startColumn": 2,
+    "startColumn": 4,
     "bays": [
-        0,
-        3
+        1,
+        16
     ],
     "rows": [
         {
@@ -27,8 +27,8 @@
             "objects": [
                 {
                     "pieceId": "convertible",
-                    "offset": 13.779999732971192,
-                    "spacing": 8.0,
+                    "offset": 23.25,
+                    "spacing": 9.0,
                     "phase": 0
                 }
             ],
@@ -41,24 +41,17 @@
             "objects": [
                 {
                     "pieceId": "car",
-                    "offset": 12.989999771118164,
-                    "spacing": 16.0,
+                    "offset": 21.93000030517578,
+                    "spacing": 13.5,
                     "phase": 0
                 },
                 {
                     "pieceId": "convertible",
-                    "offset": 4.989999771118164,
-                    "spacing": 16.0,
+                    "offset": 1.6799999475479127,
+                    "spacing": 13.5,
                     "phase": 0
                 }
             ],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
             "obstructions": []
         },
         {
@@ -69,7 +62,7 @@
             "obstructions": [
                 {
                     "pieceId": "bush",
-                    "column": 0
+                    "column": 11
                 }
             ]
         },
@@ -80,12 +73,24 @@
             "objects": [
                 {
                     "pieceId": "convertible",
-                    "offset": 12.350000381469727,
-                    "spacing": 8.0,
+                    "offset": 20.84000015258789,
+                    "spacing": 6.75,
                     "phase": 0
                 }
             ],
             "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "bench",
+                    "column": 11
+                }
+            ]
         },
         {
             "kind": "grass",

--- a/Assets/Resources/Levels/level-007.json
+++ b/Assets/Resources/Levels/level-007.json
@@ -1,17 +1,17 @@
 {
     "id": "level-007",
     "name": "level-007",
-    "columns": 11,
+    "columns": 23,
     "medal": {
-        "gold": 22.600000381469728,
-        "silver": 32.79999923706055,
-        "bronze": 47.5
+        "gold": 23.399999618530275,
+        "silver": 34.0,
+        "bronze": 49.20000076293945
     },
-    "startColumn": 7,
+    "startColumn": 16,
     "bays": [
-        1,
-        6,
-        10
+        8,
+        14,
+        17
     ],
     "rows": [
         {
@@ -28,8 +28,8 @@
             "objects": [
                 {
                     "pieceId": "convertible",
-                    "offset": 9.829999923706055,
-                    "spacing": 8.5,
+                    "offset": 16.760000228881837,
+                    "spacing": 7.25,
                     "phase": 0
                 }
             ],
@@ -42,8 +42,8 @@
             "objects": [
                 {
                     "pieceId": "convertible",
-                    "offset": 4.78000020980835,
-                    "spacing": 8.5,
+                    "offset": 8.149999618530274,
+                    "spacing": 7.25,
                     "phase": 0
                 }
             ],
@@ -56,14 +56,14 @@
             "objects": [
                 {
                     "pieceId": "car",
-                    "offset": 3.8499999046325685,
-                    "spacing": 21.0,
+                    "offset": 6.039999961853027,
+                    "spacing": 16.5,
                     "phase": 0
                 },
                 {
                     "pieceId": "truck",
-                    "offset": 14.350000381469727,
-                    "spacing": 21.0,
+                    "offset": 14.289999961853028,
+                    "spacing": 16.5,
                     "phase": 0
                 }
             ],
@@ -79,18 +79,12 @@
         {
             "kind": "road",
             "dir": "left",
-            "speed": 1.3799999952316285,
+            "speed": 1.4500000476837159,
             "objects": [
                 {
-                    "pieceId": "truck",
-                    "offset": 5.070000171661377,
-                    "spacing": 21.0,
-                    "phase": 0
-                },
-                {
                     "pieceId": "convertible",
-                    "offset": 15.569999694824219,
-                    "spacing": 21.0,
+                    "offset": 27.579999923706056,
+                    "spacing": 5.800000190734863,
                     "phase": 0
                 }
             ],
@@ -101,7 +95,12 @@
             "dir": "",
             "speed": 0.0,
             "objects": [],
-            "obstructions": []
+            "obstructions": [
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 20
+                }
+            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-008.json
+++ b/Assets/Resources/Levels/level-008.json
@@ -1,17 +1,17 @@
 {
     "id": "level-008",
     "name": "level-008",
-    "columns": 9,
+    "columns": 23,
     "medal": {
-        "gold": 23.899999618530275,
-        "silver": 34.70000076293945,
-        "bronze": 50.20000076293945
+        "gold": 35.400001525878909,
+        "silver": 51.400001525878909,
+        "bronze": 74.4000015258789
     },
-    "startColumn": 1,
+    "startColumn": 13,
     "bays": [
-        2,
-        4,
-        8
+        0,
+        6,
+        19
     ],
     "rows": [
         {
@@ -23,57 +23,30 @@
         },
         {
             "kind": "road",
-            "dir": "left",
+            "dir": "right",
+            "speed": 1.659999966621399,
+            "objects": [
+                {
+                    "pieceId": "bus",
+                    "offset": 12.970000267028809,
+                    "spacing": 7.75,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "right",
             "speed": 1.5,
             "objects": [
                 {
-                    "pieceId": "convertible",
-                    "offset": 4.420000076293945,
-                    "spacing": 7.5,
+                    "pieceId": "car",
+                    "offset": 12.369999885559082,
+                    "spacing": 5.800000190734863,
                     "phase": 0
                 }
             ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.5800000429153443,
-            "objects": [
-                {
-                    "pieceId": "truck",
-                    "offset": 15.239999771118164,
-                    "spacing": 9.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.5199999809265137,
-            "objects": [
-                {
-                    "pieceId": "bus",
-                    "offset": 8.989999771118164,
-                    "spacing": 17.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "bus",
-                    "offset": 0.49000000953674319,
-                    "spacing": 17.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
             "obstructions": []
         },
         {
@@ -83,20 +56,53 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-daisy",
-                    "column": 7
+                    "pieceId": "lamp",
+                    "column": 14
                 }
             ]
         },
         {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": []
+        },
+        {
             "kind": "road",
             "dir": "left",
-            "speed": 1.340000033378601,
+            "speed": 1.3899999856948853,
             "objects": [
                 {
+                    "pieceId": "bus",
+                    "offset": 25.34000015258789,
+                    "spacing": 15.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "bus",
+                    "offset": 2.0899999141693117,
+                    "spacing": 15.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 1.5099999904632569,
+            "objects": [
+                {
+                    "pieceId": "convertible",
+                    "offset": 28.81999969482422,
+                    "spacing": 14.5,
+                    "phase": 0
+                },
+                {
                     "pieceId": "car",
-                    "offset": 12.369999885559082,
-                    "spacing": 7.5,
+                    "offset": 7.070000171661377,
+                    "spacing": 14.5,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-009.json
+++ b/Assets/Resources/Levels/level-009.json
@@ -1,17 +1,17 @@
 {
     "id": "level-009",
     "name": "level-009",
-    "columns": 11,
+    "columns": 20,
     "medal": {
-        "gold": 18.600000381469728,
-        "silver": 27.0,
-        "bronze": 39.099998474121097
+        "gold": 46.599998474121097,
+        "silver": 67.5999984741211,
+        "bronze": 97.9000015258789
     },
-    "startColumn": 5,
+    "startColumn": 3,
     "bays": [
-        4,
-        5,
-        9
+        13,
+        17,
+        19
     ],
     "rows": [
         {
@@ -22,38 +22,94 @@
             "obstructions": []
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.350000023841858,
-            "objects": [
-                {
-                    "pieceId": "convertible",
-                    "offset": 0.1899999976158142,
-                    "spacing": 5.670000076293945,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
             "kind": "grass",
             "dir": "",
             "speed": 0.0,
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-lavender",
+                    "pieceId": "planter-fern",
                     "column": 3
                 },
                 {
                     "pieceId": "planter-lavender",
-                    "column": 9
-                },
-                {
-                    "pieceId": "planter-tulip",
-                    "column": 10
+                    "column": 8
                 }
             ]
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 1.3700000047683716,
+            "objects": [
+                {
+                    "pieceId": "convertible",
+                    "offset": 24.420000076293947,
+                    "spacing": 6.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 1.4199999570846558,
+            "objects": [
+                {
+                    "pieceId": "car",
+                    "offset": 23.5,
+                    "spacing": 13.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 4.0,
+                    "spacing": 13.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 1.690000057220459,
+            "objects": [
+                {
+                    "pieceId": "truck",
+                    "offset": 24.799999237060548,
+                    "spacing": 30.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 9.800000190734864,
+                    "spacing": 30.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 1.4500000476837159,
+            "objects": [
+                {
+                    "pieceId": "car",
+                    "offset": 24.700000762939454,
+                    "spacing": 13.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 5.199999809265137,
+                    "spacing": 13.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
         },
         {
             "kind": "grass",
@@ -62,58 +118,10 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "tree",
-                    "column": 7
+                    "pieceId": "planter-tulip",
+                    "column": 12
                 }
             ]
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.4299999475479127,
-            "objects": [
-                {
-                    "pieceId": "bus",
-                    "offset": 10.819999694824219,
-                    "spacing": 9.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.5199999809265137,
-            "objects": [
-                {
-                    "pieceId": "truck",
-                    "offset": 11.029999732971192,
-                    "spacing": 21.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "convertible",
-                    "offset": 0.5299999713897705,
-                    "spacing": 21.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.5099999904632569,
-            "objects": [
-                {
-                    "pieceId": "convertible",
-                    "offset": 16.649999618530275,
-                    "spacing": 8.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-010.json
+++ b/Assets/Resources/Levels/level-010.json
@@ -1,17 +1,17 @@
 {
     "id": "level-010",
     "name": "level-010",
-    "columns": 9,
+    "columns": 20,
     "medal": {
-        "gold": 22.0,
-        "silver": 31.899999618530275,
-        "bronze": 46.20000076293945
+        "gold": 41.79999923706055,
+        "silver": 60.70000076293945,
+        "bronze": 87.9000015258789
     },
-    "startColumn": 2,
+    "startColumn": 18,
     "bays": [
-        1,
-        2,
-        5
+        0,
+        3,
+        19
     ],
     "rows": [
         {
@@ -28,8 +28,8 @@
             "objects": [
                 {
                     "pieceId": "truck",
-                    "offset": 13.829999923706055,
-                    "spacing": 9.5,
+                    "offset": 21.84000015258789,
+                    "spacing": 10.0,
                     "phase": 0
                 }
             ],
@@ -42,8 +42,8 @@
             "objects": [
                 {
                     "pieceId": "car",
-                    "offset": 12.65999984741211,
-                    "spacing": 7.5,
+                    "offset": 21.940000534057618,
+                    "spacing": 6.5,
                     "phase": 0
                 }
             ],
@@ -56,8 +56,8 @@
             "objects": [
                 {
                     "pieceId": "truck",
-                    "offset": 1.2699999809265137,
-                    "spacing": 9.5,
+                    "offset": 2.009999990463257,
+                    "spacing": 10.0,
                     "phase": 0
                 }
             ],
@@ -70,8 +70,8 @@
             "objects": [
                 {
                     "pieceId": "truck",
-                    "offset": 9.020000457763672,
-                    "spacing": 9.5,
+                    "offset": 14.25,
+                    "spacing": 10.0,
                     "phase": 0
                 }
             ],
@@ -98,10 +98,17 @@
             ]
         },
         {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
+            "kind": "road",
+            "dir": "left",
+            "speed": 1.409999966621399,
+            "objects": [
+                {
+                    "pieceId": "car",
+                    "offset": 16.059999465942384,
+                    "spacing": 6.5,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-011.json
+++ b/Assets/Resources/Levels/level-011.json
@@ -1,16 +1,16 @@
 {
     "id": "level-011",
     "name": "level-011",
-    "columns": 10,
+    "columns": 20,
     "medal": {
-        "gold": 105.19999694824219,
-        "silver": 152.60000610351563,
-        "bronze": 221.0
+        "gold": 17.200000762939454,
+        "silver": 25.0,
+        "bronze": 36.20000076293945
     },
-    "startColumn": 6,
+    "startColumn": 5,
     "bays": [
-        3,
-        5
+        2,
+        15
     ],
     "rows": [
         {
@@ -21,88 +21,72 @@
             "obstructions": []
         },
         {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.190000057220459,
-            "objects": [
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
                 {
-                    "pieceId": "raft",
-                    "offset": 6.409999847412109,
-                    "spacing": 22.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log-long",
-                    "offset": 17.40999984741211,
-                    "spacing": 22.0,
-                    "phase": 0
+                    "pieceId": "planter-lavender",
+                    "column": 13
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
             "kind": "river",
-            "dir": "right",
-            "speed": 1.149999976158142,
+            "dir": "left",
+            "speed": 0.9100000262260437,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 21.65999984741211,
-                    "spacing": 22.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log-long",
-                    "offset": 10.65999984741211,
-                    "spacing": 22.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.1200000047683716,
-            "objects": [
-                {
-                    "pieceId": "gator",
-                    "offset": 15.829999923706055,
+                    "pieceId": "log",
+                    "offset": 12.010000228881836,
                     "spacing": 10.0,
-                    "phase": 190
+                    "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
             "kind": "road",
-            "dir": "left",
-            "speed": 1.7799999713897706,
+            "dir": "right",
+            "speed": 1.3700000047683716,
             "objects": [
                 {
                     "pieceId": "bus",
-                    "offset": 2.369999885559082,
-                    "spacing": 20.0,
+                    "offset": 15.260000228881836,
+                    "spacing": 14.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "truck",
-                    "offset": 12.369999885559082,
-                    "spacing": 20.0,
+                    "pieceId": "car",
+                    "offset": 22.260000228881837,
+                    "spacing": 14.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.090000033378601,
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "bench",
+                    "column": 2
+                }
+            ]
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 1.7599999904632569,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 14.09000015258789,
-                    "spacing": 11.0,
+                    "pieceId": "car",
+                    "offset": 10.229999542236329,
+                    "spacing": 8.670000076293946,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-012.json
+++ b/Assets/Resources/Levels/level-012.json
@@ -1,16 +1,16 @@
 {
     "id": "level-012",
     "name": "level-012",
-    "columns": 11,
+    "columns": 26,
     "medal": {
         "gold": 33.599998474121097,
         "silver": 48.70000076293945,
         "bronze": 70.5999984741211
     },
-    "startColumn": 9,
+    "startColumn": 18,
     "bays": [
-        3,
-        7
+        2,
+        18
     ],
     "rows": [
         {
@@ -27,14 +27,14 @@
             "objects": [
                 {
                     "pieceId": "turtle-log",
-                    "offset": 0.8899999856948853,
-                    "spacing": 21.0,
+                    "offset": 1.5299999713897706,
+                    "spacing": 18.0,
                     "phase": 234
                 },
                 {
                     "pieceId": "gator",
-                    "offset": 11.390000343322754,
-                    "spacing": 21.0,
+                    "offset": 10.529999732971192,
+                    "spacing": 18.0,
                     "phase": 257
                 }
             ],
@@ -45,38 +45,54 @@
             "dir": "",
             "speed": 0.0,
             "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.2100000381469727,
-            "objects": [
+            "obstructions": [
                 {
-                    "pieceId": "log",
-                    "offset": 4.380000114440918,
-                    "spacing": 10.5,
-                    "phase": 0
+                    "pieceId": "bush",
+                    "column": 14
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
             "kind": "grass",
             "dir": "",
             "speed": 0.0,
             "objects": [],
-            "obstructions": []
+            "obstructions": [
+                {
+                    "pieceId": "tree",
+                    "column": 2
+                }
+            ]
         },
         {
             "kind": "road",
             "dir": "right",
-            "speed": 1.6699999570846558,
+            "speed": 1.7899999618530274,
             "objects": [
                 {
-                    "pieceId": "truck",
-                    "offset": 2.109999895095825,
-                    "spacing": 10.5,
+                    "pieceId": "car",
+                    "offset": 14.760000228881836,
+                    "spacing": 6.400000095367432,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 0.9200000166893005,
+            "objects": [
+                {
+                    "pieceId": "gator",
+                    "offset": 2.990000009536743,
+                    "spacing": 18.0,
+                    "phase": 28
+                },
+                {
+                    "pieceId": "log-short",
+                    "offset": 11.989999771118164,
+                    "spacing": 18.0,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-013.json
+++ b/Assets/Resources/Levels/level-013.json
@@ -1,16 +1,16 @@
 {
     "id": "level-013",
     "name": "level-013",
-    "columns": 10,
+    "columns": 22,
     "medal": {
-        "gold": 16.0,
-        "silver": 23.200000762939454,
-        "bronze": 33.599998474121097
+        "gold": 34.79999923706055,
+        "silver": 50.5,
+        "bronze": 73.0999984741211
     },
-    "startColumn": 6,
+    "startColumn": 1,
     "bays": [
-        1,
-        4
+        3,
+        10
     ],
     "rows": [
         {
@@ -27,14 +27,14 @@
             "objects": [
                 {
                     "pieceId": "turtle-log",
-                    "offset": 15.869999885559082,
-                    "spacing": 20.0,
+                    "offset": 25.389999389648439,
+                    "spacing": 32.0,
                     "phase": 145
                 },
                 {
                     "pieceId": "raft",
-                    "offset": 5.869999885559082,
-                    "spacing": 20.0,
+                    "offset": 9.390000343322754,
+                    "spacing": 32.0,
                     "phase": 0
                 }
             ],
@@ -57,58 +57,42 @@
             ]
         },
         {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.159999966621399,
-            "objects": [
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 17.06999969482422,
-                    "spacing": 22.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log-short",
-                    "offset": 6.070000171661377,
-                    "spacing": 22.0,
-                    "phase": 0
+                    "pieceId": "planter-fern",
+                    "column": 3
                 }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.2200000286102296,
-            "objects": [
-                {
-                    "pieceId": "log",
-                    "offset": 9.079999923706055,
-                    "spacing": 22.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log-long",
-                    "offset": 20.079999923706056,
-                    "spacing": 22.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
+            ]
         },
         {
             "kind": "road",
-            "dir": "right",
-            "speed": 1.7400000095367432,
+            "dir": "left",
+            "speed": 1.5399999618530274,
             "objects": [
                 {
-                    "pieceId": "bus",
-                    "offset": 5.78000020980835,
-                    "spacing": 9.0,
+                    "pieceId": "car",
+                    "offset": 22.3700008392334,
+                    "spacing": 7.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-fern",
+                    "column": 17
+                }
+            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-014.json
+++ b/Assets/Resources/Levels/level-014.json
@@ -1,16 +1,16 @@
 {
     "id": "level-014",
     "name": "level-014",
-    "columns": 11,
+    "columns": 25,
     "medal": {
-        "gold": 12.600000381469727,
-        "silver": 18.200000762939454,
-        "bronze": 26.399999618530275
+        "gold": 28.399999618530275,
+        "silver": 41.20000076293945,
+        "bronze": 59.70000076293945
     },
-    "startColumn": 9,
+    "startColumn": 6,
     "bays": [
-        4,
-        6
+        12,
+        22
     ],
     "rows": [
         {
@@ -27,14 +27,14 @@
             "objects": [
                 {
                     "pieceId": "turtle-log",
-                    "offset": 12.520000457763672,
-                    "spacing": 23.0,
+                    "offset": 20.149999618530275,
+                    "spacing": 18.5,
                     "phase": 56
                 },
                 {
                     "pieceId": "log-long",
-                    "offset": 1.0199999809265137,
-                    "spacing": 23.0,
+                    "offset": 29.399999618530275,
+                    "spacing": 18.5,
                     "phase": 0
                 }
             ],
@@ -47,8 +47,8 @@
             "objects": [
                 {
                     "pieceId": "truck",
-                    "offset": 20.6299991607666,
-                    "spacing": 10.5,
+                    "offset": 34.38999938964844,
+                    "spacing": 8.75,
                     "phase": 0
                 }
             ],
@@ -61,8 +61,8 @@
             "objects": [
                 {
                     "pieceId": "bus",
-                    "offset": 15.359999656677246,
-                    "spacing": 9.5,
+                    "offset": 26.68000030517578,
+                    "spacing": 8.25,
                     "phase": 0
                 }
             ],
@@ -75,14 +75,14 @@
             "objects": [
                 {
                     "pieceId": "truck",
-                    "offset": 13.699999809265137,
-                    "spacing": 21.0,
+                    "offset": 22.84000015258789,
+                    "spacing": 17.5,
                     "phase": 0
                 },
                 {
                     "pieceId": "convertible",
-                    "offset": 3.200000047683716,
-                    "spacing": 21.0,
+                    "offset": 31.59000015258789,
+                    "spacing": 17.5,
                     "phase": 0
                 }
             ],
@@ -97,18 +97,28 @@
                 {
                     "pieceId": "bush",
                     "column": 0
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 16
                 }
             ]
         },
         {
             "kind": "river",
-            "dir": "left",
-            "speed": 1.0499999523162842,
+            "dir": "right",
+            "speed": 1.1799999475479127,
             "objects": [
                 {
-                    "pieceId": "raft",
-                    "offset": 0.27000001072883608,
-                    "spacing": 7.0,
+                    "pieceId": "turtle-log",
+                    "offset": 10.470000267028809,
+                    "spacing": 37.0,
+                    "phase": 86
+                },
+                {
+                    "pieceId": "log-long",
+                    "offset": 28.969999313354493,
+                    "spacing": 37.0,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-015.json
+++ b/Assets/Resources/Levels/level-015.json
@@ -1,16 +1,16 @@
 {
     "id": "level-015",
     "name": "level-015",
-    "columns": 9,
+    "columns": 22,
     "medal": {
-        "gold": 19.100000381469728,
-        "silver": 27.700000762939454,
-        "bronze": 40.099998474121097
+        "gold": 16.100000381469728,
+        "silver": 23.299999237060548,
+        "bronze": 33.79999923706055
     },
-    "startColumn": 3,
+    "startColumn": 12,
     "bays": [
-        0,
-        3
+        18,
+        19
     ],
     "rows": [
         {
@@ -21,88 +21,26 @@
             "obstructions": []
         },
         {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 2
+                }
+            ]
+        },
+        {
             "kind": "river",
             "dir": "left",
             "speed": 1.2999999523162842,
             "objects": [
                 {
-                    "pieceId": "gator",
-                    "offset": 5.619999885559082,
-                    "spacing": 19.0,
-                    "phase": 379
-                },
-                {
-                    "pieceId": "gator",
-                    "offset": 15.119999885559082,
-                    "spacing": 19.0,
-                    "phase": 317
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.1100000143051148,
-            "objects": [
-                {
-                    "pieceId": "gator",
-                    "offset": 1.6100000143051148,
-                    "spacing": 9.5,
-                    "phase": 173
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.440000057220459,
-            "objects": [
-                {
-                    "pieceId": "truck",
-                    "offset": 16.09000015258789,
-                    "spacing": 19.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "bus",
-                    "offset": 6.590000152587891,
-                    "spacing": 19.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.2300000190734864,
-            "objects": [
-                {
-                    "pieceId": "raft",
-                    "offset": 10.989999771118164,
-                    "spacing": 21.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log-long",
-                    "offset": 0.49000000953674319,
-                    "spacing": 21.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "left",
-            "speed": 1.600000023841858,
-            "objects": [
-                {
-                    "pieceId": "car",
-                    "offset": 0.7900000214576721,
-                    "spacing": 7.5,
+                    "pieceId": "log",
+                    "offset": 12.319999694824219,
+                    "spacing": 8.0,
                     "phase": 0
                 }
             ],
@@ -111,22 +49,64 @@
         {
             "kind": "river",
             "dir": "right",
-            "speed": 1.1799999475479127,
+            "speed": 1.2200000286102296,
             "objects": [
                 {
-                    "pieceId": "raft",
-                    "offset": 18.950000762939454,
-                    "spacing": 19.0,
-                    "phase": 0
-                },
-                {
                     "pieceId": "gator",
-                    "offset": 9.449999809265137,
-                    "spacing": 19.0,
-                    "phase": 305
+                    "offset": 9.289999961853028,
+                    "spacing": 8.0,
+                    "phase": 207
                 }
             ],
             "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 1
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 15
+                }
+            ]
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-fern",
+                    "column": 1
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 16
+                }
+            ]
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "bench",
+                    "column": 0
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 4
+                }
+            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-016.json
+++ b/Assets/Resources/Levels/level-016.json
@@ -1,17 +1,17 @@
 {
     "id": "level-016",
     "name": "level-016",
-    "columns": 10,
+    "columns": 21,
     "medal": {
-        "gold": 98.30000305175781,
-        "silver": 142.60000610351563,
-        "bronze": 206.5
+        "gold": 48.099998474121097,
+        "silver": 69.69999694824219,
+        "bronze": 100.9000015258789
     },
-    "startColumn": 5,
+    "startColumn": 3,
     "bays": [
-        2,
-        3,
-        8
+        8,
+        18,
+        20
     ],
     "rows": [
         {
@@ -22,69 +22,15 @@
             "obstructions": []
         },
         {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.1200000047683716,
-            "objects": [
-                {
-                    "pieceId": "gator",
-                    "offset": 0.5699999928474426,
-                    "spacing": 10.0,
-                    "phase": 19
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
+            "kind": "road",
             "dir": "left",
-            "speed": 1.0,
+            "speed": 1.8899999856948853,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 21.59000015258789,
-                    "spacing": 22.0,
+                    "pieceId": "convertible",
+                    "offset": 4.099999904632568,
+                    "spacing": 6.75,
                     "phase": 0
-                },
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 10.59000015258789,
-                    "spacing": 22.0,
-                    "phase": 51
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.3300000429153443,
-            "objects": [
-                {
-                    "pieceId": "log",
-                    "offset": 7.389999866485596,
-                    "spacing": 10.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 0.9599999785423279,
-            "objects": [
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 9.430000305175782,
-                    "spacing": 20.0,
-                    "phase": 129
-                },
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 19.43000030517578,
-                    "spacing": 20.0,
-                    "phase": 284
                 }
             ],
             "obstructions": []
@@ -96,20 +42,76 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "bush",
-                    "column": 4
+                    "pieceId": "lamp",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 14
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 15
                 }
             ]
         },
         {
             "kind": "river",
             "dir": "right",
-            "speed": 1.0299999713897706,
+            "speed": 1.0399999618530274,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 0.3199999928474426,
-                    "spacing": 9.0,
+                    "pieceId": "raft",
+                    "offset": 9.710000038146973,
+                    "spacing": 33.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log-long",
+                    "offset": 26.209999084472658,
+                    "spacing": 33.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.1200000047683716,
+            "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 25.18000030517578,
+                    "spacing": 7.75,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.3200000524520875,
+            "objects": [
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 0.5,
+                    "spacing": 7.75,
+                    "phase": 209
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.2999999523162842,
+            "objects": [
+                {
+                    "pieceId": "log-long",
+                    "offset": 23.56999969482422,
+                    "spacing": 11.0,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-017.json
+++ b/Assets/Resources/Levels/level-017.json
@@ -1,17 +1,17 @@
 {
     "id": "level-017",
     "name": "level-017",
-    "columns": 9,
+    "columns": 24,
     "medal": {
-        "gold": 21.600000381469728,
-        "silver": 31.399999618530275,
-        "bronze": 45.5
+        "gold": 22.600000381469728,
+        "silver": 32.70000076293945,
+        "bronze": 47.400001525878909
     },
-    "startColumn": 5,
+    "startColumn": 3,
     "bays": [
-        4,
-        6,
-        7
+        3,
+        7,
+        14
     ],
     "rows": [
         {
@@ -22,52 +22,42 @@
             "obstructions": []
         },
         {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.350000023841858,
+            "kind": "road",
+            "dir": "right",
+            "speed": 1.6299999952316285,
             "objects": [
                 {
-                    "pieceId": "gator",
-                    "offset": 14.149999618530274,
-                    "spacing": 9.5,
-                    "phase": 335
+                    "pieceId": "convertible",
+                    "offset": 26.059999465942384,
+                    "spacing": 5.0,
+                    "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
+            "kind": "road",
+            "dir": "left",
+            "speed": 1.9800000190734864,
+            "objects": [
                 {
-                    "pieceId": "planter-daisy",
-                    "column": 2
+                    "pieceId": "convertible",
+                    "offset": 3.440000057220459,
+                    "spacing": 6.0,
+                    "phase": 0
                 }
-            ]
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "lamp",
-                    "column": 5
-                }
-            ]
+            ],
+            "obstructions": []
         },
         {
             "kind": "road",
             "dir": "right",
-            "speed": 1.7599999904632569,
+            "speed": 1.5800000429153443,
             "objects": [
                 {
-                    "pieceId": "convertible",
-                    "offset": 13.279999732971192,
-                    "spacing": 7.5,
+                    "pieceId": "bus",
+                    "offset": 8.680000305175782,
+                    "spacing": 8.0,
                     "phase": 0
                 }
             ],
@@ -76,26 +66,58 @@
         {
             "kind": "river",
             "dir": "right",
-            "speed": 1.3300000429153443,
+            "speed": 1.0499999523162842,
             "objects": [
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 16.59000015258789,
-                    "spacing": 9.5,
-                    "phase": 68
+                    "pieceId": "raft",
+                    "offset": 15.869999885559082,
+                    "spacing": 17.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log-short",
+                    "offset": 24.3700008392334,
+                    "spacing": 17.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.2100000381469727,
+            "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 1.9199999570846558,
+                    "spacing": 17.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log-short",
+                    "offset": 10.420000076293946,
+                    "spacing": 17.0,
+                    "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
             "kind": "road",
-            "dir": "left",
-            "speed": 1.9700000286102296,
+            "dir": "right",
+            "speed": 1.5,
             "objects": [
                 {
-                    "pieceId": "bus",
-                    "offset": 8.15999984741211,
-                    "spacing": 8.5,
+                    "pieceId": "truck",
+                    "offset": 18.59000015258789,
+                    "spacing": 17.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "convertible",
+                    "offset": 27.09000015258789,
+                    "spacing": 17.0,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-018.json
+++ b/Assets/Resources/Levels/level-018.json
@@ -1,17 +1,17 @@
 {
     "id": "level-018",
     "name": "level-018",
-    "columns": 9,
+    "columns": 23,
     "medal": {
-        "gold": 27.5,
-        "silver": 39.900001525878909,
-        "bronze": 57.79999923706055
+        "gold": 36.29999923706055,
+        "silver": 52.70000076293945,
+        "bronze": 76.30000305175781
     },
-    "startColumn": 3,
+    "startColumn": 6,
     "bays": [
-        3,
-        4,
-        8
+        12,
+        18,
+        20
     ],
     "rows": [
         {
@@ -22,14 +22,72 @@
             "obstructions": []
         },
         {
-            "kind": "road",
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 9
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 11
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 14
+                }
+            ]
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 6
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 12
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 20
+                }
+            ]
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 20
+                }
+            ]
+        },
+        {
+            "kind": "river",
             "dir": "right",
-            "speed": 1.9299999475479127,
+            "speed": 1.1299999952316285,
             "objects": [
                 {
-                    "pieceId": "convertible",
-                    "offset": 8.779999732971192,
-                    "spacing": 7.5,
+                    "pieceId": "log-long",
+                    "offset": 4.75,
+                    "spacing": 35.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "raft",
+                    "offset": 22.25,
+                    "spacing": 35.0,
                     "phase": 0
                 }
             ],
@@ -37,20 +95,20 @@
         },
         {
             "kind": "river",
-            "dir": "right",
-            "speed": 1.2899999618530274,
+            "dir": "left",
+            "speed": 1.2300000190734864,
             "objects": [
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 10.289999961853028,
-                    "spacing": 19.0,
-                    "phase": 197
+                    "pieceId": "log-long",
+                    "offset": 32.43000030517578,
+                    "spacing": 35.0,
+                    "phase": 0
                 },
                 {
-                    "pieceId": "gator",
-                    "offset": 0.7900000214576721,
-                    "spacing": 19.0,
-                    "phase": 135
+                    "pieceId": "raft",
+                    "offset": 14.930000305175782,
+                    "spacing": 35.0,
+                    "phase": 0
                 }
             ],
             "obstructions": []
@@ -60,58 +118,26 @@
             "dir": "",
             "speed": 0.0,
             "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.5,
-            "objects": [
+            "obstructions": [
                 {
-                    "pieceId": "convertible",
-                    "offset": 15.180000305175782,
-                    "spacing": 17.0,
-                    "phase": 0
+                    "pieceId": "planter-succulent",
+                    "column": 1
                 },
                 {
-                    "pieceId": "bus",
-                    "offset": 6.679999828338623,
-                    "spacing": 17.0,
-                    "phase": 0
+                    "pieceId": "bush",
+                    "column": 2
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
             "kind": "river",
-            "dir": "left",
-            "speed": 1.4299999475479127,
+            "dir": "right",
+            "speed": 1.149999976158142,
             "objects": [
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 3.009999990463257,
-                    "spacing": 9.5,
-                    "phase": 284
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "left",
-            "speed": 1.9500000476837159,
-            "objects": [
-                {
-                    "pieceId": "car",
-                    "offset": 5.519999980926514,
-                    "spacing": 7.5,
+                    "pieceId": "log-long",
+                    "offset": 18.989999771118165,
+                    "spacing": 8.75,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-019.json
+++ b/Assets/Resources/Levels/level-019.json
@@ -1,17 +1,17 @@
 {
     "id": "level-019",
     "name": "level-019",
-    "columns": 11,
+    "columns": 26,
     "medal": {
-        "gold": 20.0,
-        "silver": 29.0,
-        "bronze": 42.0
+        "gold": 25.799999237060548,
+        "silver": 37.400001525878909,
+        "bronze": 54.099998474121097
     },
-    "startColumn": 3,
+    "startColumn": 17,
     "bays": [
-        0,
-        7,
-        10
+        5,
+        15,
+        20
     ],
     "rows": [
         {
@@ -29,55 +29,14 @@
             "obstructions": []
         },
         {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": []
-        },
-        {
             "kind": "river",
-            "dir": "right",
-            "speed": 1.3700000047683716,
+            "dir": "left",
+            "speed": 1.090000033378601,
             "objects": [
                 {
                     "pieceId": "raft",
-                    "offset": 3.069999933242798,
-                    "spacing": 21.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "gator",
-                    "offset": 13.569999694824219,
-                    "spacing": 21.0,
-                    "phase": 147
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.4600000381469727,
-            "objects": [
-                {
-                    "pieceId": "log-long",
-                    "offset": 13.970000267028809,
-                    "spacing": 11.5,
+                    "offset": 31.510000228881837,
+                    "spacing": 9.0,
                     "phase": 0
                 }
             ],
@@ -90,8 +49,68 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "bush",
-                    "column": 7
+                    "pieceId": "planter-succulent",
+                    "column": 18
+                }
+            ]
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.149999976158142,
+            "objects": [
+                {
+                    "pieceId": "log-short",
+                    "offset": 4.840000152587891,
+                    "spacing": 19.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log-long",
+                    "offset": 14.34000015258789,
+                    "spacing": 19.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.0,
+            "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 27.469999313354493,
+                    "spacing": 9.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.399999976158142,
+            "objects": [
+                {
+                    "pieceId": "log-long",
+                    "offset": 35.09000015258789,
+                    "spacing": 12.670000076293946,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 5
                 }
             ]
         },

--- a/Assets/Resources/Levels/level-020.json
+++ b/Assets/Resources/Levels/level-020.json
@@ -1,17 +1,17 @@
 {
     "id": "level-020",
     "name": "level-020",
-    "columns": 10,
+    "columns": 26,
     "medal": {
-        "gold": 23.899999618530275,
-        "silver": 34.70000076293945,
-        "bronze": 50.20000076293945
+        "gold": 42.400001525878909,
+        "silver": 61.5,
+        "bronze": 89.0999984741211
     },
-    "startColumn": 3,
+    "startColumn": 22,
     "bays": [
-        4,
-        7,
-        9
+        3,
+        10,
+        23
     ],
     "rows": [
         {
@@ -22,43 +22,41 @@
             "obstructions": []
         },
         {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "lamp",
-                    "column": 2
-                },
-                {
-                    "pieceId": "planter-fern",
-                    "column": 5
-                }
-            ]
-        },
-        {
-            "kind": "road",
+            "kind": "river",
             "dir": "right",
-            "speed": 2.0899999141693117,
+            "speed": 1.2999999523162842,
             "objects": [
                 {
-                    "pieceId": "car",
-                    "offset": 4.25,
-                    "spacing": 8.0,
+                    "pieceId": "log-short",
+                    "offset": 17.459999084472658,
+                    "spacing": 6.800000190734863,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.009999990463257,
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.1200000047683716,
             "objects": [
                 {
-                    "pieceId": "bus",
-                    "offset": 15.6899995803833,
+                    "pieceId": "log-long",
+                    "offset": 6.659999847412109,
+                    "spacing": 9.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.2899999618530274,
+            "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 34.63999938964844,
                     "spacing": 9.0,
                     "phase": 0
                 }
@@ -66,14 +64,42 @@
             "obstructions": []
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.8700000047683716,
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-fern",
+                    "column": 5
+                }
+            ]
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 8
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 24
+                }
+            ]
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.0,
             "objects": [
                 {
-                    "pieceId": "truck",
-                    "offset": 4.269999980926514,
-                    "spacing": 10.0,
+                    "pieceId": "log-short",
+                    "offset": 25.469999313354493,
+                    "spacing": 8.5,
                     "phase": 0
                 }
             ],
@@ -82,47 +108,19 @@
         {
             "kind": "river",
             "dir": "right",
-            "speed": 1.3200000524520875,
-            "objects": [
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 15.729999542236329,
-                    "spacing": 10.0,
-                    "phase": 123
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.440000057220459,
+            "speed": 1.190000057220459,
             "objects": [
                 {
                     "pieceId": "log-long",
-                    "offset": 19.670000076293947,
-                    "spacing": 11.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.899999976158142,
-            "objects": [
-                {
-                    "pieceId": "bus",
-                    "offset": 14.199999809265137,
-                    "spacing": 18.0,
+                    "offset": 32.560001373291019,
+                    "spacing": 19.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "bus",
-                    "offset": 5.199999809265137,
-                    "spacing": 18.0,
-                    "phase": 0
+                    "pieceId": "turtle-log",
+                    "offset": 4.059999942779541,
+                    "spacing": 19.0,
+                    "phase": 53
                 }
             ],
             "obstructions": []

--- a/Assets/Resources/Levels/level-021.json
+++ b/Assets/Resources/Levels/level-021.json
@@ -1,16 +1,16 @@
 {
     "id": "level-021",
     "name": "level-021",
-    "columns": 12,
+    "columns": 26,
     "medal": {
-        "gold": 10.699999809265137,
-        "silver": 15.600000381469727,
-        "bronze": 22.5
+        "gold": 15.100000381469727,
+        "silver": 21.899999618530275,
+        "bronze": 31.799999237060548
     },
-    "startColumn": 5,
+    "startColumn": 8,
     "bays": [
-        5,
-        7
+        4,
+        12
     ],
     "rows": [
         {
@@ -27,14 +27,14 @@
             "objects": [
                 {
                     "pieceId": "log-long",
-                    "offset": 19.25,
-                    "spacing": 24.0,
+                    "offset": 30.489999771118165,
+                    "spacing": 19.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "log",
-                    "offset": 7.25,
-                    "spacing": 24.0,
+                    "offset": 1.9900000095367432,
+                    "spacing": 19.0,
                     "phase": 0
                 }
             ],
@@ -53,56 +53,42 @@
                 {
                     "pieceId": "planter-tulip",
                     "column": 11
-                }
-            ]
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "planter-fern",
-                    "column": 5
-                }
-            ]
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.0499999523162842,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 2.0199999809265138,
-                    "spacing": 22.0,
-                    "phase": 0
                 },
                 {
+                    "pieceId": "planter-fern",
+                    "column": 18
+                }
+            ]
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.3700000047683716,
+            "objects": [
+                {
                     "pieceId": "gator",
-                    "offset": 13.020000457763672,
-                    "spacing": 22.0,
-                    "phase": 323
+                    "offset": 29.280000686645509,
+                    "spacing": 19.0,
+                    "phase": 76
+                },
+                {
+                    "pieceId": "log-long",
+                    "offset": 0.7799999713897705,
+                    "spacing": 19.0,
+                    "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.440000057220459,
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.3700000047683716,
             "objects": [
                 {
-                    "pieceId": "car",
-                    "offset": 3.2799999713897707,
-                    "spacing": 18.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "car",
-                    "offset": 12.279999732971192,
-                    "spacing": 18.0,
+                    "pieceId": "log-long",
+                    "offset": 6.920000076293945,
+                    "spacing": 9.5,
                     "phase": 0
                 }
             ],
@@ -115,15 +101,35 @@
             "objects": [
                 {
                     "pieceId": "gator",
-                    "offset": 3.990000009536743,
-                    "spacing": 22.0,
+                    "offset": 6.53000020980835,
+                    "spacing": 18.0,
                     "phase": 417
                 },
                 {
                     "pieceId": "turtle-log",
-                    "offset": 14.989999771118164,
-                    "spacing": 22.0,
+                    "offset": 15.529999732971192,
+                    "spacing": 18.0,
                     "phase": 84
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.3300000429153443,
+            "objects": [
+                {
+                    "pieceId": "log-long",
+                    "offset": 25.450000762939454,
+                    "spacing": 19.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 34.95000076293945,
+                    "spacing": 19.0,
+                    "phase": 13
                 }
             ],
             "obstructions": []

--- a/Assets/Resources/Levels/level-022.json
+++ b/Assets/Resources/Levels/level-022.json
@@ -1,16 +1,16 @@
 {
     "id": "level-022",
     "name": "level-022",
-    "columns": 9,
+    "columns": 24,
     "medal": {
-        "gold": 22.5,
-        "silver": 32.70000076293945,
-        "bronze": 47.29999923706055
+        "gold": 18.100000381469728,
+        "silver": 26.200000762939454,
+        "bronze": 38.0
     },
-    "startColumn": 6,
+    "startColumn": 18,
     "bays": [
-        2,
-        7
+        4,
+        12
     ],
     "rows": [
         {
@@ -21,81 +21,61 @@
             "obstructions": []
         },
         {
-            "kind": "river",
+            "kind": "swamp",
             "dir": "right",
-            "speed": 1.1399999856948853,
+            "speed": 1.100000023841858,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 11.619999885559082,
-                    "spacing": 21.0,
+                    "pieceId": "log",
+                    "offset": 9.890000343322754,
+                    "spacing": 17.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "turtle-log",
-                    "offset": 1.1200000047683716,
-                    "spacing": 21.0,
-                    "phase": 5
+                    "offset": 18.389999389648439,
+                    "spacing": 17.0,
+                    "phase": 161
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.159999966621399,
-            "objects": [
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
                 {
-                    "pieceId": "gator",
-                    "offset": 18.56999969482422,
-                    "spacing": 9.5,
-                    "phase": 242
+                    "pieceId": "bench",
+                    "column": 11
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.399999976158142,
-            "objects": [
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 9.819999694824219,
-                    "spacing": 10.5,
-                    "phase": 0
+                    "pieceId": "bench",
+                    "column": 10
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 23
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
             "kind": "river",
-            "dir": "left",
-            "speed": 1.1299999952316285,
+            "dir": "right",
+            "speed": 1.3700000047683716,
             "objects": [
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 18.799999237060548,
-                    "spacing": 21.0,
-                    "phase": 153
-                },
-                {
-                    "pieceId": "log-long",
-                    "offset": 8.300000190734864,
-                    "spacing": 21.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.3600000143051148,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 16.309999465942384,
+                    "pieceId": "log",
+                    "offset": 7.659999847412109,
                     "spacing": 8.5,
                     "phase": 0
                 }
@@ -105,16 +85,38 @@
         {
             "kind": "road",
             "dir": "right",
-            "speed": 1.559999942779541,
+            "speed": 1.8600000143051148,
             "objects": [
                 {
-                    "pieceId": "car",
-                    "offset": 13.149999618530274,
-                    "spacing": 7.5,
+                    "pieceId": "bus",
+                    "offset": 23.59000015258789,
+                    "spacing": 16.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "bus",
+                    "offset": 31.59000015258789,
+                    "spacing": 16.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-fern",
+                    "column": 13
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 16
+                }
+            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-023.json
+++ b/Assets/Resources/Levels/level-023.json
@@ -1,16 +1,16 @@
 {
     "id": "level-023",
     "name": "level-023",
-    "columns": 11,
+    "columns": 23,
     "medal": {
-        "gold": 37.599998474121097,
-        "silver": 54.5,
-        "bronze": 78.9000015258789
+        "gold": 13.600000381469727,
+        "silver": 19.799999237060548,
+        "bronze": 28.600000381469728
     },
-    "startColumn": 8,
+    "startColumn": 1,
     "bays": [
-        3,
-        5
+        4,
+        7
     ],
     "rows": [
         {
@@ -21,21 +21,35 @@
             "obstructions": []
         },
         {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.3600000143051148,
+            "kind": "road",
+            "dir": "left",
+            "speed": 1.5800000429153443,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 7.0,
-                    "spacing": 23.0,
+                    "pieceId": "truck",
+                    "offset": 22.219999313354493,
+                    "spacing": 16.5,
                     "phase": 0
                 },
                 {
-                    "pieceId": "log-short",
-                    "offset": 18.5,
-                    "spacing": 23.0,
+                    "pieceId": "bus",
+                    "offset": 30.469999313354493,
+                    "spacing": 16.5,
                     "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.4199999570846558,
+            "objects": [
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 11.109999656677246,
+                    "spacing": 8.25,
+                    "phase": 196
                 }
             ],
             "obstructions": []
@@ -43,33 +57,19 @@
         {
             "kind": "swamp",
             "dir": "left",
-            "speed": 1.1299999952316285,
+            "speed": 1.159999966621399,
             "objects": [
                 {
                     "pieceId": "log",
-                    "offset": 20.510000228881837,
-                    "spacing": 21.0,
+                    "offset": 9.6899995803833,
+                    "spacing": 33.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "log-short",
-                    "offset": 10.010000228881836,
-                    "spacing": 21.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.100000023841858,
-            "objects": [
-                {
                     "pieceId": "gator",
-                    "offset": 18.059999465942384,
-                    "spacing": 10.5,
-                    "phase": 273
+                    "offset": 26.190000534057618,
+                    "spacing": 33.0,
+                    "phase": 89
                 }
             ],
             "obstructions": []
@@ -79,30 +79,64 @@
             "dir": "",
             "speed": 0.0,
             "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": []
+            "obstructions": [
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 10
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 11
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 13
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 21
+                }
+            ]
         },
         {
             "kind": "river",
             "dir": "left",
-            "speed": 1.3700000047683716,
+            "speed": 1.1100000143051148,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 16.43000030517578,
-                    "spacing": 23.0,
+                    "pieceId": "log-long",
+                    "offset": 7.489999771118164,
+                    "spacing": 17.5,
                     "phase": 0
                 },
                 {
-                    "pieceId": "log-long",
-                    "offset": 4.929999828338623,
-                    "spacing": 23.0,
+                    "pieceId": "log-short",
+                    "offset": 16.239999771118165,
+                    "spacing": 17.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 1.4900000095367432,
+            "objects": [
+                {
+                    "pieceId": "bus",
+                    "offset": 9.529999732971192,
+                    "spacing": 15.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "convertible",
+                    "offset": 17.280000686645509,
+                    "spacing": 15.5,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-024.json
+++ b/Assets/Resources/Levels/level-024.json
@@ -1,16 +1,16 @@
 {
     "id": "level-024",
     "name": "level-024",
-    "columns": 9,
+    "columns": 23,
     "medal": {
-        "gold": 16.399999618530275,
-        "silver": 23.799999237060548,
-        "bronze": 34.400001525878909
+        "gold": 18.100000381469728,
+        "silver": 26.200000762939454,
+        "bronze": 38.0
     },
-    "startColumn": 3,
+    "startColumn": 17,
     "bays": [
-        4,
-        8
+        6,
+        19
     ],
     "rows": [
         {
@@ -21,87 +21,33 @@
             "obstructions": []
         },
         {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.159999966621399,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 1.059999942779541,
-                    "spacing": 19.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log",
-                    "offset": 10.5600004196167,
-                    "spacing": 19.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.340000033378601,
-            "objects": [
-                {
-                    "pieceId": "gator",
-                    "offset": 18.540000915527345,
-                    "spacing": 19.0,
-                    "phase": 301
-                },
-                {
-                    "pieceId": "gator",
-                    "offset": 9.039999961853028,
-                    "spacing": 19.0,
-                    "phase": 107
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.5399999618530274,
-            "objects": [
-                {
-                    "pieceId": "truck",
-                    "offset": 2.240000009536743,
-                    "spacing": 9.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
             "kind": "grass",
             "dir": "",
             "speed": 0.0,
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-tulip",
-                    "column": 5
+                    "pieceId": "planter-daisy",
+                    "column": 2
                 }
             ]
         },
         {
             "kind": "swamp",
-            "dir": "left",
-            "speed": 1.3300000429153443,
+            "dir": "right",
+            "speed": 1.350000023841858,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 7.409999847412109,
-                    "spacing": 21.0,
+                    "pieceId": "log",
+                    "offset": 7.239999771118164,
+                    "spacing": 16.5,
                     "phase": 0
                 },
                 {
-                    "pieceId": "gator",
-                    "offset": 17.90999984741211,
-                    "spacing": 21.0,
-                    "phase": 317
+                    "pieceId": "log-short",
+                    "offset": 15.489999771118164,
+                    "spacing": 16.5,
+                    "phase": 0
                 }
             ],
             "obstructions": []
@@ -109,18 +55,66 @@
         {
             "kind": "swamp",
             "dir": "left",
-            "speed": 1.090000033378601,
+            "speed": 1.2799999713897706,
+            "objects": [
+                {
+                    "pieceId": "log-short",
+                    "offset": 22.280000686645509,
+                    "spacing": 7.75,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.409999966621399,
             "objects": [
                 {
                     "pieceId": "gator",
-                    "offset": 16.25,
-                    "spacing": 19.0,
-                    "phase": 188
+                    "offset": 21.84000015258789,
+                    "spacing": 16.5,
+                    "phase": 32
                 },
                 {
+                    "pieceId": "raft",
+                    "offset": 30.09000015258789,
+                    "spacing": 16.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.2000000476837159,
+            "objects": [
+                {
                     "pieceId": "log-short",
-                    "offset": 6.75,
-                    "spacing": 19.0,
+                    "offset": 32.97999954223633,
+                    "spacing": 16.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log",
+                    "offset": 8.229999542236329,
+                    "spacing": 16.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.2699999809265137,
+            "objects": [
+                {
+                    "pieceId": "log-short",
+                    "offset": 3.700000047683716,
+                    "spacing": 7.75,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-025.json
+++ b/Assets/Resources/Levels/level-025.json
@@ -1,16 +1,16 @@
 {
     "id": "level-025",
     "name": "level-025",
-    "columns": 10,
+    "columns": 24,
     "medal": {
-        "gold": 100.30000305175781,
-        "silver": 145.39999389648438,
-        "bronze": 210.60000610351563
+        "gold": 49.599998474121097,
+        "silver": 71.9000015258789,
+        "bronze": 104.0999984741211
     },
-    "startColumn": 1,
+    "startColumn": 17,
     "bays": [
-        2,
-        4
+        9,
+        14
     ],
     "rows": [
         {
@@ -27,8 +27,8 @@
             "objects": [
                 {
                     "pieceId": "log-short",
-                    "offset": 8.609999656677246,
-                    "spacing": 9.0,
+                    "offset": 15.3100004196167,
+                    "spacing": 8.0,
                     "phase": 0
                 }
             ],
@@ -41,8 +41,8 @@
             "objects": [
                 {
                     "pieceId": "gator",
-                    "offset": 13.149999618530274,
-                    "spacing": 10.0,
+                    "offset": 22.350000381469728,
+                    "spacing": 8.5,
                     "phase": 266
                 }
             ],
@@ -55,14 +55,14 @@
             "objects": [
                 {
                     "pieceId": "turtle-log",
-                    "offset": 17.43000030517578,
-                    "spacing": 20.0,
+                    "offset": 29.6299991607666,
+                    "spacing": 17.0,
                     "phase": 5
                 },
                 {
                     "pieceId": "gator",
-                    "offset": 7.429999828338623,
-                    "spacing": 20.0,
+                    "offset": 4.130000114440918,
+                    "spacing": 17.0,
                     "phase": 370
                 }
             ],
@@ -75,14 +75,14 @@
             "objects": [
                 {
                     "pieceId": "log-short",
-                    "offset": 0.029999999329447748,
-                    "spacing": 20.0,
+                    "offset": 0.05000000074505806,
+                    "spacing": 17.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "gator",
-                    "offset": 10.029999732971192,
-                    "spacing": 20.0,
+                    "offset": 8.550000190734864,
+                    "spacing": 17.0,
                     "phase": 379
                 }
             ],
@@ -95,8 +95,8 @@
             "objects": [
                 {
                     "pieceId": "log-long",
-                    "offset": 11.4399995803833,
-                    "spacing": 11.0,
+                    "offset": 18.719999313354493,
+                    "spacing": 9.0,
                     "phase": 0
                 }
             ],
@@ -109,14 +109,14 @@
             "objects": [
                 {
                     "pieceId": "car",
-                    "offset": 15.819999694824219,
-                    "spacing": 20.0,
+                    "offset": 26.899999618530275,
+                    "spacing": 17.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "truck",
-                    "offset": 5.820000171661377,
-                    "spacing": 20.0,
+                    "offset": 1.399999976158142,
+                    "spacing": 17.0,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-026.json
+++ b/Assets/Resources/Levels/level-026.json
@@ -1,17 +1,17 @@
 {
     "id": "level-026",
     "name": "level-026",
-    "columns": 12,
+    "columns": 26,
     "medal": {
-        "gold": 27.399999618530275,
-        "silver": 39.70000076293945,
-        "bronze": 57.599998474121097
+        "gold": 38.5,
+        "silver": 55.900001525878909,
+        "bronze": 80.9000015258789
     },
-    "startColumn": 7,
+    "startColumn": 22,
     "bays": [
-        4,
-        7,
-        9
+        3,
+        6,
+        10
     ],
     "rows": [
         {
@@ -29,20 +29,108 @@
             "obstructions": []
         },
         {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "bush",
+                    "column": 1
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 15
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 20
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 25
+                }
+            ]
+        },
+        {
             "kind": "road",
             "dir": "right",
             "speed": 2.049999952316284,
             "objects": [
                 {
-                    "pieceId": "convertible",
-                    "offset": 3.240000009536743,
-                    "spacing": 22.0,
+                    "pieceId": "truck",
+                    "offset": 7.300000190734863,
+                    "spacing": 18.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "truck",
-                    "offset": 14.239999771118164,
-                    "spacing": 22.0,
+                    "pieceId": "car",
+                    "offset": 16.299999237060548,
+                    "spacing": 18.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.1200000047683716,
+            "objects": [
+                {
+                    "pieceId": "gator",
+                    "offset": 22.290000915527345,
+                    "spacing": 18.0,
+                    "phase": 331
+                },
+                {
+                    "pieceId": "log-short",
+                    "offset": 31.290000915527345,
+                    "spacing": 18.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.059999942779541,
+            "objects": [
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 9.520000457763672,
+                    "spacing": 18.0,
+                    "phase": 317
+                },
+                {
+                    "pieceId": "raft",
+                    "offset": 18.520000457763673,
+                    "spacing": 18.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 1.8200000524520875,
+            "objects": [
+                {
+                    "pieceId": "bus",
+                    "offset": 3.740000009536743,
+                    "spacing": 17.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 12.239999771118164,
+                    "spacing": 17.0,
                     "phase": 0
                 }
             ],
@@ -51,87 +139,13 @@
         {
             "kind": "swamp",
             "dir": "right",
-            "speed": 1.149999976158142,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 15.34000015258789,
-                    "spacing": 22.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "gator",
-                    "offset": 4.340000152587891,
-                    "spacing": 22.0,
-                    "phase": 27
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "left",
-            "speed": 1.6100000143051148,
-            "objects": [
-                {
-                    "pieceId": "truck",
-                    "offset": 3.3499999046325685,
-                    "spacing": 11.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.1699999570846558,
+            "speed": 1.3700000047683716,
             "objects": [
                 {
                     "pieceId": "log-long",
-                    "offset": 4.760000228881836,
-                    "spacing": 24.0,
+                    "offset": 28.90999984741211,
+                    "spacing": 9.5,
                     "phase": 0
-                },
-                {
-                    "pieceId": "log",
-                    "offset": 16.760000228881837,
-                    "spacing": 24.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.7699999809265137,
-            "objects": [
-                {
-                    "pieceId": "car",
-                    "offset": 6.289999961853027,
-                    "spacing": 20.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "bus",
-                    "offset": 16.290000915527345,
-                    "spacing": 20.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.350000023841858,
-            "objects": [
-                {
-                    "pieceId": "gator",
-                    "offset": 2.8399999141693117,
-                    "spacing": 11.0,
-                    "phase": 213
                 }
             ],
             "obstructions": []

--- a/Assets/Resources/Levels/level-027.json
+++ b/Assets/Resources/Levels/level-027.json
@@ -1,17 +1,17 @@
 {
     "id": "level-027",
     "name": "level-027",
-    "columns": 12,
+    "columns": 24,
     "medal": {
-        "gold": 71.0999984741211,
-        "silver": 103.0999984741211,
-        "bronze": 149.3000030517578
+        "gold": 40.5,
+        "silver": 58.70000076293945,
+        "bronze": 85.0
     },
-    "startColumn": 9,
+    "startColumn": 11,
     "bays": [
-        1,
-        9,
-        11
+        5,
+        6,
+        23
     ],
     "rows": [
         {
@@ -22,54 +22,34 @@
             "obstructions": []
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.649999976158142,
-            "objects": [
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
                 {
-                    "pieceId": "bus",
-                    "offset": 0.7099999785423279,
-                    "spacing": 10.0,
-                    "phase": 0
+                    "pieceId": "planter-lavender",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 10
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 18
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
             "kind": "swamp",
             "dir": "left",
-            "speed": 1.1200000047683716,
+            "speed": 1.190000057220459,
             "objects": [
-                {
-                    "pieceId": "gator",
-                    "offset": 17.010000228881837,
-                    "spacing": 22.0,
-                    "phase": 249
-                },
-                {
-                    "pieceId": "raft",
-                    "offset": 6.010000228881836,
-                    "spacing": 22.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.440000057220459,
-            "objects": [
-                {
-                    "pieceId": "log",
-                    "offset": 0.6200000047683716,
-                    "spacing": 24.0,
-                    "phase": 0
-                },
                 {
                     "pieceId": "log-long",
-                    "offset": 12.619999885559082,
-                    "spacing": 24.0,
+                    "offset": 7.489999771118164,
+                    "spacing": 9.0,
                     "phase": 0
                 }
             ],
@@ -82,48 +62,91 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "bench",
-                    "column": 9
+                    "pieceId": "planter-tulip",
+                    "column": 3
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 17
                 }
             ]
         },
         {
             "kind": "river",
             "dir": "left",
-            "speed": 1.25,
+            "speed": 1.100000023841858,
             "objects": [
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 17.190000534057618,
-                    "spacing": 22.0,
-                    "phase": 146
+                    "pieceId": "log",
+                    "offset": 0.3199999928474426,
+                    "spacing": 17.0,
+                    "phase": 0
                 },
                 {
-                    "pieceId": "gator",
-                    "offset": 6.190000057220459,
-                    "spacing": 22.0,
-                    "phase": 324
+                    "pieceId": "log-short",
+                    "offset": 8.819999694824219,
+                    "spacing": 17.0,
+                    "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.1100000143051148,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 20.739999771118165,
+                    "spacing": 17.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log-short",
+                    "offset": 29.239999771118165,
+                    "spacing": 17.0,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {
             "kind": "swamp",
-            "dir": "left",
-            "speed": 1.3799999952316285,
+            "dir": "right",
+            "speed": 1.440000057220459,
             "objects": [
                 {
                     "pieceId": "log-long",
-                    "offset": 3.819999933242798,
-                    "spacing": 12.0,
+                    "offset": 18.540000915527345,
+                    "spacing": 18.0,
                     "phase": 0
+                },
+                {
+                    "pieceId": "raft",
+                    "offset": 27.540000915527345,
+                    "spacing": 18.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.309999942779541,
+            "objects": [
+                {
+                    "pieceId": "log-long",
+                    "offset": 7.110000133514404,
+                    "spacing": 36.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "gator",
+                    "offset": 25.110000610351564,
+                    "spacing": 36.0,
+                    "phase": 41
                 }
             ],
             "obstructions": []

--- a/Assets/Resources/Levels/level-028.json
+++ b/Assets/Resources/Levels/level-028.json
@@ -1,17 +1,17 @@
 {
     "id": "level-028",
     "name": "level-028",
-    "columns": 12,
+    "columns": 24,
     "medal": {
-        "gold": 21.299999237060548,
-        "silver": 30.899999618530275,
-        "bronze": 44.79999923706055
+        "gold": 40.599998474121097,
+        "silver": 58.900001525878909,
+        "bronze": 85.4000015258789
     },
-    "startColumn": 5,
+    "startColumn": 15,
     "bays": [
-        2,
-        3,
-        7
+        5,
+        9,
+        18
     ],
     "rows": [
         {
@@ -22,33 +22,27 @@
             "obstructions": []
         },
         {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.1399999856948853,
+            "kind": "road",
+            "dir": "left",
+            "speed": 1.9500000476837159,
             "objects": [
                 {
-                    "pieceId": "raft",
-                    "offset": 17.540000915527345,
-                    "spacing": 22.0,
+                    "pieceId": "bus",
+                    "offset": 24.079999923706056,
+                    "spacing": 8.0,
                     "phase": 0
-                },
-                {
-                    "pieceId": "gator",
-                    "offset": 6.539999961853027,
-                    "spacing": 22.0,
-                    "phase": 366
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.5199999809265137,
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.4700000286102296,
             "objects": [
                 {
                     "pieceId": "log-long",
-                    "offset": 5.119999885559082,
+                    "offset": 30.399999618530275,
                     "spacing": 12.0,
                     "phase": 0
                 }
@@ -58,11 +52,11 @@
         {
             "kind": "road",
             "dir": "right",
-            "speed": 2.0199999809265138,
+            "speed": 1.5700000524520875,
             "objects": [
                 {
-                    "pieceId": "car",
-                    "offset": 1.5199999809265137,
+                    "pieceId": "convertible",
+                    "offset": 9.789999961853028,
                     "spacing": 6.0,
                     "phase": 0
                 }
@@ -72,26 +66,12 @@
         {
             "kind": "swamp",
             "dir": "right",
-            "speed": 1.5499999523162842,
+            "speed": 1.1799999475479127,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 8.109999656677246,
-                    "spacing": 6.670000076293945,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "left",
-            "speed": 1.690000057220459,
-            "objects": [
-                {
-                    "pieceId": "bus",
-                    "offset": 19.969999313354493,
-                    "spacing": 6.670000076293945,
+                    "pieceId": "log-long",
+                    "offset": 27.110000610351564,
+                    "spacing": 12.0,
                     "phase": 0
                 }
             ],
@@ -100,33 +80,41 @@
         {
             "kind": "river",
             "dir": "left",
-            "speed": 1.2999999523162842,
+            "speed": 1.4600000381469727,
             "objects": [
                 {
                     "pieceId": "turtle-log",
-                    "offset": 14.829999923706055,
-                    "spacing": 11.0,
-                    "phase": 106
+                    "offset": 13.119999885559082,
+                    "spacing": 8.5,
+                    "phase": 172
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "river",
+            "kind": "swamp",
             "dir": "left",
-            "speed": 1.1100000143051148,
+            "speed": 1.190000057220459,
             "objects": [
                 {
-                    "pieceId": "raft",
-                    "offset": 3.8299999237060549,
-                    "spacing": 22.0,
+                    "pieceId": "log-short",
+                    "offset": 7.090000152587891,
+                    "spacing": 8.0,
                     "phase": 0
-                },
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.2899999618530274,
+            "objects": [
                 {
-                    "pieceId": "gator",
-                    "offset": 14.829999923706055,
-                    "spacing": 22.0,
-                    "phase": 149
+                    "pieceId": "turtle-log",
+                    "offset": 9.670000076293946,
+                    "spacing": 8.5,
+                    "phase": 113
                 }
             ],
             "obstructions": []

--- a/Assets/Resources/Levels/level-029.json
+++ b/Assets/Resources/Levels/level-029.json
@@ -1,17 +1,17 @@
 {
     "id": "level-029",
     "name": "level-029",
-    "columns": 9,
+    "columns": 23,
     "medal": {
-        "gold": 31.799999237060548,
-        "silver": 46.0,
-        "bronze": 66.69999694824219
+        "gold": 25.100000381469728,
+        "silver": 36.400001525878909,
+        "bronze": 52.70000076293945
     },
-    "startColumn": 7,
+    "startColumn": 18,
     "bays": [
-        3,
-        5,
-        7
+        14,
+        16,
+        21
     ],
     "rows": [
         {
@@ -30,49 +30,20 @@
                 {
                     "pieceId": "planter-tulip",
                     "column": 2
-                }
-            ]
-        },
-        {
-            "kind": "road",
-            "dir": "left",
-            "speed": 2.009999990463257,
-            "objects": [
-                {
-                    "pieceId": "truck",
-                    "offset": 5.329999923706055,
-                    "spacing": 9.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.1699999570846558,
-            "objects": [
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 6.809999942779541,
-                    "spacing": 19.0,
-                    "phase": 260
                 },
                 {
-                    "pieceId": "raft",
-                    "offset": 16.309999465942384,
-                    "spacing": 19.0,
-                    "phase": 0
+                    "pieceId": "planter-succulent",
+                    "column": 10
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 11
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 12
                 }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": []
+            ]
         },
         {
             "kind": "grass",
@@ -82,47 +53,115 @@
             "obstructions": [
                 {
                     "pieceId": "planter-tulip",
-                    "column": 2
+                    "column": 11
                 },
                 {
                     "pieceId": "planter-succulent",
-                    "column": 6
+                    "column": 15
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 21
                 }
             ]
         },
         {
             "kind": "river",
-            "dir": "left",
-            "speed": 1.190000057220459,
+            "dir": "right",
+            "speed": 1.559999942779541,
             "objects": [
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 10.779999732971192,
-                    "spacing": 9.5,
-                    "phase": 238
+                    "pieceId": "log-long",
+                    "offset": 1.340000033378601,
+                    "spacing": 11.670000076293946,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.2100000381469727,
+            "objects": [
+                {
+                    "pieceId": "log-long",
+                    "offset": 25.549999237060548,
+                    "spacing": 35.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "raft",
+                    "offset": 8.050000190734864,
+                    "spacing": 35.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 1.6399999856948853,
+            "objects": [
+                {
+                    "pieceId": "bus",
+                    "offset": 10.59000015258789,
+                    "spacing": 15.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 18.34000015258789,
+                    "spacing": 15.5,
+                    "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
             "kind": "swamp",
-            "dir": "left",
-            "speed": 1.3200000524520875,
+            "dir": "right",
+            "speed": 1.3899999856948853,
             "objects": [
                 {
-                    "pieceId": "gator",
-                    "offset": 4.679999828338623,
-                    "spacing": 19.0,
-                    "phase": 243
+                    "pieceId": "raft",
+                    "offset": 10.199999809265137,
+                    "spacing": 16.5,
+                    "phase": 0
                 },
                 {
-                    "pieceId": "log-short",
-                    "offset": 14.180000305175782,
-                    "spacing": 19.0,
+                    "pieceId": "raft",
+                    "offset": 18.450000762939454,
+                    "spacing": 16.5,
                     "phase": 0
                 }
             ],
             "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "lamp",
+                    "column": 8
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 9
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 17
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 22
+                }
+            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-030.json
+++ b/Assets/Resources/Levels/level-030.json
@@ -1,17 +1,17 @@
 {
     "id": "level-030",
     "name": "level-030",
-    "columns": 9,
+    "columns": 23,
     "medal": {
-        "gold": 21.799999237060548,
-        "silver": 31.600000381469728,
-        "bronze": 45.79999923706055
+        "gold": 59.70000076293945,
+        "silver": 86.5999984741211,
+        "bronze": 125.4000015258789
     },
-    "startColumn": 2,
+    "startColumn": 9,
     "bays": [
-        1,
-        2,
-        7
+        5,
+        19,
+        21
     ],
     "rows": [
         {
@@ -22,41 +22,21 @@
             "obstructions": []
         },
         {
-            "kind": "road",
-            "dir": "left",
-            "speed": 2.0,
-            "objects": [
-                {
-                    "pieceId": "car",
-                    "offset": 17.690000534057618,
-                    "spacing": 19.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "truck",
-                    "offset": 8.1899995803833,
-                    "spacing": 19.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
             "kind": "river",
-            "dir": "left",
-            "speed": 1.149999976158142,
+            "dir": "right",
+            "speed": 1.3799999952316285,
             "objects": [
                 {
-                    "pieceId": "raft",
-                    "offset": 11.239999771118164,
-                    "spacing": 19.0,
+                    "pieceId": "log",
+                    "offset": 22.059999465942384,
+                    "spacing": 16.5,
                     "phase": 0
                 },
                 {
                     "pieceId": "turtle-log",
-                    "offset": 1.7400000095367432,
-                    "spacing": 19.0,
-                    "phase": 55
+                    "offset": 30.309999465942384,
+                    "spacing": 16.5,
+                    "phase": 23
                 }
             ],
             "obstructions": []
@@ -64,75 +44,107 @@
         {
             "kind": "swamp",
             "dir": "left",
-            "speed": 1.5399999618530274,
+            "speed": 1.5800000429153443,
+            "objects": [
+                {
+                    "pieceId": "gator",
+                    "offset": 27.450000762939454,
+                    "spacing": 8.25,
+                    "phase": 93
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.2799999713897706,
+            "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 9.470000267028809,
+                    "spacing": 16.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log",
+                    "offset": 17.719999313354493,
+                    "spacing": 16.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.1399999856948853,
             "objects": [
                 {
                     "pieceId": "log-long",
-                    "offset": 12.069999694824219,
-                    "spacing": 10.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.2400000095367432,
-            "objects": [
-                {
-                    "pieceId": "raft",
-                    "offset": 0.7200000286102295,
-                    "spacing": 9.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.4199999570846558,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 10.760000228881836,
-                    "spacing": 8.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.5099999904632569,
-            "objects": [
-                {
-                    "pieceId": "raft",
-                    "offset": 8.0600004196167,
-                    "spacing": 9.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.2400000095367432,
-            "objects": [
-                {
-                    "pieceId": "raft",
-                    "offset": 8.229999542236329,
-                    "spacing": 19.0,
+                    "offset": 32.970001220703128,
+                    "spacing": 17.5,
                     "phase": 0
                 },
                 {
                     "pieceId": "turtle-log",
-                    "offset": 17.729999542236329,
-                    "spacing": 19.0,
-                    "phase": 84
+                    "offset": 6.71999979019165,
+                    "spacing": 17.5,
+                    "phase": 238
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.440000057220459,
+            "objects": [
+                {
+                    "pieceId": "gator",
+                    "offset": 12.350000381469727,
+                    "spacing": 35.0,
+                    "phase": 314
+                },
+                {
+                    "pieceId": "log-long",
+                    "offset": 29.850000381469728,
+                    "spacing": 35.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.5099999904632569,
+            "objects": [
+                {
+                    "pieceId": "log-short",
+                    "offset": 10.350000381469727,
+                    "spacing": 16.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "gator",
+                    "offset": 18.600000381469728,
+                    "spacing": 16.5,
+                    "phase": 227
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.440000057220459,
+            "objects": [
+                {
+                    "pieceId": "log-short",
+                    "offset": 9.819999694824219,
+                    "spacing": 7.75,
+                    "phase": 0
                 }
             ],
             "obstructions": []

--- a/Assets/Resources/Levels/level-031.json
+++ b/Assets/Resources/Levels/level-031.json
@@ -1,16 +1,16 @@
 {
     "id": "level-031",
     "name": "level-031",
-    "columns": 10,
+    "columns": 23,
     "medal": {
-        "gold": 21.799999237060548,
-        "silver": 31.600000381469728,
-        "bronze": 45.79999923706055
+        "gold": 14.5,
+        "silver": 21.0,
+        "bronze": 30.399999618530275
     },
-    "startColumn": 7,
+    "startColumn": 9,
     "bays": [
-        2,
-        5
+        12,
+        15
     ],
     "rows": [
         {
@@ -21,48 +21,66 @@
             "obstructions": []
         },
         {
-            "kind": "tracks",
+            "kind": "river",
             "dir": "right",
-            "speed": 1.7999999523162842,
+            "speed": 1.350000023841858,
             "objects": [
                 {
-                    "pieceId": "passenger",
-                    "offset": 2.859999895095825,
-                    "spacing": 17.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "left",
-            "speed": 1.5299999713897706,
-            "objects": [
-                {
-                    "pieceId": "bus",
-                    "offset": 0.5699999928474426,
-                    "spacing": 18.0,
-                    "phase": 0
+                    "pieceId": "turtle-log",
+                    "offset": 10.34000015258789,
+                    "spacing": 16.5,
+                    "phase": 195
                 },
                 {
-                    "pieceId": "convertible",
-                    "offset": 9.569999694824219,
-                    "spacing": 18.0,
-                    "phase": 0
+                    "pieceId": "gator",
+                    "offset": 18.59000015258789,
+                    "spacing": 16.5,
+                    "phase": 78
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "swamp",
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 16
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 17
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 19
+                }
+            ]
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 15
+                }
+            ]
+        },
+        {
+            "kind": "tracks",
             "dir": "left",
-            "speed": 1.1299999952316285,
+            "speed": 1.7100000381469727,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 11.229999542236329,
-                    "spacing": 11.0,
+                    "pieceId": "freight",
+                    "offset": 1.7699999809265137,
+                    "spacing": 15.670000076293946,
                     "phase": 0
                 }
             ],
@@ -73,32 +91,31 @@
             "dir": "",
             "speed": 0.0,
             "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 1.6299999952316285,
-            "objects": [
+            "obstructions": [
                 {
-                    "pieceId": "passenger",
-                    "offset": 0.12999999523162843,
-                    "spacing": 17.0,
-                    "phase": 0
+                    "pieceId": "bench",
+                    "column": 7
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 9
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 15
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.7699999809265137,
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.4600000381469727,
             "objects": [
                 {
-                    "pieceId": "car",
-                    "offset": 15.770000457763672,
-                    "spacing": 8.0,
-                    "phase": 0
+                    "pieceId": "turtle-log",
+                    "offset": 2.7300000190734865,
+                    "spacing": 8.25,
+                    "phase": 46
                 }
             ],
             "obstructions": []

--- a/Assets/Resources/Levels/level-032.json
+++ b/Assets/Resources/Levels/level-032.json
@@ -1,16 +1,16 @@
 {
     "id": "level-032",
     "name": "level-032",
-    "columns": 11,
+    "columns": 26,
     "medal": {
-        "gold": 17.700000762939454,
-        "silver": 25.700000762939454,
-        "bronze": 37.20000076293945
+        "gold": 42.400001525878909,
+        "silver": 61.5,
+        "bronze": 89.0999984741211
     },
-    "startColumn": 4,
+    "startColumn": 17,
     "bays": [
-        3,
-        9
+        2,
+        22
     ],
     "rows": [
         {
@@ -27,8 +27,8 @@
             "objects": [
                 {
                     "pieceId": "passenger",
-                    "offset": 26.899999618530275,
-                    "spacing": 17.5,
+                    "offset": 38.41999816894531,
+                    "spacing": 16.670000076293947,
                     "phase": 0
                 }
             ],
@@ -41,8 +41,8 @@
             "objects": [
                 {
                     "pieceId": "freight",
-                    "offset": 33.41999816894531,
-                    "spacing": 17.5,
+                    "offset": 47.75,
+                    "spacing": 16.670000076293947,
                     "phase": 0
                 }
             ],
@@ -55,8 +55,8 @@
             "objects": [
                 {
                     "pieceId": "log-long",
-                    "offset": 6.730000019073486,
-                    "spacing": 11.5,
+                    "offset": 11.119999885559082,
+                    "spacing": 9.5,
                     "phase": 0
                 }
             ],
@@ -69,8 +69,8 @@
             "objects": [
                 {
                     "pieceId": "freight",
-                    "offset": 33.5,
-                    "spacing": 17.5,
+                    "offset": 47.86000061035156,
+                    "spacing": 16.670000076293947,
                     "phase": 0
                 }
             ],
@@ -83,14 +83,14 @@
             "objects": [
                 {
                     "pieceId": "gator",
-                    "offset": 19.950000762939454,
-                    "spacing": 21.0,
+                    "offset": 34.20000076293945,
+                    "spacing": 18.0,
                     "phase": 149
                 },
                 {
                     "pieceId": "raft",
-                    "offset": 9.449999809265137,
-                    "spacing": 21.0,
+                    "offset": 7.199999809265137,
+                    "spacing": 18.0,
                     "phase": 0
                 }
             ],
@@ -103,14 +103,14 @@
             "objects": [
                 {
                     "pieceId": "raft",
-                    "offset": 11.920000076293946,
-                    "spacing": 21.0,
+                    "offset": 20.440000534057618,
+                    "spacing": 18.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "raft",
-                    "offset": 1.4199999570846558,
-                    "spacing": 21.0,
+                    "offset": 29.440000534057618,
+                    "spacing": 18.0,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-033.json
+++ b/Assets/Resources/Levels/level-033.json
@@ -1,16 +1,16 @@
 {
     "id": "level-033",
     "name": "level-033",
-    "columns": 11,
+    "columns": 29,
     "medal": {
-        "gold": 16.100000381469728,
-        "silver": 23.299999237060548,
-        "bronze": 33.79999923706055
+        "gold": 15.699999809265137,
+        "silver": 22.799999237060548,
+        "bronze": 33.0
     },
-    "startColumn": 5,
+    "startColumn": 10,
     "bays": [
-        0,
-        1
+        1,
+        5
     ],
     "rows": [
         {
@@ -21,20 +21,48 @@
             "obstructions": []
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.6100000143051148,
-            "objects": [
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
                 {
-                    "pieceId": "convertible",
-                    "offset": 3.869999885559082,
-                    "spacing": 21.0,
-                    "phase": 0
+                    "pieceId": "planter-fern",
+                    "column": 3
                 },
                 {
-                    "pieceId": "truck",
-                    "offset": 14.369999885559082,
-                    "spacing": 21.0,
+                    "pieceId": "planter-lavender",
+                    "column": 6
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 20
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 25
+                }
+            ]
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.2799999713897706,
+            "objects": [
+                {
+                    "pieceId": "gator",
+                    "offset": 34.099998474121097,
+                    "spacing": 19.5,
+                    "phase": 47
+                },
+                {
+                    "pieceId": "raft",
+                    "offset": 4.849999904632568,
+                    "spacing": 19.5,
                     "phase": 0
                 }
             ],
@@ -42,33 +70,31 @@
         },
         {
             "kind": "tracks",
-            "dir": "left",
-            "speed": 1.7999999523162842,
+            "dir": "right",
+            "speed": 1.8200000524520875,
             "objects": [
                 {
                     "pieceId": "passenger",
-                    "offset": 15.710000038146973,
-                    "spacing": 17.5,
+                    "offset": 17.809999465942384,
+                    "spacing": 17.670000076293947,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.5099999904632569,
+            "objects": [
                 {
-                    "pieceId": "planter-tulip",
-                    "column": 3
-                },
-                {
-                    "pieceId": "bush",
-                    "column": 6
+                    "pieceId": "log-short",
+                    "offset": 17.479999542236329,
+                    "spacing": 6.170000076293945,
+                    "phase": 0
                 }
-            ]
+            ],
+            "obstructions": []
         },
         {
             "kind": "grass",
@@ -77,54 +103,38 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "bench",
-                    "column": 6
-                },
-                {
                     "pieceId": "planter-succulent",
                     "column": 7
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 11
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 28
                 }
             ]
         },
         {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.090000033378601,
-            "objects": [
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 16.520000457763673,
-                    "spacing": 21.0,
-                    "phase": 0
+                    "pieceId": "bush",
+                    "column": 9
                 },
                 {
-                    "pieceId": "raft",
-                    "offset": 6.019999980926514,
-                    "spacing": 21.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "left",
-            "speed": 1.6100000143051148,
-            "objects": [
-                {
-                    "pieceId": "convertible",
-                    "offset": 16.860000610351564,
-                    "spacing": 17.0,
-                    "phase": 0
+                    "pieceId": "lamp",
+                    "column": 11
                 },
                 {
-                    "pieceId": "car",
-                    "offset": 8.359999656677246,
-                    "spacing": 17.0,
-                    "phase": 0
+                    "pieceId": "lamp",
+                    "column": 14
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-034.json
+++ b/Assets/Resources/Levels/level-034.json
@@ -1,17 +1,17 @@
 {
     "id": "level-034",
     "name": "level-034",
-    "columns": 10,
+    "columns": 29,
     "medal": {
-        "gold": 15.699999809265137,
-        "silver": 22.799999237060548,
-        "bronze": 33.0
+        "gold": 21.600000381469728,
+        "silver": 31.299999237060548,
+        "bronze": 45.29999923706055
     },
-    "startColumn": 6,
+    "startColumn": 4,
     "bays": [
-        1,
-        3,
-        6
+        6,
+        14,
+        16
     ],
     "rows": [
         {
@@ -22,27 +22,28 @@
             "obstructions": []
         },
         {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.3200000524520875,
+            "objects": [
+                {
+                    "pieceId": "log-long",
+                    "offset": 12.300000190734864,
+                    "spacing": 10.25,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {
-            "kind": "river",
+            "kind": "tracks",
             "dir": "right",
-            "speed": 1.2400000095367432,
+            "speed": 1.9500000476837159,
             "objects": [
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 16.889999389648439,
-                    "spacing": 22.0,
-                    "phase": 323
-                },
-                {
-                    "pieceId": "log-long",
-                    "offset": 5.889999866485596,
-                    "spacing": 22.0,
+                    "pieceId": "freight",
+                    "offset": 52.20000076293945,
+                    "spacing": 17.670000076293947,
                     "phase": 0
                 }
             ],
@@ -55,26 +56,42 @@
             "objects": [],
             "obstructions": [
                 {
+                    "pieceId": "planter-daisy",
+                    "column": 15
+                },
+                {
                     "pieceId": "bush",
-                    "column": 6
+                    "column": 18
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 25
                 }
             ]
         },
         {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.3899999856948853,
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.440000057220459,
             "objects": [
                 {
-                    "pieceId": "log",
-                    "offset": 16.90999984741211,
-                    "spacing": 20.0,
+                    "pieceId": "log-long",
+                    "offset": 30.850000381469728,
+                    "spacing": 10.25,
                     "phase": 0
-                },
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.0399999618530275,
+            "objects": [
                 {
-                    "pieceId": "log",
-                    "offset": 6.909999847412109,
-                    "spacing": 20.0,
+                    "pieceId": "truck",
+                    "offset": 7.980000019073486,
+                    "spacing": 7.800000190734863,
                     "phase": 0
                 }
             ],
@@ -87,44 +104,30 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-succulent",
-                    "column": 1
+                    "pieceId": "lamp",
+                    "column": 7
                 },
                 {
-                    "pieceId": "bush",
-                    "column": 7
+                    "pieceId": "planter-fern",
+                    "column": 24
                 }
             ]
         },
         {
-            "kind": "river",
+            "kind": "road",
             "dir": "right",
-            "speed": 1.4600000381469727,
+            "speed": 1.9800000190734864,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 6.170000076293945,
-                    "spacing": 22.0,
+                    "pieceId": "convertible",
+                    "offset": 20.34000015258789,
+                    "spacing": 19.5,
                     "phase": 0
                 },
                 {
-                    "pieceId": "raft",
-                    "offset": 17.170000076293947,
-                    "spacing": 22.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 1.8300000429153443,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 27.739999771118165,
-                    "spacing": 17.0,
+                    "pieceId": "truck",
+                    "offset": 30.09000015258789,
+                    "spacing": 19.5,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-035.json
+++ b/Assets/Resources/Levels/level-035.json
@@ -1,17 +1,17 @@
 {
     "id": "level-035",
     "name": "level-035",
-    "columns": 10,
+    "columns": 24,
     "medal": {
-        "gold": 14.199999809265137,
-        "silver": 20.600000381469728,
-        "bronze": 29.799999237060548
+        "gold": 31.399999618530275,
+        "silver": 45.5,
+        "bronze": 65.9000015258789
     },
-    "startColumn": 3,
+    "startColumn": 13,
     "bays": [
-        5,
-        6,
-        7
+        3,
+        7,
+        8
     ],
     "rows": [
         {
@@ -30,38 +30,10 @@
                 {
                     "pieceId": "planter-daisy",
                     "column": 1
-                }
-            ]
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.409999966621399,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 11.229999542236329,
-                    "spacing": 20.0,
-                    "phase": 0
                 },
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 1.2300000190734864,
-                    "spacing": 20.0,
-                    "phase": 119
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
                     "pieceId": "planter-fern",
-                    "column": 0
+                    "column": 20
                 }
             ]
         },
@@ -73,37 +45,17 @@
             "obstructions": [
                 {
                     "pieceId": "planter-lavender",
-                    "column": 1
-                },
-                {
-                    "pieceId": "tree",
-                    "column": 3
+                    "column": 7
                 },
                 {
                     "pieceId": "tree",
                     "column": 9
-                }
-            ]
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.7000000476837159,
-            "objects": [
-                {
-                    "pieceId": "truck",
-                    "offset": 9.880000114440918,
-                    "spacing": 20.0,
-                    "phase": 0
                 },
                 {
-                    "pieceId": "convertible",
-                    "offset": 19.8799991607666,
-                    "spacing": 20.0,
-                    "phase": 0
+                    "pieceId": "tree",
+                    "column": 15
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
             "kind": "tracks",
@@ -112,8 +64,8 @@
             "objects": [
                 {
                     "pieceId": "passenger",
-                    "offset": 33.220001220703128,
-                    "spacing": 17.0,
+                    "offset": 46.900001525878909,
+                    "spacing": 16.0,
                     "phase": 0
                 }
             ],
@@ -126,8 +78,56 @@
             "objects": [
                 {
                     "pieceId": "log-short",
-                    "offset": 4.139999866485596,
-                    "spacing": 6.0,
+                    "offset": 7.349999904632568,
+                    "spacing": 6.400000095367432,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.590000033378601,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 14.100000381469727,
+                    "spacing": 17.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "raft",
+                    "offset": 22.600000381469728,
+                    "spacing": 17.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.5700000524520875,
+            "objects": [
+                {
+                    "pieceId": "log-short",
+                    "offset": 18.209999084472658,
+                    "spacing": 6.400000095367432,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.5299999713897706,
+            "objects": [
+                {
+                    "pieceId": "log-long",
+                    "offset": 2.2100000381469728,
+                    "spacing": 12.0,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-036.json
+++ b/Assets/Resources/Levels/level-036.json
@@ -1,17 +1,17 @@
 {
     "id": "level-036",
     "name": "level-036",
-    "columns": 10,
+    "columns": 24,
     "medal": {
-        "gold": 18.299999237060548,
-        "silver": 26.5,
-        "bronze": 38.400001525878909
+        "gold": 23.0,
+        "silver": 33.400001525878909,
+        "bronze": 48.29999923706055
     },
-    "startColumn": 5,
+    "startColumn": 10,
     "bays": [
-        1,
         3,
-        8
+        14,
+        15
     ],
     "rows": [
         {
@@ -22,74 +22,92 @@
             "obstructions": []
         },
         {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 1.6299999952316285,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 17.209999084472658,
-                    "spacing": 17.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
+            "kind": "road",
             "dir": "right",
-            "speed": 1.4700000286102296,
+            "speed": 2.180000066757202,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 4.110000133514404,
-                    "spacing": 9.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.2100000381469727,
-            "objects": [
-                {
-                    "pieceId": "log-long",
-                    "offset": 11.779999732971192,
-                    "spacing": 22.0,
+                    "pieceId": "bus",
+                    "offset": 17.399999618530275,
+                    "spacing": 16.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "raft",
-                    "offset": 0.7799999713897705,
-                    "spacing": 22.0,
+                    "pieceId": "convertible",
+                    "offset": 25.399999618530275,
+                    "spacing": 16.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "concrete",
+            "kind": "grass",
             "dir": "",
             "speed": 0.0,
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-tulip",
+                    "pieceId": "planter-lavender",
                     "column": 2
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 8
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 14
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 15
                 }
             ]
         },
         {
-            "kind": "tracks",
+            "kind": "road",
             "dir": "left",
-            "speed": 1.7300000190734864,
+            "speed": 1.9800000190734864,
             "objects": [
                 {
-                    "pieceId": "freight",
-                    "offset": 19.530000686645509,
-                    "spacing": 17.0,
+                    "pieceId": "car",
+                    "offset": 16.639999389648439,
+                    "spacing": 6.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "right",
+            "speed": 2.2100000381469728,
+            "objects": [
+                {
+                    "pieceId": "passenger",
+                    "offset": 11.529999732971192,
+                    "spacing": 16.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.3200000524520875,
+            "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 11.699999809265137,
+                    "spacing": 18.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log-long",
+                    "offset": 20.700000762939454,
+                    "spacing": 18.0,
                     "phase": 0
                 }
             ],
@@ -97,33 +115,39 @@
         },
         {
             "kind": "road",
-            "dir": "left",
-            "speed": 1.75,
+            "dir": "right",
+            "speed": 1.690000057220459,
             "objects": [
                 {
-                    "pieceId": "truck",
-                    "offset": 15.6899995803833,
-                    "spacing": 20.0,
+                    "pieceId": "convertible",
+                    "offset": 28.530000686645509,
+                    "spacing": 16.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "bus",
-                    "offset": 5.690000057220459,
-                    "spacing": 20.0,
+                    "offset": 4.53000020980835,
+                    "spacing": 16.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "river",
+            "kind": "swamp",
             "dir": "right",
-            "speed": 1.2799999713897706,
+            "speed": 1.2200000286102296,
             "objects": [
                 {
-                    "pieceId": "raft",
-                    "offset": 1.309999942779541,
-                    "spacing": 6.670000076293945,
+                    "pieceId": "gator",
+                    "offset": 14.819999694824219,
+                    "spacing": 17.0,
+                    "phase": 88
+                },
+                {
+                    "pieceId": "log-short",
+                    "offset": 23.31999969482422,
+                    "spacing": 17.0,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-037.json
+++ b/Assets/Resources/Levels/level-037.json
@@ -1,17 +1,17 @@
 {
     "id": "level-037",
     "name": "level-037",
-    "columns": 11,
+    "columns": 27,
     "medal": {
-        "gold": 24.200000762939454,
-        "silver": 35.0,
-        "bronze": 50.70000076293945
+        "gold": 23.0,
+        "silver": 33.400001525878909,
+        "bronze": 48.29999923706055
     },
-    "startColumn": 9,
+    "startColumn": 12,
     "bays": [
-        3,
-        6,
-        8
+        1,
+        11,
+        19
     ],
     "rows": [
         {
@@ -30,58 +30,29 @@
                 {
                     "pieceId": "planter-tulip",
                     "column": 5
-                }
-            ]
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
+                },
                 {
                     "pieceId": "bush",
-                    "column": 10
+                    "column": 22
                 }
             ]
         },
         {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.4600000381469727,
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.2100000381469727,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 20.149999618530275,
-                    "spacing": 21.0,
+                    "pieceId": "raft",
+                    "offset": 25.40999984741211,
+                    "spacing": 18.5,
                     "phase": 0
                 },
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 9.649999618530274,
-                    "spacing": 21.0,
-                    "phase": 231
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.2000000476837159,
-            "objects": [
-                {
-                    "pieceId": "gator",
-                    "offset": 12.600000381469727,
-                    "spacing": 10.5,
-                    "phase": 82
+                    "pieceId": "log",
+                    "offset": 34.65999984741211,
+                    "spacing": 18.5,
+                    "phase": 0
                 }
             ],
             "obstructions": []
@@ -89,13 +60,27 @@
         {
             "kind": "tracks",
             "dir": "left",
-            "speed": 1.8799999952316285,
+            "speed": 1.809999942779541,
             "objects": [
                 {
                     "pieceId": "freight",
-                    "offset": 24.309999465942384,
-                    "spacing": 17.5,
+                    "offset": 34.279998779296878,
+                    "spacing": 17.0,
                     "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.2699999809265137,
+            "objects": [
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 16.1299991607666,
+                    "spacing": 7.400000095367432,
+                    "phase": 6
                 }
             ],
             "obstructions": []
@@ -107,22 +92,64 @@
             "objects": [],
             "obstructions": [
                 {
+                    "pieceId": "planter-succulent",
+                    "column": 6
+                },
+                {
                     "pieceId": "planter-tulip",
-                    "column": 4
+                    "column": 12
                 },
                 {
                     "pieceId": "tree",
-                    "column": 7
+                    "column": 15
                 },
                 {
                     "pieceId": "planter-succulent",
-                    "column": 9
+                    "column": 17
                 },
                 {
                     "pieceId": "planter-succulent",
-                    "column": 10
+                    "column": 18
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 26
                 }
             ]
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 2.119999885559082,
+            "objects": [
+                {
+                    "pieceId": "bus",
+                    "offset": 23.43000030517578,
+                    "spacing": 17.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "convertible",
+                    "offset": 32.18000030517578,
+                    "spacing": 17.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.6299999952316285,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 14.020000457763672,
+                    "spacing": 7.400000095367432,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-038.json
+++ b/Assets/Resources/Levels/level-038.json
@@ -1,18 +1,18 @@
 {
     "id": "level-038",
     "name": "level-038",
-    "columns": 11,
+    "columns": 23,
     "medal": {
-        "gold": 40.0,
-        "silver": 58.0,
-        "bronze": 84.0
+        "gold": 29.200000762939454,
+        "silver": 42.29999923706055,
+        "bronze": 61.29999923706055
     },
-    "startColumn": 7,
+    "startColumn": 18,
     "bays": [
-        1,
         3,
-        4,
-        8
+        7,
+        11,
+        21
     ],
     "rows": [
         {
@@ -23,32 +23,40 @@
             "obstructions": []
         },
         {
-            "kind": "concrete",
+            "kind": "grass",
             "dir": "",
             "speed": 0.0,
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-tulip",
-                    "column": 2
+                    "pieceId": "bush",
+                    "column": 1
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 8
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 14
                 }
             ]
         },
         {
-            "kind": "road",
+            "kind": "swamp",
             "dir": "right",
-            "speed": 2.0399999618530275,
+            "speed": 1.6299999952316285,
             "objects": [
                 {
-                    "pieceId": "convertible",
-                    "offset": 6.400000095367432,
-                    "spacing": 17.0,
-                    "phase": 0
+                    "pieceId": "gator",
+                    "offset": 1.6699999570846558,
+                    "spacing": 16.5,
+                    "phase": 348
                 },
                 {
-                    "pieceId": "car",
-                    "offset": 14.899999618530274,
-                    "spacing": 17.0,
+                    "pieceId": "log",
+                    "offset": 9.920000076293946,
+                    "spacing": 16.5,
                     "phase": 0
                 }
             ],
@@ -61,39 +69,65 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "bench",
-                    "column": 0
+                    "pieceId": "lamp",
+                    "column": 5
                 },
                 {
-                    "pieceId": "bench",
+                    "pieceId": "tree",
                     "column": 7
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 12
                 }
             ]
         },
         {
             "kind": "swamp",
             "dir": "left",
-            "speed": 1.1799999475479127,
+            "speed": 1.2200000286102296,
             "objects": [
                 {
                     "pieceId": "log-long",
-                    "offset": 10.09000015258789,
-                    "spacing": 11.5,
+                    "offset": 27.690000534057618,
+                    "spacing": 8.75,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "tree",
+                    "column": 1
+                }
+            ]
+        },
+        {
             "kind": "swamp",
             "dir": "left",
-            "speed": 1.25,
+            "speed": 1.5299999713897706,
             "objects": [
                 {
-                    "pieceId": "gator",
-                    "offset": 5.019999980926514,
-                    "spacing": 10.5,
-                    "phase": 121
+                    "pieceId": "turtle-log",
+                    "offset": 21.469999313354493,
+                    "spacing": 16.5,
+                    "phase": 15
+                },
+                {
+                    "pieceId": "log-short",
+                    "offset": 29.719999313354493,
+                    "spacing": 16.5,
+                    "phase": 0
                 }
             ],
             "obstructions": []
@@ -103,27 +137,41 @@
             "dir": "",
             "speed": 0.0,
             "objects": [],
-            "obstructions": []
+            "obstructions": [
+                {
+                    "pieceId": "tree",
+                    "column": 0
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 4
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 10
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 11
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 16
+                }
+            ]
         },
         {
             "kind": "tracks",
             "dir": "left",
-            "speed": 2.2699999809265138,
+            "speed": 1.7100000381469727,
             "objects": [
                 {
                     "pieceId": "passenger",
-                    "offset": 4.599999904632568,
-                    "spacing": 17.5,
+                    "offset": 36.36000061035156,
+                    "spacing": 15.670000076293946,
                     "phase": 0
                 }
             ],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-039.json
+++ b/Assets/Resources/Levels/level-039.json
@@ -1,18 +1,18 @@
 {
     "id": "level-039",
     "name": "level-039",
-    "columns": 11,
+    "columns": 23,
     "medal": {
-        "gold": 30.399999618530275,
-        "silver": 44.0,
-        "bronze": 63.79999923706055
+        "gold": 38.400001525878909,
+        "silver": 55.70000076293945,
+        "bronze": 80.5999984741211
     },
-    "startColumn": 2,
+    "startColumn": 20,
     "bays": [
-        2,
-        3,
+        0,
         7,
-        8
+        12,
+        18
     ],
     "rows": [
         {
@@ -23,34 +23,36 @@
             "obstructions": []
         },
         {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.6399999856948853,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 14.130000114440918,
+                    "spacing": 16.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "gator",
+                    "offset": 22.3799991607666,
+                    "spacing": 16.5,
+                    "phase": 271
+                }
+            ],
+            "obstructions": []
+        },
+        {
             "kind": "grass",
             "dir": "",
             "speed": 0.0,
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-lavender",
-                    "column": 0
-                },
-                {
-                    "pieceId": "planter-daisy",
-                    "column": 1
+                    "pieceId": "bush",
+                    "column": 18
                 }
             ]
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.559999942779541,
-            "objects": [
-                {
-                    "pieceId": "gator",
-                    "offset": 4.460000038146973,
-                    "spacing": 10.5,
-                    "phase": 105
-                }
-            ],
-            "obstructions": []
         },
         {
             "kind": "concrete",
@@ -59,50 +61,96 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-daisy",
-                    "column": 5
+                    "pieceId": "planter-tulip",
+                    "column": 9
                 },
                 {
-                    "pieceId": "planter-fern",
-                    "column": 7
+                    "pieceId": "planter-lavender",
+                    "column": 11
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 13
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 17
                 }
             ]
         },
         {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.2400000095367432,
-            "objects": [
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 21.899999618530275,
-                    "spacing": 23.0,
-                    "phase": 0
+                    "pieceId": "tree",
+                    "column": 4
                 },
                 {
-                    "pieceId": "log-long",
-                    "offset": 10.399999618530274,
-                    "spacing": 23.0,
-                    "phase": 0
+                    "pieceId": "planter-succulent",
+                    "column": 8
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 18
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.130000114440918,
-            "objects": [
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
                 {
-                    "pieceId": "car",
-                    "offset": 8.029999732971192,
-                    "spacing": 17.0,
-                    "phase": 0
+                    "pieceId": "planter-tulip",
+                    "column": 9
                 },
                 {
-                    "pieceId": "convertible",
-                    "offset": 16.530000686645509,
-                    "spacing": 17.0,
+                    "pieceId": "bench",
+                    "column": 10
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 11
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 12
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 17
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 18
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 20
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 22
+                }
+            ]
+        },
+        {
+            "kind": "tracks",
+            "dir": "left",
+            "speed": 2.0999999046325685,
+            "objects": [
+                {
+                    "pieceId": "freight",
+                    "offset": 3.740000009536743,
+                    "spacing": 15.670000076293946,
                     "phase": 0
                 }
             ],
@@ -115,48 +163,24 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "tree",
-                    "column": 1
-                },
-                {
-                    "pieceId": "tree",
+                    "pieceId": "planter-daisy",
                     "column": 2
                 },
                 {
-                    "pieceId": "bush",
-                    "column": 8
+                    "pieceId": "planter-daisy",
+                    "column": 11
                 }
             ]
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.899999976158142,
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.2699999809265137,
             "objects": [
                 {
-                    "pieceId": "car",
-                    "offset": 1.690000057220459,
-                    "spacing": 19.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "bus",
-                    "offset": 11.1899995803833,
-                    "spacing": 19.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 2.359999895095825,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 26.8700008392334,
-                    "spacing": 17.5,
+                    "pieceId": "log-long",
+                    "offset": 31.399999618530275,
+                    "spacing": 8.75,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-040.json
+++ b/Assets/Resources/Levels/level-040.json
@@ -1,18 +1,18 @@
 {
     "id": "level-040",
     "name": "level-040",
-    "columns": 12,
+    "columns": 29,
     "medal": {
-        "gold": 69.80000305175781,
-        "silver": 101.19999694824219,
-        "bronze": 146.60000610351563
+        "gold": 37.70000076293945,
+        "silver": 54.599998474121097,
+        "bronze": 79.0999984741211
     },
-    "startColumn": 10,
+    "startColumn": 22,
     "bays": [
         3,
-        7,
-        9,
-        10
+        23,
+        27,
+        28
     ],
     "rows": [
         {
@@ -23,128 +23,136 @@
             "obstructions": []
         },
         {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.6799999475479127,
-            "objects": [
-                {
-                    "pieceId": "log-long",
-                    "offset": 19.450000762939454,
-                    "spacing": 24.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log",
-                    "offset": 7.449999809265137,
-                    "spacing": 24.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.350000023841858,
-            "objects": [
-                {
-                    "pieceId": "gator",
-                    "offset": 4.510000228881836,
-                    "spacing": 22.0,
-                    "phase": 377
-                },
-                {
-                    "pieceId": "raft",
-                    "offset": 15.510000228881836,
-                    "spacing": 22.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
             "kind": "grass",
             "dir": "",
             "speed": 0.0,
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "bench",
-                    "column": 5
-                }
-            ]
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "planter-daisy",
+                    "pieceId": "tree",
                     "column": 1
                 },
                 {
-                    "pieceId": "lamp",
-                    "column": 3
+                    "pieceId": "bush",
+                    "column": 5
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 11
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 21
                 }
             ]
         },
         {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.559999942779541,
+            "kind": "tracks",
+            "dir": "right",
+            "speed": 2.180000066757202,
             "objects": [
                 {
-                    "pieceId": "gator",
-                    "offset": 20.459999084472658,
-                    "spacing": 11.0,
-                    "phase": 176
+                    "pieceId": "freight",
+                    "offset": 41.79999923706055,
+                    "spacing": 17.670000076293947,
+                    "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
             "kind": "tracks",
-            "dir": "left",
-            "speed": 2.2300000190734865,
+            "dir": "right",
+            "speed": 2.069999933242798,
             "objects": [
                 {
                     "pieceId": "passenger",
-                    "offset": 2.4700000286102297,
-                    "spacing": 18.0,
+                    "offset": 22.389999389648439,
+                    "spacing": 17.670000076293947,
                     "phase": 0
                 }
             ],
             "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.440000057220459,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 20.65999984741211,
+                    "spacing": 6.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "tree",
+                    "column": 6
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 21
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 28
+                }
+            ]
         },
         {
             "kind": "swamp",
             "dir": "right",
-            "speed": 1.6399999856948853,
+            "speed": 1.4700000286102296,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 14.829999923706055,
-                    "spacing": 12.0,
+                    "pieceId": "log",
+                    "offset": 19.229999542236329,
+                    "spacing": 7.800000190734863,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "road",
-            "dir": "left",
-            "speed": 2.1700000762939455,
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.5800000429153443,
             "objects": [
                 {
-                    "pieceId": "convertible",
-                    "offset": 16.43000030517578,
-                    "spacing": 6.0,
-                    "phase": 0
+                    "pieceId": "gator",
+                    "offset": 5.71999979019165,
+                    "spacing": 19.5,
+                    "phase": 260
+                },
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 15.470000267028809,
+                    "spacing": 19.5,
+                    "phase": 40
                 }
             ],
             "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "bush",
+                    "column": 15
+                }
+            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-041.json
+++ b/Assets/Resources/Levels/level-041.json
@@ -1,17 +1,17 @@
 {
     "id": "level-041",
     "name": "level-041",
-    "columns": 10,
+    "columns": 26,
     "medal": {
-        "gold": 16.600000381469728,
-        "silver": 24.100000381469728,
-        "bronze": 34.900001525878909
+        "gold": 13.399999618530274,
+        "silver": 19.5,
+        "bronze": 28.200000762939454
     },
-    "startColumn": 6,
+    "startColumn": 12,
     "bays": [
         2,
-        3,
-        4
+        6,
+        13
     ],
     "rows": [
         {
@@ -22,17 +22,23 @@
             "obstructions": []
         },
         {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
+            "kind": "bike",
+            "dir": "left",
+            "speed": 1.9900000095367432,
+            "objects": [
+                {
+                    "pieceId": "cyclist",
+                    "offset": 10.65999984741211,
+                    "spacing": 15.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "runner",
+                    "offset": 18.15999984741211,
+                    "spacing": 15.0,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {
@@ -40,23 +46,46 @@
             "dir": "",
             "speed": 0.0,
             "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.2599999904632569,
-            "objects": [
+            "obstructions": [
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 17.34000015258789,
-                    "spacing": 20.0,
-                    "phase": 269
+                    "pieceId": "planter-succulent",
+                    "column": 0
                 },
                 {
-                    "pieceId": "log-short",
-                    "offset": 7.340000152587891,
-                    "spacing": 20.0,
+                    "pieceId": "bush",
+                    "column": 1
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 8
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 12
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 16
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 18
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 23
+                }
+            ]
+        },
+        {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.1700000762939455,
+            "objects": [
+                {
+                    "pieceId": "runner",
+                    "offset": 12.109999656677246,
+                    "spacing": 6.0,
                     "phase": 0
                 }
             ],
@@ -65,33 +94,78 @@
         {
             "kind": "bike",
             "dir": "left",
-            "speed": 2.109999895095825,
+            "speed": 2.390000104904175,
             "objects": [
                 {
                     "pieceId": "cyclist",
-                    "offset": 9.25,
-                    "spacing": 4.670000076293945,
+                    "offset": 21.049999237060548,
+                    "spacing": 10.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "skater",
+                    "offset": 26.049999237060548,
+                    "spacing": 10.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
+            "kind": "bike",
+            "dir": "right",
+            "speed": 1.9700000286102296,
+            "objects": [
+                {
+                    "pieceId": "cyclist",
+                    "offset": 0.33000001311302187,
+                    "spacing": 15.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "runner",
+                    "offset": 7.829999923706055,
+                    "spacing": 15.0,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 1.8799999952316285,
+            "kind": "road",
+            "dir": "right",
+            "speed": 1.7400000095367432,
             "objects": [
                 {
-                    "pieceId": "passenger",
-                    "offset": 4.900000095367432,
-                    "spacing": 17.0,
+                    "pieceId": "bus",
+                    "offset": 18.469999313354493,
+                    "spacing": 18.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "truck",
+                    "offset": 27.469999313354493,
+                    "spacing": 18.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 1.75,
+            "objects": [
+                {
+                    "pieceId": "truck",
+                    "offset": 15.300000190734864,
+                    "spacing": 18.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "truck",
+                    "offset": 24.299999237060548,
+                    "spacing": 18.0,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-042.json
+++ b/Assets/Resources/Levels/level-042.json
@@ -1,17 +1,17 @@
 {
     "id": "level-042",
     "name": "level-042",
-    "columns": 10,
+    "columns": 26,
     "medal": {
-        "gold": 15.5,
-        "silver": 22.5,
-        "bronze": 32.5
+        "gold": 19.700000762939454,
+        "silver": 28.600000381469728,
+        "bronze": 41.400001525878909
     },
-    "startColumn": 2,
+    "startColumn": 3,
     "bays": [
-        1,
         2,
-        7
+        11,
+        18
     ],
     "rows": [
         {
@@ -30,58 +30,26 @@
                 {
                     "pieceId": "bench",
                     "column": 3
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 19
                 }
             ]
         },
         {
-            "kind": "river",
+            "kind": "tracks",
             "dir": "left",
-            "speed": 1.190000057220459,
+            "speed": 1.8600000143051148,
             "objects": [
                 {
-                    "pieceId": "gator",
-                    "offset": 18.360000610351564,
-                    "spacing": 20.0,
-                    "phase": 166
-                },
-                {
-                    "pieceId": "log",
-                    "offset": 8.359999656677246,
-                    "spacing": 20.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.299999952316284,
-            "objects": [
-                {
-                    "pieceId": "skater",
-                    "offset": 12.739999771118164,
-                    "spacing": 14.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "skater",
-                    "offset": 5.739999771118164,
-                    "spacing": 14.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.0299999713897707,
-            "objects": [
-                {
-                    "pieceId": "skater",
-                    "offset": 7.099999904632568,
-                    "spacing": 4.670000076293945,
+                    "pieceId": "passenger",
+                    "offset": 25.350000381469728,
+                    "spacing": 16.670000076293947,
                     "phase": 0
                 }
             ],
@@ -94,14 +62,14 @@
             "objects": [
                 {
                     "pieceId": "log-short",
-                    "offset": 15.050000190734864,
-                    "spacing": 20.0,
+                    "offset": 27.09000015258789,
+                    "spacing": 18.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "gator",
-                    "offset": 5.050000190734863,
-                    "spacing": 20.0,
+                    "offset": 0.09000000357627869,
+                    "spacing": 18.0,
                     "phase": 33
                 }
             ],
@@ -114,14 +82,14 @@
             "objects": [
                 {
                     "pieceId": "cyclist",
-                    "offset": 2.6500000953674318,
-                    "spacing": 14.0,
+                    "offset": 5.679999828338623,
+                    "spacing": 15.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "skater",
-                    "offset": 9.649999618530274,
-                    "spacing": 14.0,
+                    "offset": 13.180000305175782,
+                    "spacing": 15.0,
                     "phase": 0
                 }
             ],
@@ -134,15 +102,43 @@
             "objects": [
                 {
                     "pieceId": "raft",
-                    "offset": 5.539999961853027,
-                    "spacing": 20.0,
+                    "offset": 9.970000267028809,
+                    "spacing": 18.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "turtle-log",
-                    "offset": 15.539999961853028,
-                    "spacing": 20.0,
+                    "offset": 18.969999313354493,
+                    "spacing": 18.0,
                     "phase": 329
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 1.809999942779541,
+            "objects": [
+                {
+                    "pieceId": "convertible",
+                    "offset": 27.549999237060548,
+                    "spacing": 6.400000095367432,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.2799999713897707,
+            "objects": [
+                {
+                    "pieceId": "cyclist",
+                    "offset": 9.050000190734864,
+                    "spacing": 5.0,
+                    "phase": 0
                 }
             ],
             "obstructions": []

--- a/Assets/Resources/Levels/level-043.json
+++ b/Assets/Resources/Levels/level-043.json
@@ -1,17 +1,17 @@
 {
     "id": "level-043",
     "name": "level-043",
-    "columns": 10,
+    "columns": 29,
     "medal": {
-        "gold": 15.899999618530274,
-        "silver": 23.100000381469728,
-        "bronze": 33.5
+        "gold": 35.79999923706055,
+        "silver": 51.900001525878909,
+        "bronze": 75.0999984741211
     },
-    "startColumn": 8,
+    "startColumn": 22,
     "bays": [
+        0,
         2,
-        3,
-        6
+        27
     ],
     "rows": [
         {
@@ -22,21 +22,20 @@
             "obstructions": []
         },
         {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 1.8700000047683716,
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.069999933242798,
             "objects": [
                 {
-                    "pieceId": "skater",
-                    "offset": 2.0899999141693117,
-                    "spacing": 4.670000076293945,
+                    "pieceId": "truck",
+                    "offset": 35.400001525878909,
+                    "spacing": 19.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "truck",
+                    "offset": 6.150000095367432,
+                    "spacing": 19.5,
                     "phase": 0
                 }
             ],
@@ -45,12 +44,32 @@
         {
             "kind": "tracks",
             "dir": "left",
-            "speed": 1.7899999618530274,
+            "speed": 1.7000000476837159,
             "objects": [
                 {
-                    "pieceId": "passenger",
-                    "offset": 10.569999694824219,
-                    "spacing": 17.0,
+                    "pieceId": "freight",
+                    "offset": 21.469999313354493,
+                    "spacing": 17.670000076293947,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 1.7999999523162842,
+            "objects": [
+                {
+                    "pieceId": "convertible",
+                    "offset": 2.809999942779541,
+                    "spacing": 11.670000076293946,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "convertible",
+                    "offset": 8.640000343322754,
+                    "spacing": 11.670000076293946,
                     "phase": 0
                 }
             ],
@@ -59,46 +78,32 @@
         {
             "kind": "bike",
             "dir": "right",
-            "speed": 2.3399999141693117,
+            "speed": 2.2799999713897707,
             "objects": [
                 {
                     "pieceId": "skater",
-                    "offset": 3.4700000286102297,
-                    "spacing": 7.0,
+                    "offset": 10.0,
+                    "spacing": 5.5,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "swamp",
+            "kind": "bike",
             "dir": "left",
-            "speed": 1.6399999856948853,
+            "speed": 2.200000047683716,
             "objects": [
                 {
-                    "pieceId": "log",
-                    "offset": 20.030000686645509,
-                    "spacing": 22.0,
+                    "pieceId": "cyclist",
+                    "offset": 20.90999984741211,
+                    "spacing": 8.25,
                     "phase": 0
                 },
                 {
-                    "pieceId": "log-long",
-                    "offset": 9.029999732971192,
-                    "spacing": 22.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.2000000476837159,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 7.559999942779541,
-                    "spacing": 9.0,
+                    "pieceId": "runner",
+                    "offset": 25.030000686645509,
+                    "spacing": 8.25,
                     "phase": 0
                 }
             ],
@@ -107,13 +112,27 @@
         {
             "kind": "swamp",
             "dir": "left",
-            "speed": 1.1299999952316285,
+            "speed": 1.2300000190734864,
             "objects": [
                 {
                     "pieceId": "turtle-log",
-                    "offset": 4.369999885559082,
-                    "spacing": 10.0,
-                    "phase": 43
+                    "offset": 26.3700008392334,
+                    "spacing": 7.800000190734863,
+                    "phase": 113
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "left",
+            "speed": 1.8200000524520875,
+            "objects": [
+                {
+                    "pieceId": "passenger",
+                    "offset": 3.630000114440918,
+                    "spacing": 17.670000076293947,
+                    "phase": 0
                 }
             ],
             "obstructions": []

--- a/Assets/Resources/Levels/level-044.json
+++ b/Assets/Resources/Levels/level-044.json
@@ -1,17 +1,17 @@
 {
     "id": "level-044",
     "name": "level-044",
-    "columns": 11,
+    "columns": 26,
     "medal": {
-        "gold": 20.200000762939454,
-        "silver": 29.200000762939454,
-        "bronze": 42.29999923706055
+        "gold": 17.100000381469728,
+        "silver": 24.799999237060548,
+        "bronze": 35.900001525878909
     },
-    "startColumn": 1,
+    "startColumn": 11,
     "bays": [
-        4,
+        1,
         5,
-        9
+        25
     ],
     "rows": [
         {
@@ -22,88 +22,56 @@
             "obstructions": []
         },
         {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 2.240000009536743,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 34.34000015258789,
-                    "spacing": 17.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.4299999475479127,
-            "objects": [
-                {
-                    "pieceId": "gator",
-                    "offset": 0.07000000029802323,
-                    "spacing": 7.0,
-                    "phase": 337
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.2300000190734864,
-            "objects": [
-                {
-                    "pieceId": "raft",
-                    "offset": 12.079999923706055,
-                    "spacing": 10.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.390000104904175,
-            "objects": [
-                {
-                    "pieceId": "skater",
-                    "offset": 4.679999828338623,
-                    "spacing": 5.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 1.9800000190734864,
-            "objects": [
-                {
-                    "pieceId": "cyclist",
-                    "offset": 12.050000190734864,
-                    "spacing": 5.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
+            "kind": "concrete",
             "dir": "",
             "speed": 0.0,
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-daisy",
-                    "column": 0
+                    "pieceId": "planter-fern",
+                    "column": 3
                 },
                 {
-                    "pieceId": "planter-daisy",
-                    "column": 8
+                    "pieceId": "bush",
+                    "column": 20
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 22
+                }
+            ]
+        },
+        {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.359999895095825,
+            "objects": [
+                {
+                    "pieceId": "skater",
+                    "offset": 25.739999771118165,
+                    "spacing": 5.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-fern",
+                    "column": 5
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 6
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 19
                 }
             ]
         },
@@ -114,14 +82,60 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "bush",
-                    "column": 7
+                    "pieceId": "planter-lavender",
+                    "column": 9
                 },
                 {
-                    "pieceId": "bush",
-                    "column": 10
+                    "pieceId": "planter-fern",
+                    "column": 21
                 }
             ]
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "bush",
+                    "column": 22
+                }
+            ]
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.4299999475479127,
+            "objects": [
+                {
+                    "pieceId": "gator",
+                    "offset": 26.700000762939454,
+                    "spacing": 9.0,
+                    "phase": 213
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.5700000524520875,
+            "objects": [
+                {
+                    "pieceId": "gator",
+                    "offset": 35.900001525878909,
+                    "spacing": 18.0,
+                    "phase": 218
+                },
+                {
+                    "pieceId": "log",
+                    "offset": 8.899999618530274,
+                    "spacing": 18.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-045.json
+++ b/Assets/Resources/Levels/level-045.json
@@ -1,17 +1,17 @@
 {
     "id": "level-045",
     "name": "level-045",
-    "columns": 11,
+    "columns": 29,
     "medal": {
-        "gold": 14.100000381469727,
-        "silver": 20.399999618530275,
-        "bronze": 29.600000381469728
+        "gold": 20.200000762939454,
+        "silver": 29.200000762939454,
+        "bronze": 42.29999923706055
     },
     "startColumn": 7,
     "bays": [
-        0,
-        4,
-        10
+        16,
+        18,
+        26
     ],
     "rows": [
         {
@@ -22,101 +22,40 @@
             "obstructions": []
         },
         {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.5399999618530275,
-            "objects": [
-                {
-                    "pieceId": "cyclist",
-                    "offset": 14.039999961853028,
-                    "spacing": 5.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
             "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "concrete",
             "dir": "",
             "speed": 0.0,
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "lamp",
-                    "column": 2
+                    "pieceId": "planter-tulip",
+                    "column": 12
                 },
                 {
-                    "pieceId": "planter-succulent",
-                    "column": 3
+                    "pieceId": "bush",
+                    "column": 23
                 },
                 {
-                    "pieceId": "tree",
-                    "column": 7
+                    "pieceId": "bench",
+                    "column": 24
                 }
             ]
         },
         {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.2000000476837159,
-            "objects": [
-                {
-                    "pieceId": "gator",
-                    "offset": 12.319999694824219,
-                    "spacing": 21.0,
-                    "phase": 97
-                },
-                {
-                    "pieceId": "log",
-                    "offset": 1.8200000524520875,
-                    "spacing": 21.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
             "kind": "bike",
-            "dir": "right",
-            "speed": 2.4200000762939455,
+            "dir": "left",
+            "speed": 2.109999895095825,
             "objects": [
                 {
-                    "pieceId": "skater",
-                    "offset": 3.3499999046325685,
-                    "spacing": 15.0,
+                    "pieceId": "cyclist",
+                    "offset": 14.979999542236329,
+                    "spacing": 11.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "runner",
-                    "offset": 10.850000381469727,
-                    "spacing": 15.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.069999933242798,
-            "objects": [
-                {
-                    "pieceId": "bus",
-                    "offset": 5.900000095367432,
-                    "spacing": 21.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "truck",
-                    "offset": 16.399999618530275,
-                    "spacing": 21.0,
+                    "pieceId": "cyclist",
+                    "offset": 20.479999542236329,
+                    "spacing": 11.0,
                     "phase": 0
                 }
             ],
@@ -125,19 +64,93 @@
         {
             "kind": "swamp",
             "dir": "right",
-            "speed": 1.1799999475479127,
+            "speed": 1.5800000429153443,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 19.09000015258789,
-                    "spacing": 23.0,
+                    "pieceId": "raft",
+                    "offset": 26.899999618530275,
+                    "spacing": 7.800000190734863,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.409999966621399,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 32.79999923706055,
+                    "spacing": 19.5,
                     "phase": 0
                 },
                 {
-                    "pieceId": "gator",
-                    "offset": 7.590000152587891,
-                    "spacing": 23.0,
-                    "phase": 238
+                    "pieceId": "log",
+                    "offset": 3.549999952316284,
+                    "spacing": 19.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "right",
+            "speed": 2.069999933242798,
+            "objects": [
+                {
+                    "pieceId": "runner",
+                    "offset": 0.7900000214576721,
+                    "spacing": 11.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "skater",
+                    "offset": 6.289999961853027,
+                    "spacing": 11.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "right",
+            "speed": 2.3399999141693117,
+            "objects": [
+                {
+                    "pieceId": "runner",
+                    "offset": 2.809999942779541,
+                    "spacing": 8.25,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "runner",
+                    "offset": 6.929999828338623,
+                    "spacing": 8.25,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.2699999809265137,
+            "objects": [
+                {
+                    "pieceId": "log-short",
+                    "offset": 16.780000686645509,
+                    "spacing": 19.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log",
+                    "offset": 26.530000686645509,
+                    "spacing": 19.5,
+                    "phase": 0
                 }
             ],
             "obstructions": []

--- a/Assets/Resources/Levels/level-046.json
+++ b/Assets/Resources/Levels/level-046.json
@@ -1,18 +1,18 @@
 {
     "id": "level-046",
     "name": "level-046",
-    "columns": 11,
+    "columns": 27,
     "medal": {
-        "gold": 26.200000762939454,
-        "silver": 38.0,
-        "bronze": 55.099998474121097
+        "gold": 26.700000762939454,
+        "silver": 38.70000076293945,
+        "bronze": 56.0
     },
-    "startColumn": 4,
+    "startColumn": 23,
     "bays": [
-        1,
-        6,
-        7,
-        8
+        9,
+        12,
+        23,
+        24
     ],
     "rows": [
         {
@@ -23,90 +23,42 @@
             "obstructions": []
         },
         {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 2.2899999618530275,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 12.25,
-                    "spacing": 17.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 1.9299999475479127,
-            "objects": [
-                {
-                    "pieceId": "cyclist",
-                    "offset": 14.210000038146973,
-                    "spacing": 5.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.049999952316284,
-            "objects": [
-                {
-                    "pieceId": "runner",
-                    "offset": 7.650000095367432,
-                    "spacing": 5.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 1.8300000429153443,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 32.650001525878909,
-                    "spacing": 17.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "concrete",
+            "kind": "grass",
             "dir": "",
             "speed": 0.0,
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "tree",
-                    "column": 0
-                },
-                {
-                    "pieceId": "planter-fern",
-                    "column": 5
-                },
-                {
-                    "pieceId": "planter-fern",
-                    "column": 8
+                    "pieceId": "lamp",
+                    "column": 18
                 }
             ]
         },
         {
-            "kind": "bike",
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 3
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 26
+                }
+            ]
+        },
+        {
+            "kind": "road",
             "dir": "right",
-            "speed": 2.049999952316284,
+            "speed": 1.7799999713897706,
             "objects": [
                 {
-                    "pieceId": "runner",
-                    "offset": 1.850000023841858,
-                    "spacing": 5.0,
+                    "pieceId": "car",
+                    "offset": 1.5299999713897706,
+                    "spacing": 5.5,
                     "phase": 0
                 }
             ],
@@ -114,19 +66,13 @@
         },
         {
             "kind": "bike",
-            "dir": "left",
-            "speed": 2.4100000858306886,
+            "dir": "right",
+            "speed": 2.450000047683716,
             "objects": [
                 {
-                    "pieceId": "cyclist",
-                    "offset": 2.740000009536743,
-                    "spacing": 15.0,
-                    "phase": 0
-                },
-                {
                     "pieceId": "skater",
-                    "offset": 10.239999771118164,
-                    "spacing": 15.0,
+                    "offset": 23.719999313354493,
+                    "spacing": 4.429999828338623,
                     "phase": 0
                 }
             ],
@@ -134,20 +80,74 @@
         },
         {
             "kind": "swamp",
-            "dir": "right",
-            "speed": 1.3899999856948853,
+            "dir": "left",
+            "speed": 1.4900000095367432,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 6.769999980926514,
-                    "spacing": 23.0,
+                    "pieceId": "log-short",
+                    "offset": 6.199999809265137,
+                    "spacing": 18.5,
                     "phase": 0
                 },
                 {
-                    "pieceId": "raft",
-                    "offset": 18.270000457763673,
-                    "spacing": 23.0,
+                    "pieceId": "log",
+                    "offset": 15.449999809265137,
+                    "spacing": 18.5,
                     "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "right",
+            "speed": 2.240000009536743,
+            "objects": [
+                {
+                    "pieceId": "passenger",
+                    "offset": 34.810001373291019,
+                    "spacing": 17.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.3600000143051148,
+            "objects": [
+                {
+                    "pieceId": "gator",
+                    "offset": 29.399999618530275,
+                    "spacing": 18.5,
+                    "phase": 206
+                },
+                {
+                    "pieceId": "log-short",
+                    "offset": 1.649999976158142,
+                    "spacing": 18.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.2400000095367432,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 7.53000020980835,
+                    "spacing": 18.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 16.780000686645509,
+                    "spacing": 18.5,
+                    "phase": 221
                 }
             ],
             "obstructions": []

--- a/Assets/Resources/Levels/level-047.json
+++ b/Assets/Resources/Levels/level-047.json
@@ -1,18 +1,18 @@
 {
     "id": "level-047",
     "name": "level-047",
-    "columns": 11,
+    "columns": 29,
     "medal": {
-        "gold": 37.0,
-        "silver": 53.70000076293945,
-        "bronze": 77.80000305175781
+        "gold": 32.0,
+        "silver": 46.400001525878909,
+        "bronze": 67.19999694824219
     },
-    "startColumn": 6,
+    "startColumn": 24,
     "bays": [
         2,
-        4,
-        5,
-        8
+        6,
+        22,
+        27
     ],
     "rows": [
         {
@@ -23,48 +23,28 @@
             "obstructions": []
         },
         {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.609999895095825,
-            "objects": [
-                {
-                    "pieceId": "cyclist",
-                    "offset": 5.550000190734863,
-                    "spacing": 5.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.2300000190734865,
-            "objects": [
-                {
-                    "pieceId": "cyclist",
-                    "offset": 14.319999694824219,
-                    "spacing": 15.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "cyclist",
-                    "offset": 6.820000171661377,
-                    "spacing": 15.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
             "kind": "tracks",
             "dir": "left",
-            "speed": 1.9700000286102296,
+            "speed": 1.9800000190734864,
             "objects": [
                 {
-                    "pieceId": "freight",
-                    "offset": 14.75,
-                    "spacing": 17.5,
+                    "pieceId": "passenger",
+                    "offset": 1.8300000429153443,
+                    "spacing": 17.670000076293947,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.590000033378601,
+            "objects": [
+                {
+                    "pieceId": "log-long",
+                    "offset": 37.68000030517578,
+                    "spacing": 10.25,
                     "phase": 0
                 }
             ],
@@ -73,53 +53,27 @@
         {
             "kind": "river",
             "dir": "left",
-            "speed": 1.559999942779541,
-            "objects": [
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 16.780000686645509,
-                    "spacing": 21.0,
-                    "phase": 287
-                },
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 6.28000020980835,
-                    "spacing": 21.0,
-                    "phase": 48
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.2100000381469728,
-            "objects": [
-                {
-                    "pieceId": "cyclist",
-                    "offset": 4.28000020980835,
-                    "spacing": 5.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.350000023841858,
+            "speed": 1.2799999713897706,
             "objects": [
                 {
                     "pieceId": "raft",
-                    "offset": 2.0899999141693117,
-                    "spacing": 21.0,
+                    "offset": 33.029998779296878,
+                    "spacing": 7.800000190734863,
                     "phase": 0
-                },
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "right",
+            "speed": 1.8600000143051148,
+            "objects": [
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 12.59000015258789,
-                    "spacing": 21.0,
-                    "phase": 104
+                    "pieceId": "freight",
+                    "offset": 28.65999984741211,
+                    "spacing": 17.670000076293947,
+                    "phase": 0
                 }
             ],
             "obstructions": []
@@ -129,24 +83,79 @@
             "dir": "",
             "speed": 0.0,
             "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-fern",
+                    "column": 2
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 11
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 12
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 15
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 18
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 21
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 24
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 27
+                }
+            ]
+        },
+        {
+            "kind": "bike",
+            "dir": "right",
+            "speed": 2.049999952316284,
+            "objects": [
+                {
+                    "pieceId": "runner",
+                    "offset": 13.710000038146973,
+                    "spacing": 5.5,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {
-            "kind": "swamp",
+            "kind": "tracks",
             "dir": "right",
-            "speed": 1.6100000143051148,
+            "speed": 1.8899999856948853,
             "objects": [
                 {
-                    "pieceId": "gator",
-                    "offset": 20.649999618530275,
-                    "spacing": 21.0,
-                    "phase": 351
-                },
-                {
-                    "pieceId": "log",
-                    "offset": 10.149999618530274,
-                    "spacing": 21.0,
+                    "pieceId": "passenger",
+                    "offset": 25.690000534057618,
+                    "spacing": 17.670000076293947,
                     "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.350000023841858,
+            "objects": [
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 4.849999904632568,
+                    "spacing": 7.800000190734863,
+                    "phase": 221
                 }
             ],
             "obstructions": []

--- a/Assets/Resources/Levels/level-048.json
+++ b/Assets/Resources/Levels/level-048.json
@@ -1,18 +1,18 @@
 {
     "id": "level-048",
     "name": "level-048",
-    "columns": 10,
+    "columns": 29,
     "medal": {
-        "gold": 26.399999618530275,
-        "silver": 38.20000076293945,
-        "bronze": 55.400001525878909
+        "gold": 23.0,
+        "silver": 33.400001525878909,
+        "bronze": 48.29999923706055
     },
-    "startColumn": 6,
+    "startColumn": 18,
     "bays": [
-        1,
-        3,
-        4,
-        5
+        0,
+        11,
+        16,
+        25
     ],
     "rows": [
         {
@@ -23,14 +23,88 @@
             "obstructions": []
         },
         {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.109999895095825,
+            "objects": [
+                {
+                    "pieceId": "cyclist",
+                    "offset": 30.549999237060548,
+                    "spacing": 11.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "cyclist",
+                    "offset": 3.049999952316284,
+                    "spacing": 11.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.690000057220459,
+            "objects": [
+                {
+                    "pieceId": "skater",
+                    "offset": 1.9700000286102296,
+                    "spacing": 11.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "skater",
+                    "offset": 7.46999979019165,
+                    "spacing": 11.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
             "kind": "tracks",
             "dir": "left",
-            "speed": 2.3299999237060549,
+            "speed": 2.180000066757202,
             "objects": [
                 {
                     "pieceId": "passenger",
-                    "offset": 24.440000534057618,
-                    "spacing": 17.0,
+                    "offset": 5.880000114440918,
+                    "spacing": 17.670000076293947,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.6299999952316285,
+            "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 17.68000030517578,
+                    "spacing": 7.800000190734863,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.6699999570846558,
+            "objects": [
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 21.469999313354493,
+                    "spacing": 19.5,
+                    "phase": 118
+                },
+                {
+                    "pieceId": "raft",
+                    "offset": 31.219999313354493,
+                    "spacing": 19.5,
                     "phase": 0
                 }
             ],
@@ -43,8 +117,28 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "tree",
-                    "column": 4
+                    "pieceId": "bush",
+                    "column": 3
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 10
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 17
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 22
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 23
                 }
             ]
         },
@@ -55,96 +149,36 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "bush",
-                    "column": 2
+                    "pieceId": "planter-daisy",
+                    "column": 1
                 },
                 {
-                    "pieceId": "planter-daisy",
-                    "column": 5
+                    "pieceId": "planter-succulent",
+                    "column": 17
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 19
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 22
                 }
             ]
         },
         {
             "kind": "bike",
             "dir": "right",
-            "speed": 2.5299999713897707,
-            "objects": [
-                {
-                    "pieceId": "cyclist",
-                    "offset": 9.1899995803833,
-                    "spacing": 4.670000076293945,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "bush",
-                    "column": 1
-                },
-                {
-                    "pieceId": "planter-fern",
-                    "column": 6
-                },
-                {
-                    "pieceId": "planter-succulent",
-                    "column": 7
-                }
-            ]
-        },
-        {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.7100000381469728,
-            "objects": [
-                {
-                    "pieceId": "cyclist",
-                    "offset": 9.710000038146973,
-                    "spacing": 4.670000076293945,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "left",
             "speed": 2.299999952316284,
             "objects": [
                 {
-                    "pieceId": "skater",
-                    "offset": 1.850000023841858,
-                    "spacing": 4.670000076293945,
+                    "pieceId": "cyclist",
+                    "offset": 17.760000228881837,
+                    "spacing": 5.5,
                     "phase": 0
                 }
             ],
             "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "planter-succulent",
-                    "column": 0
-                },
-                {
-                    "pieceId": "lamp",
-                    "column": 4
-                },
-                {
-                    "pieceId": "planter-daisy",
-                    "column": 5
-                }
-            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-049.json
+++ b/Assets/Resources/Levels/level-049.json
@@ -1,18 +1,18 @@
 {
     "id": "level-049",
     "name": "level-049",
-    "columns": 10,
+    "columns": 26,
     "medal": {
-        "gold": 20.700000762939454,
-        "silver": 30.0,
-        "bronze": 43.400001525878909
+        "gold": 26.200000762939454,
+        "silver": 38.0,
+        "bronze": 55.099998474121097
     },
-    "startColumn": 4,
+    "startColumn": 2,
     "bays": [
-        1,
         3,
         4,
-        5
+        18,
+        22
     ],
     "rows": [
         {
@@ -29,14 +29,14 @@
             "objects": [
                 {
                     "pieceId": "runner",
-                    "offset": 2.819999933242798,
-                    "spacing": 14.0,
+                    "offset": 6.050000190734863,
+                    "spacing": 10.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "skater",
-                    "offset": 9.819999694824219,
-                    "spacing": 14.0,
+                    "offset": 11.050000190734864,
+                    "spacing": 10.0,
                     "phase": 0
                 }
             ],
@@ -49,14 +49,14 @@
             "objects": [
                 {
                     "pieceId": "gator",
-                    "offset": 11.579999923706055,
-                    "spacing": 20.0,
+                    "offset": 20.84000015258789,
+                    "spacing": 18.0,
                     "phase": 212
                 },
                 {
                     "pieceId": "raft",
-                    "offset": 1.5800000429153443,
-                    "spacing": 20.0,
+                    "offset": 29.84000015258789,
+                    "spacing": 18.0,
                     "phase": 0
                 }
             ],
@@ -69,8 +69,8 @@
             "objects": [
                 {
                     "pieceId": "cyclist",
-                    "offset": 0.7300000190734863,
-                    "spacing": 4.670000076293945,
+                    "offset": 1.559999942779541,
+                    "spacing": 4.289999961853027,
                     "phase": 0
                 }
             ],
@@ -83,8 +83,8 @@
             "objects": [
                 {
                     "pieceId": "bus",
-                    "offset": 7.079999923706055,
-                    "spacing": 9.0,
+                    "offset": 13.380000114440918,
+                    "spacing": 6.800000190734863,
                     "phase": 0
                 }
             ],
@@ -97,14 +97,14 @@
             "objects": [
                 {
                     "pieceId": "skater",
-                    "offset": 11.949999809265137,
-                    "spacing": 14.0,
+                    "offset": 25.6200008392334,
+                    "spacing": 10.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "cyclist",
-                    "offset": 4.949999809265137,
-                    "spacing": 14.0,
+                    "offset": 0.6200000047683716,
+                    "spacing": 10.0,
                     "phase": 0
                 }
             ],
@@ -117,8 +117,8 @@
             "objects": [
                 {
                     "pieceId": "log",
-                    "offset": 8.619999885559082,
-                    "spacing": 10.0,
+                    "offset": 15.520000457763672,
+                    "spacing": 9.0,
                     "phase": 0
                 }
             ],
@@ -131,14 +131,14 @@
             "objects": [
                 {
                     "pieceId": "cyclist",
-                    "offset": 13.170000076293946,
-                    "spacing": 14.0,
+                    "offset": 28.219999313354493,
+                    "spacing": 10.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "skater",
-                    "offset": 6.170000076293945,
-                    "spacing": 14.0,
+                    "offset": 3.2200000286102297,
+                    "spacing": 10.0,
                     "phase": 0
                 }
             ],
@@ -151,14 +151,14 @@
             "objects": [
                 {
                     "pieceId": "raft",
-                    "offset": 9.970000267028809,
-                    "spacing": 20.0,
+                    "offset": 17.950000762939454,
+                    "spacing": 18.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "log",
-                    "offset": 19.969999313354493,
-                    "spacing": 20.0,
+                    "offset": 26.950000762939454,
+                    "spacing": 18.0,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-050.json
+++ b/Assets/Resources/Levels/level-050.json
@@ -1,18 +1,18 @@
 {
     "id": "level-050",
     "name": "level-050",
-    "columns": 10,
+    "columns": 26,
     "medal": {
-        "gold": 18.100000381469728,
-        "silver": 26.200000762939454,
-        "bronze": 37.900001525878909
+        "gold": 35.5,
+        "silver": 51.400001525878909,
+        "bronze": 74.5
     },
-    "startColumn": 5,
+    "startColumn": 3,
     "bays": [
-        2,
-        4,
-        5,
-        6
+        14,
+        22,
+        23,
+        25
     ],
     "rows": [
         {
@@ -23,68 +23,14 @@
             "obstructions": []
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.450000047683716,
-            "objects": [
-                {
-                    "pieceId": "bus",
-                    "offset": 10.510000228881836,
-                    "spacing": 18.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "bus",
-                    "offset": 1.5099999904632569,
-                    "spacing": 18.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.4600000381469727,
-            "objects": [
-                {
-                    "pieceId": "log-long",
-                    "offset": 21.079999923706056,
-                    "spacing": 22.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "raft",
-                    "offset": 10.079999923706055,
-                    "spacing": 22.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
             "kind": "tracks",
-            "dir": "right",
-            "speed": 2.2899999618530275,
+            "dir": "left",
+            "speed": 2.380000114440918,
             "objects": [
                 {
-                    "pieceId": "freight",
-                    "offset": 1.899999976158142,
-                    "spacing": 17.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.7999999523162842,
-            "objects": [
-                {
-                    "pieceId": "car",
-                    "offset": 15.40999984741211,
-                    "spacing": 8.0,
+                    "pieceId": "passenger",
+                    "offset": 4.389999866485596,
+                    "spacing": 16.670000076293947,
                     "phase": 0
                 }
             ],
@@ -93,13 +39,40 @@
         {
             "kind": "bike",
             "dir": "left",
-            "speed": 2.700000047683716,
+            "speed": 2.759999990463257,
             "objects": [
                 {
-                    "pieceId": "runner",
-                    "offset": 11.420000076293946,
-                    "spacing": 4.670000076293945,
+                    "pieceId": "skater",
+                    "offset": 25.040000915527345,
+                    "spacing": 5.0,
                     "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.7599999904632569,
+            "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 28.84000015258789,
+                    "spacing": 18.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "gator",
+                    "offset": 1.840000033378601,
+                    "spacing": 18.0,
+                    "phase": 213
                 }
             ],
             "obstructions": []
@@ -111,50 +84,70 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-tulip",
-                    "column": 0
-                },
-                {
-                    "pieceId": "bush",
-                    "column": 1
+                    "pieceId": "tree",
+                    "column": 6
                 },
                 {
                     "pieceId": "lamp",
-                    "column": 6
+                    "column": 17
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 20
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 22
                 }
             ]
         },
         {
-            "kind": "river",
+            "kind": "bike",
             "dir": "left",
-            "speed": 1.7000000476837159,
+            "speed": 2.7699999809265138,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 6.599999904632568,
-                    "spacing": 20.0,
+                    "pieceId": "runner",
+                    "offset": 25.770000457763673,
+                    "spacing": 10.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "gator",
-                    "offset": 16.600000381469728,
-                    "spacing": 20.0,
-                    "phase": 391
+                    "pieceId": "cyclist",
+                    "offset": 0.7699999809265137,
+                    "spacing": 10.0,
+                    "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
+            "kind": "tracks",
+            "dir": "left",
+            "speed": 1.8300000429153443,
+            "objects": [
                 {
-                    "pieceId": "bench",
-                    "column": 6
+                    "pieceId": "passenger",
+                    "offset": 38.08000183105469,
+                    "spacing": 16.670000076293947,
+                    "phase": 0
                 }
-            ]
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.7400000095367432,
+            "objects": [
+                {
+                    "pieceId": "log-long",
+                    "offset": 27.670000076293947,
+                    "spacing": 9.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-051.json
+++ b/Assets/Resources/Levels/level-051.json
@@ -1,17 +1,17 @@
 {
     "id": "level-051",
     "name": "level-051",
-    "columns": 10,
+    "columns": 29,
     "medal": {
-        "gold": 10.399999618530274,
-        "silver": 15.100000381469727,
-        "bronze": 21.899999618530275
+        "gold": 17.399999618530275,
+        "silver": 25.299999237060548,
+        "bronze": 36.599998474121097
     },
-    "startColumn": 1,
+    "startColumn": 9,
     "bays": [
-        0,
-        2,
-        9
+        8,
+        22,
+        26
     ],
     "rows": [
         {
@@ -22,85 +22,116 @@
             "obstructions": []
         },
         {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.340000033378601,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.1100000143051148,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.659999966621399,
+            "kind": "road",
+            "dir": "left",
+            "speed": 1.940000057220459,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 1.9199999570846558,
-                    "spacing": 6.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.2300000190734864,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.4200000762939455,
-            "objects": [
-                {
-                    "pieceId": "runner",
-                    "offset": 5.849999904632568,
-                    "spacing": 14.0,
+                    "pieceId": "bus",
+                    "offset": 13.069999694824219,
+                    "spacing": 19.5,
                     "phase": 0
                 },
                 {
-                    "pieceId": "skater",
-                    "offset": 12.850000381469727,
-                    "spacing": 14.0,
+                    "pieceId": "truck",
+                    "offset": 22.81999969482422,
+                    "spacing": 19.5,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.450000047683716,
-            "objects": [
-                {
-                    "pieceId": "runner",
-                    "offset": 8.979999542236329,
-                    "spacing": 4.670000076293945,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "concrete",
+            "kind": "grass",
             "dir": "",
             "speed": 0.0,
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "tree",
-                    "column": 7
+                    "pieceId": "planter-succulent",
+                    "column": 13
                 }
             ]
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.1799999475479127,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "bush",
+                    "column": 7
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 8
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 13
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 20
+                }
+            ]
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.1299999952316285,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 29.780000686645509,
+                    "spacing": 7.800000190734863,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 1
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 8
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 16
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 26
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 28
+                }
+            ]
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.0199999809265137,
+            "objects": [],
+            "obstructions": []
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-052.json
+++ b/Assets/Resources/Levels/level-052.json
@@ -1,17 +1,17 @@
 {
     "id": "level-052",
     "name": "level-052",
-    "columns": 13,
+    "columns": 32,
     "medal": {
-        "gold": 11.800000190734864,
-        "silver": 17.100000381469728,
-        "bronze": 24.700000762939454
+        "gold": 19.299999237060548,
+        "silver": 28.0,
+        "bronze": 40.5
     },
-    "startColumn": 9,
+    "startColumn": 10,
     "bays": [
-        1,
-        6,
-        10
+        11,
+        23,
+        30
     ],
     "rows": [
         {
@@ -28,14 +28,14 @@
             "objects": [
                 {
                     "pieceId": "bus",
-                    "offset": 1.809999942779541,
-                    "spacing": 21.0,
+                    "offset": 3.450000047683716,
+                    "spacing": 20.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "car",
-                    "offset": 12.3100004196167,
-                    "spacing": 21.0,
+                    "offset": 13.449999809265137,
+                    "spacing": 20.0,
                     "phase": 0
                 }
             ],
@@ -58,56 +58,57 @@
                 {
                     "pieceId": "tree",
                     "column": 11
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 19
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 20
                 }
             ]
         },
         {
-            "kind": "swamp",
+            "kind": "walkway",
             "dir": "right",
-            "speed": 1.4600000381469727,
+            "speed": 1.2899999618530274,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "right",
+            "speed": 2.5899999141693117,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 0.30000001192092898,
-                    "spacing": 7.0,
+                    "pieceId": "skater",
+                    "offset": 12.09000015258789,
+                    "spacing": 4.5,
                     "phase": 0
                 }
             ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.1100000143051148,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.1299999952316285,
+            "objects": [],
             "obstructions": []
         },
         {
             "kind": "walkway",
             "dir": "left",
-            "speed": 1.4199999570846558,
+            "speed": 1.3700000047683716,
             "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.3300000429153443,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.3600000143051148,
-            "objects": [
-                {
-                    "pieceId": "raft",
-                    "offset": 4.53000020980835,
-                    "spacing": 7.670000076293945,
-                    "phase": 0
-                }
-            ],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-053.json
+++ b/Assets/Resources/Levels/level-053.json
@@ -1,17 +1,17 @@
 {
     "id": "level-053",
     "name": "level-053",
-    "columns": 13,
+    "columns": 29,
     "medal": {
-        "gold": 23.299999237060548,
-        "silver": 33.79999923706055,
-        "bronze": 49.0
+        "gold": 21.100000381469728,
+        "silver": 30.5,
+        "bronze": 44.20000076293945
     },
-    "startColumn": 9,
+    "startColumn": 23,
     "bays": [
-        6,
-        8,
-        12
+        2,
+        26,
+        27
     ],
     "rows": [
         {
@@ -22,21 +22,14 @@
             "obstructions": []
         },
         {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.409999966621399,
-            "objects": [],
-            "obstructions": []
-        },
-        {
             "kind": "tracks",
             "dir": "right",
-            "speed": 2.140000104904175,
+            "speed": 1.9199999570846558,
             "objects": [
                 {
-                    "pieceId": "passenger",
-                    "offset": 14.770000457763672,
-                    "spacing": 18.5,
+                    "pieceId": "freight",
+                    "offset": 7.46999979019165,
+                    "spacing": 17.670000076293947,
                     "phase": 0
                 }
             ],
@@ -44,40 +37,20 @@
         },
         {
             "kind": "walkway",
-            "dir": "left",
-            "speed": 1.399999976158142,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
             "dir": "right",
-            "speed": 1.809999942779541,
-            "objects": [
-                {
-                    "pieceId": "truck",
-                    "offset": 14.300000190734864,
-                    "spacing": 23.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "convertible",
-                    "offset": 2.799999952316284,
-                    "spacing": 23.0,
-                    "phase": 0
-                }
-            ],
+            "speed": 1.100000023841858,
+            "objects": [],
             "obstructions": []
         },
         {
             "kind": "tracks",
             "dir": "left",
-            "speed": 1.8200000524520875,
+            "speed": 1.940000057220459,
             "objects": [
                 {
                     "pieceId": "passenger",
-                    "offset": 21.049999237060548,
-                    "spacing": 18.5,
+                    "offset": 28.049999237060548,
+                    "spacing": 17.670000076293947,
                     "phase": 0
                 }
             ],
@@ -90,35 +63,90 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-daisy",
-                    "column": 4
+                    "pieceId": "bush",
+                    "column": 8
                 },
                 {
-                    "pieceId": "tree",
-                    "column": 6
+                    "pieceId": "planter-succulent",
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 21
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 22
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 25
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 27
                 },
                 {
                     "pieceId": "bench",
-                    "column": 7
-                },
-                {
-                    "pieceId": "planter-tulip",
-                    "column": 12
+                    "column": 28
                 }
             ]
         },
         {
-            "kind": "tracks",
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 1
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 11
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 16
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 18
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 19
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 23
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 28
+                }
+            ]
+        },
+        {
+            "kind": "river",
             "dir": "left",
-            "speed": 2.0399999618530275,
+            "speed": 1.399999976158142,
             "objects": [
                 {
-                    "pieceId": "freight",
-                    "offset": 29.440000534057618,
-                    "spacing": 18.5,
+                    "pieceId": "log-short",
+                    "offset": 19.469999313354493,
+                    "spacing": 6.170000076293945,
                     "phase": 0
                 }
             ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.2699999809265137,
+            "objects": [],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-054.json
+++ b/Assets/Resources/Levels/level-054.json
@@ -1,17 +1,17 @@
 {
     "id": "level-054",
     "name": "level-054",
-    "columns": 11,
+    "columns": 31,
     "medal": {
-        "gold": 17.200000762939454,
-        "silver": 25.0,
-        "bronze": 36.20000076293945
+        "gold": 16.5,
+        "silver": 23.899999618530275,
+        "bronze": 34.599998474121097
     },
-    "startColumn": 3,
+    "startColumn": 4,
     "bays": [
-        1,
-        5,
-        8
+        9,
+        10,
+        13
     ],
     "rows": [
         {
@@ -22,117 +22,128 @@
             "obstructions": []
         },
         {
-            "kind": "walkway",
+            "kind": "road",
             "dir": "right",
-            "speed": 1.2100000381469727,
-            "objects": [],
+            "speed": 2.309999942779541,
+            "objects": [
+                {
+                    "pieceId": "car",
+                    "offset": 24.1299991607666,
+                    "spacing": 13.670000076293946,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "truck",
+                    "offset": 30.959999084472658,
+                    "spacing": 13.670000076293946,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {
             "kind": "swamp",
             "dir": "right",
-            "speed": 1.350000023841858,
+            "speed": 1.309999942779541,
             "objects": [
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 8.40999984741211,
-                    "spacing": 7.0,
-                    "phase": 307
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "left",
-            "speed": 2.009999990463257,
-            "objects": [
-                {
-                    "pieceId": "convertible",
-                    "offset": 13.430000305175782,
-                    "spacing": 5.670000076293945,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.4299999475479127,
-            "objects": [
-                {
-                    "pieceId": "gator",
-                    "offset": 3.7100000381469728,
-                    "spacing": 21.0,
-                    "phase": 163
-                },
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 14.210000038146973,
-                    "spacing": 21.0,
-                    "phase": 33
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.7799999713897706,
-            "objects": [
-                {
-                    "pieceId": "convertible",
-                    "offset": 7.949999809265137,
-                    "spacing": 5.670000076293945,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.3399999141693117,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 12.119999885559082,
-                    "spacing": 17.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "left",
-            "speed": 2.0399999618530275,
-            "objects": [
-                {
-                    "pieceId": "truck",
-                    "offset": 2.2899999618530275,
-                    "spacing": 21.0,
+                    "pieceId": "log",
+                    "offset": 39.18000030517578,
+                    "spacing": 13.670000076293946,
                     "phase": 0
                 },
+                {
+                    "pieceId": "raft",
+                    "offset": 5.010000228881836,
+                    "spacing": 13.670000076293946,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.149999976158142,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.2699999809265137,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 1.809999942779541,
+            "objects": [
                 {
                     "pieceId": "bus",
-                    "offset": 12.789999961853028,
-                    "spacing": 21.0,
+                    "offset": 17.780000686645509,
+                    "spacing": 19.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 27.530000686645509,
+                    "spacing": 19.5,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "tracks",
+            "kind": "bike",
             "dir": "left",
-            "speed": 2.130000114440918,
+            "speed": 2.180000066757202,
             "objects": [
                 {
-                    "pieceId": "passenger",
-                    "offset": 12.34000015258789,
-                    "spacing": 17.5,
+                    "pieceId": "runner",
+                    "offset": 11.869999885559082,
+                    "spacing": 8.75,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "skater",
+                    "offset": 16.239999771118165,
+                    "spacing": 8.75,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.559999942779541,
+            "objects": [
+                {
+                    "pieceId": "skater",
+                    "offset": 26.079999923706056,
+                    "spacing": 8.75,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "runner",
+                    "offset": 30.450000762939454,
+                    "spacing": 8.75,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.4000000953674318,
+            "objects": [
+                {
+                    "pieceId": "car",
+                    "offset": 27.56999969482422,
+                    "spacing": 5.289999961853027,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-055.json
+++ b/Assets/Resources/Levels/level-055.json
@@ -1,17 +1,17 @@
 {
     "id": "level-055",
     "name": "level-055",
-    "columns": 13,
+    "columns": 29,
     "medal": {
-        "gold": 16.200000762939454,
-        "silver": 23.399999618530275,
-        "bronze": 33.900001525878909
+        "gold": 22.0,
+        "silver": 31.899999618530275,
+        "bronze": 46.099998474121097
     },
-    "startColumn": 3,
+    "startColumn": 22,
     "bays": [
-        1,
-        7,
-        10
+        11,
+        22,
+        24
     ],
     "rows": [
         {
@@ -22,41 +22,34 @@
             "obstructions": []
         },
         {
-            "kind": "walkway",
+            "kind": "road",
             "dir": "left",
-            "speed": 1.4800000190734864,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.190000057220459,
+            "speed": 2.3499999046325685,
             "objects": [
                 {
-                    "pieceId": "raft",
-                    "offset": 2.640000104904175,
-                    "spacing": 7.670000076293945,
+                    "pieceId": "truck",
+                    "offset": 8.449999809265137,
+                    "spacing": 7.800000190734863,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "swamp",
+            "kind": "road",
             "dir": "left",
-            "speed": 1.7400000095367432,
+            "speed": 1.8799999952316285,
             "objects": [
                 {
-                    "pieceId": "raft",
-                    "offset": 22.8799991607666,
-                    "spacing": 23.0,
+                    "pieceId": "truck",
+                    "offset": 23.799999237060548,
+                    "spacing": 19.5,
                     "phase": 0
                 },
                 {
-                    "pieceId": "log-short",
-                    "offset": 11.380000114440918,
-                    "spacing": 23.0,
+                    "pieceId": "car",
+                    "offset": 33.54999923706055,
+                    "spacing": 19.5,
                     "phase": 0
                 }
             ],
@@ -69,75 +62,62 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "bush",
-                    "column": 2
+                    "pieceId": "tree",
+                    "column": 6
                 },
                 {
                     "pieceId": "planter-succulent",
-                    "column": 3
+                    "column": 9
                 },
                 {
                     "pieceId": "bush",
-                    "column": 8
+                    "column": 17
                 },
                 {
-                    "pieceId": "planter-tulip",
-                    "column": 11
+                    "pieceId": "planter-lavender",
+                    "column": 25
                 }
             ]
         },
         {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.109999895095825,
-            "objects": [
-                {
-                    "pieceId": "runner",
-                    "offset": 10.079999923706055,
-                    "spacing": 4.25,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.059999942779541,
-            "objects": [
-                {
-                    "pieceId": "convertible",
-                    "offset": 15.170000076293946,
-                    "spacing": 9.5,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "car",
-                    "offset": 0.9200000166893005,
-                    "spacing": 9.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
             "kind": "river",
             "dir": "left",
-            "speed": 1.4500000476837159,
+            "speed": 1.2699999809265137,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 14.020000457763672,
-                    "spacing": 23.0,
-                    "phase": 0
+                    "pieceId": "turtle-log",
+                    "offset": 9.579999923706055,
+                    "spacing": 19.5,
+                    "phase": 305
                 },
                 {
-                    "pieceId": "log",
-                    "offset": 2.5199999809265138,
-                    "spacing": 23.0,
-                    "phase": 0
+                    "pieceId": "turtle-log",
+                    "offset": 19.329999923706056,
+                    "spacing": 19.5,
+                    "phase": 243
                 }
             ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.4700000286102296,
+            "objects": [
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 3.6700000762939455,
+                    "spacing": 7.800000190734863,
+                    "phase": 44
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.3300000429153443,
+            "objects": [],
             "obstructions": []
         },
         {
@@ -147,14 +127,42 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-lavender",
-                    "column": 5
+                    "pieceId": "tree",
+                    "column": 6
                 },
                 {
-                    "pieceId": "planter-tulip",
-                    "column": 7
+                    "pieceId": "planter-lavender",
+                    "column": 12
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 19
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 21
                 }
             ]
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.5199999809265137,
+            "objects": [
+                {
+                    "pieceId": "gator",
+                    "offset": 8.59000015258789,
+                    "spacing": 19.5,
+                    "phase": 3
+                },
+                {
+                    "pieceId": "gator",
+                    "offset": 18.34000015258789,
+                    "spacing": 19.5,
+                    "phase": 367
+                }
+            ],
+            "obstructions": []
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-056.json
+++ b/Assets/Resources/Levels/level-056.json
@@ -1,18 +1,18 @@
 {
     "id": "level-056",
     "name": "level-056",
-    "columns": 12,
+    "columns": 27,
     "medal": {
-        "gold": 16.0,
-        "silver": 23.200000762939454,
-        "bronze": 33.599998474121097
+        "gold": 30.799999237060548,
+        "silver": 44.599998474121097,
+        "bronze": 64.5999984741211
     },
-    "startColumn": 6,
+    "startColumn": 19,
     "bays": [
-        0,
-        3,
-        8,
-        10
+        14,
+        22,
+        23,
+        25
     ],
     "rows": [
         {
@@ -23,86 +23,60 @@
             "obstructions": []
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.359999895095825,
-            "objects": [
-                {
-                    "pieceId": "car",
-                    "offset": 12.529999732971192,
-                    "spacing": 6.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 1.840000033378601,
-            "objects": [
-                {
-                    "pieceId": "bus",
-                    "offset": 16.100000381469728,
-                    "spacing": 6.670000076293945,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
             "kind": "walkway",
             "dir": "right",
-            "speed": 1.6100000143051148,
+            "speed": 1.2599999904632569,
             "objects": [],
             "obstructions": []
         },
         {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.309999942779541,
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
             "objects": [],
-            "obstructions": []
+            "obstructions": [
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 14
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 17
+                }
+            ]
         },
         {
-            "kind": "river",
+            "kind": "swamp",
             "dir": "left",
-            "speed": 1.2400000095367432,
+            "speed": 1.4800000190734864,
             "objects": [
                 {
                     "pieceId": "log-short",
-                    "offset": 0.36000001430511477,
-                    "spacing": 22.0,
+                    "offset": 23.670000076293947,
+                    "spacing": 18.5,
                     "phase": 0
                 },
                 {
                     "pieceId": "raft",
-                    "offset": 11.359999656677246,
-                    "spacing": 22.0,
+                    "offset": 32.91999816894531,
+                    "spacing": 18.5,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "road",
-            "dir": "left",
-            "speed": 2.369999885559082,
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.600000023841858,
             "objects": [
                 {
-                    "pieceId": "convertible",
-                    "offset": 6.090000152587891,
-                    "spacing": 6.0,
-                    "phase": 0
+                    "pieceId": "gator",
+                    "offset": 25.350000381469728,
+                    "spacing": 7.400000095367432,
+                    "phase": 196
                 }
             ],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.590000033378601,
-            "objects": [],
             "obstructions": []
         },
         {
@@ -112,14 +86,86 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "lamp",
+                    "pieceId": "planter-daisy",
                     "column": 1
                 },
                 {
-                    "pieceId": "planter-fern",
-                    "column": 5
+                    "pieceId": "bench",
+                    "column": 11
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 23
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 25
                 }
             ]
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 16
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 18
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 21
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 24
+                }
+            ]
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.6200000047683716,
+            "objects": [
+                {
+                    "pieceId": "log-short",
+                    "offset": 22.049999237060548,
+                    "spacing": 18.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "gator",
+                    "offset": 31.299999237060548,
+                    "spacing": 18.5,
+                    "phase": 145
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.6699999570846558,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 12.989999771118164,
+                    "spacing": 18.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log",
+                    "offset": 22.239999771118165,
+                    "spacing": 18.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-057.json
+++ b/Assets/Resources/Levels/level-057.json
@@ -1,18 +1,18 @@
 {
     "id": "level-057",
     "name": "level-057",
-    "columns": 12,
+    "columns": 30,
     "medal": {
-        "gold": 17.600000381469728,
-        "silver": 25.5,
-        "bronze": 37.0
+        "gold": 28.5,
+        "silver": 41.29999923706055,
+        "bronze": 59.79999923706055
     },
-    "startColumn": 1,
+    "startColumn": 10,
     "bays": [
-        0,
-        2,
-        6,
-        10
+        11,
+        19,
+        22,
+        29
     ],
     "rows": [
         {
@@ -36,14 +36,14 @@
             "objects": [
                 {
                     "pieceId": "bus",
-                    "offset": 5.71999979019165,
-                    "spacing": 20.0,
+                    "offset": 10.859999656677246,
+                    "spacing": 12.670000076293946,
                     "phase": 0
                 },
                 {
                     "pieceId": "car",
-                    "offset": 15.720000267028809,
-                    "spacing": 20.0,
+                    "offset": 17.190000534057618,
+                    "spacing": 12.670000076293946,
                     "phase": 0
                 }
             ],
@@ -63,7 +63,7 @@
             "objects": [
                 {
                     "pieceId": "freight",
-                    "offset": 34.869998931884769,
+                    "offset": 52.310001373291019,
                     "spacing": 18.0,
                     "phase": 0
                 }
@@ -77,7 +77,7 @@
             "objects": [
                 {
                     "pieceId": "passenger",
-                    "offset": 0.029999999329447748,
+                    "offset": 0.03999999910593033,
                     "spacing": 18.0,
                     "phase": 0
                 }
@@ -91,14 +91,14 @@
             "objects": [
                 {
                     "pieceId": "car",
-                    "offset": 13.739999771118164,
-                    "spacing": 18.0,
+                    "offset": 27.479999542236329,
+                    "spacing": 12.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "car",
-                    "offset": 4.739999771118164,
-                    "spacing": 18.0,
+                    "offset": 33.47999954223633,
+                    "spacing": 12.0,
                     "phase": 0
                 }
             ],
@@ -111,7 +111,7 @@
             "objects": [
                 {
                     "pieceId": "freight",
-                    "offset": 2.5799999237060549,
+                    "offset": 3.869999885559082,
                     "spacing": 18.0,
                     "phase": 0
                 }

--- a/Assets/Resources/Levels/level-058.json
+++ b/Assets/Resources/Levels/level-058.json
@@ -1,18 +1,18 @@
 {
     "id": "level-058",
     "name": "level-058",
-    "columns": 10,
+    "columns": 26,
     "medal": {
-        "gold": 19.200000762939454,
-        "silver": 27.799999237060548,
-        "bronze": 40.29999923706055
+        "gold": 25.100000381469728,
+        "silver": 36.400001525878909,
+        "bronze": 52.79999923706055
     },
-    "startColumn": 1,
+    "startColumn": 19,
     "bays": [
-        2,
-        3,
-        6,
-        9
+        10,
+        20,
+        21,
+        23
     ],
     "rows": [
         {
@@ -50,73 +50,71 @@
                 {
                     "pieceId": "planter-lavender",
                     "column": 9
-                }
-            ]
-        },
-        {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.4199999570846558,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
+                },
                 {
                     "pieceId": "planter-succulent",
-                    "column": 0
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 24
                 }
             ]
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.190000057220459,
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.3200000524520875,
             "objects": [
                 {
-                    "pieceId": "bus",
-                    "offset": 16.1200008392334,
-                    "spacing": 6.0,
+                    "pieceId": "turtle-log",
+                    "offset": 35.689998626708987,
+                    "spacing": 18.0,
+                    "phase": 205
+                },
+                {
+                    "pieceId": "raft",
+                    "offset": 8.6899995803833,
+                    "spacing": 18.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.2699999809265137,
+            "objects": [
                 {
-                    "pieceId": "planter-tulip",
-                    "column": 6
+                    "pieceId": "log",
+                    "offset": 31.100000381469728,
+                    "spacing": 18.0,
+                    "phase": 0
                 },
                 {
-                    "pieceId": "planter-fern",
-                    "column": 8
+                    "pieceId": "gator",
+                    "offset": 4.099999904632568,
+                    "spacing": 18.0,
+                    "phase": 310
                 }
-            ]
-        },
-        {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.4500000476837159,
-            "objects": [],
+            ],
             "obstructions": []
         },
         {
-            "kind": "tracks",
+            "kind": "road",
             "dir": "right",
-            "speed": 1.8600000143051148,
+            "speed": 2.2100000381469728,
             "objects": [
                 {
-                    "pieceId": "freight",
+                    "pieceId": "bus",
                     "offset": 24.229999542236329,
+                    "spacing": 17.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 32.72999954223633,
                     "spacing": 17.0,
                     "phase": 0
                 }
@@ -132,8 +130,72 @@
                 {
                     "pieceId": "planter-fern",
                     "column": 8
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 13
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 20
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 22
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 25
                 }
             ]
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.200000047683716,
+            "objects": [
+                {
+                    "pieceId": "bus",
+                    "offset": 4.760000228881836,
+                    "spacing": 17.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 13.260000228881836,
+                    "spacing": 17.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.309999942779541,
+            "objects": [
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 13.170000076293946,
+                    "spacing": 9.0,
+                    "phase": 82
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.4800000190734865,
+            "objects": [
+                {
+                    "pieceId": "runner",
+                    "offset": 29.950000762939454,
+                    "spacing": 5.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-059.json
+++ b/Assets/Resources/Levels/level-059.json
@@ -1,18 +1,18 @@
 {
     "id": "level-059",
     "name": "level-059",
-    "columns": 11,
+    "columns": 29,
     "medal": {
-        "gold": 24.899999618530275,
-        "silver": 36.20000076293945,
-        "bronze": 52.400001525878909
+        "gold": 33.29999923706055,
+        "silver": 48.20000076293945,
+        "bronze": 69.9000015258789
     },
-    "startColumn": 6,
+    "startColumn": 8,
     "bays": [
-        0,
-        5,
-        7,
-        8
+        17,
+        23,
+        25,
+        28
     ],
     "rows": [
         {
@@ -34,80 +34,127 @@
             "dir": "",
             "speed": 0.0,
             "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 18
+                }
+            ]
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 5
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 9
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 11
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 19
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 21
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 22
+                }
+            ]
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.7599999904632569,
+            "objects": [
+                {
+                    "pieceId": "log-short",
+                    "offset": 1.5299999713897706,
+                    "spacing": 19.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 11.279999732971192,
+                    "spacing": 19.5,
+                    "phase": 218
+                }
+            ],
             "obstructions": []
         },
         {
             "kind": "bike",
             "dir": "left",
-            "speed": 2.740000009536743,
+            "speed": 2.7899999618530275,
             "objects": [
                 {
-                    "pieceId": "runner",
-                    "offset": 2.450000047683716,
-                    "spacing": 15.0,
+                    "pieceId": "skater",
+                    "offset": 19.700000762939454,
+                    "spacing": 11.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "runner",
-                    "offset": 9.949999809265137,
-                    "spacing": 15.0,
+                    "offset": 25.200000762939454,
+                    "spacing": 11.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.2999999523162842,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 2.5199999809265138,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 18.670000076293947,
-                    "spacing": 17.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
+            "kind": "road",
             "dir": "left",
-            "speed": 1.3899999856948853,
+            "speed": 1.899999976158142,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 15.109999656677246,
-                    "spacing": 21.0,
+                    "pieceId": "truck",
+                    "offset": 0.38999998569488528,
+                    "spacing": 19.5,
                     "phase": 0
                 },
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 4.610000133514404,
-                    "spacing": 21.0,
-                    "phase": 26
+                    "pieceId": "bus",
+                    "offset": 10.140000343322754,
+                    "spacing": 19.5,
+                    "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "walkway",
+            "kind": "road",
             "dir": "right",
-            "speed": 1.5399999618530274,
-            "objects": [],
+            "speed": 2.0799999237060549,
+            "objects": [
+                {
+                    "pieceId": "bus",
+                    "offset": 15.369999885559082,
+                    "spacing": 6.170000076293945,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {
             "kind": "walkway",
             "dir": "left",
-            "speed": 1.5499999523162842,
+            "speed": 1.4900000095367432,
             "objects": [],
             "obstructions": []
         },
@@ -118,20 +165,24 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "tree",
+                    "pieceId": "lamp",
                     "column": 0
                 },
                 {
-                    "pieceId": "planter-tulip",
-                    "column": 3
+                    "pieceId": "bush",
+                    "column": 7
                 },
                 {
-                    "pieceId": "planter-succulent",
-                    "column": 8
+                    "pieceId": "tree",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 15
                 },
                 {
                     "pieceId": "planter-tulip",
-                    "column": 10
+                    "column": 26
                 }
             ]
         },

--- a/Assets/Resources/Levels/level-060.json
+++ b/Assets/Resources/Levels/level-060.json
@@ -1,18 +1,18 @@
 {
     "id": "level-060",
     "name": "level-060",
-    "columns": 13,
+    "columns": 32,
     "medal": {
-        "gold": 19.799999237060548,
-        "silver": 28.700000762939454,
-        "bronze": 41.599998474121097
+        "gold": 19.200000762939454,
+        "silver": 27.799999237060548,
+        "bronze": 40.29999923706055
     },
-    "startColumn": 3,
+    "startColumn": 12,
     "bays": [
-        2,
-        6,
-        11,
-        12
+        5,
+        7,
+        12,
+        13
     ],
     "rows": [
         {
@@ -23,74 +23,19 @@
             "obstructions": []
         },
         {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.340000033378601,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.4600000381469727,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.5099999904632569,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.5499999523162842,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.5700000524520875,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.2100000381469728,
-            "objects": [
-                {
-                    "pieceId": "skater",
-                    "offset": 2.880000114440918,
-                    "spacing": 17.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "runner",
-                    "offset": 11.380000114440918,
-                    "spacing": 17.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
             "kind": "road",
             "dir": "right",
-            "speed": 2.4800000190734865,
+            "speed": 1.9900000095367432,
             "objects": [
                 {
-                    "pieceId": "car",
-                    "offset": 15.899999618530274,
+                    "pieceId": "truck",
+                    "offset": 8.449999809265137,
                     "spacing": 21.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "bus",
-                    "offset": 5.400000095367432,
+                    "pieceId": "car",
+                    "offset": 18.950000762939454,
                     "spacing": 21.0,
                     "phase": 0
                 }
@@ -98,20 +43,45 @@
             "obstructions": []
         },
         {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.740000009536743,
-            "objects": [
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
                 {
-                    "pieceId": "runner",
-                    "offset": 8.65999984741211,
-                    "spacing": 17.0,
-                    "phase": 0
+                    "pieceId": "planter-lavender",
+                    "column": 1
                 },
                 {
-                    "pieceId": "skater",
-                    "offset": 0.1599999964237213,
-                    "spacing": 17.0,
+                    "pieceId": "bush",
+                    "column": 15
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 27
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 31
+                }
+            ]
+        },
+        {
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.5800000429153443,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.3200000524520875,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 3.490000009536743,
+                    "spacing": 7.0,
                     "phase": 0
                 }
             ],
@@ -119,17 +89,109 @@
         },
         {
             "kind": "tracks",
-            "dir": "left",
-            "speed": 1.9299999475479127,
+            "dir": "right",
+            "speed": 2.450000047683716,
             "objects": [
                 {
-                    "pieceId": "passenger",
-                    "offset": 2.369999885559082,
-                    "spacing": 18.5,
+                    "pieceId": "freight",
+                    "offset": 11.9399995803833,
+                    "spacing": 18.670000076293947,
                     "phase": 0
                 }
             ],
             "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.109999895095825,
+            "objects": [
+                {
+                    "pieceId": "car",
+                    "offset": 20.59000015258789,
+                    "spacing": 12.670000076293946,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 26.920000076293947,
+                    "spacing": 12.670000076293946,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "right",
+            "speed": 2.5299999713897707,
+            "objects": [
+                {
+                    "pieceId": "skater",
+                    "offset": 26.479999542236329,
+                    "spacing": 9.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "cyclist",
+                    "offset": 30.979999542236329,
+                    "spacing": 9.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.5199999809265137,
+            "objects": [
+                {
+                    "pieceId": "log-short",
+                    "offset": 28.489999771118165,
+                    "spacing": 22.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log-long",
+                    "offset": 39.4900016784668,
+                    "spacing": 22.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 7
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 16
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 18
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 22
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 26
+                }
+            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-061.json
+++ b/Assets/Resources/Levels/level-061.json
@@ -1,17 +1,17 @@
 {
     "id": "level-061",
     "name": "level-061",
-    "columns": 13,
+    "columns": 30,
     "medal": {
-        "gold": 15.100000381469727,
-        "silver": 21.899999618530275,
-        "bronze": 31.700000762939454
+        "gold": 26.399999618530275,
+        "silver": 38.20000076293945,
+        "bronze": 55.400001525878909
     },
-    "startColumn": 7,
+    "startColumn": 15,
     "bays": [
-        1,
-        5,
-        6
+        10,
+        17,
+        19
     ],
     "rows": [
         {
@@ -22,55 +22,41 @@
             "obstructions": []
         },
         {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.399999976158142,
+            "objects": [
                 {
-                    "pieceId": "planter-daisy",
-                    "column": 11
-                }
-            ]
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "lamp",
-                    "column": 3
+                    "pieceId": "raft",
+                    "offset": 6.599999904632568,
+                    "spacing": 20.0,
+                    "phase": 0
                 },
                 {
-                    "pieceId": "planter-lavender",
-                    "column": 5
+                    "pieceId": "gator",
+                    "offset": 16.600000381469728,
+                    "spacing": 20.0,
+                    "phase": 57
                 }
-            ]
+            ],
+            "obstructions": []
         },
         {
             "kind": "walkway",
-            "dir": "left",
-            "speed": 1.2400000095367432,
+            "dir": "right",
+            "speed": 1.7000000476837159,
             "objects": [],
             "obstructions": []
         },
         {
-            "kind": "road",
+            "kind": "tracks",
             "dir": "left",
-            "speed": 2.5799999237060549,
+            "speed": 2.140000104904175,
             "objects": [
                 {
-                    "pieceId": "car",
-                    "offset": 2.049999952316284,
-                    "spacing": 21.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "bus",
-                    "offset": 12.550000190734864,
-                    "spacing": 21.0,
+                    "pieceId": "passenger",
+                    "offset": 17.3700008392334,
+                    "spacing": 18.0,
                     "phase": 0
                 }
             ],
@@ -79,12 +65,12 @@
         {
             "kind": "tracks",
             "dir": "left",
-            "speed": 2.559999942779541,
+            "speed": 2.490000009536743,
             "objects": [
                 {
                     "pieceId": "freight",
-                    "offset": 14.789999961853028,
-                    "spacing": 18.5,
+                    "offset": 21.260000228881837,
+                    "spacing": 18.0,
                     "phase": 0
                 }
             ],
@@ -92,27 +78,13 @@
         },
         {
             "kind": "river",
-            "dir": "right",
-            "speed": 1.5700000524520875,
+            "dir": "left",
+            "speed": 1.25,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 3.0899999141693117,
-                    "spacing": 12.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.359999895095825,
-            "objects": [
-                {
-                    "pieceId": "truck",
-                    "offset": 10.710000038146973,
-                    "spacing": 7.670000076293945,
+                    "pieceId": "log",
+                    "offset": 3.9200000762939455,
+                    "spacing": 8.0,
                     "phase": 0
                 }
             ],
@@ -125,18 +97,58 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-succulent",
-                    "column": 1
+                    "pieceId": "planter-daisy",
+                    "column": 5
                 },
                 {
                     "pieceId": "lamp",
-                    "column": 3
+                    "column": 8
                 },
                 {
-                    "pieceId": "planter-lavender",
-                    "column": 12
+                    "pieceId": "planter-fern",
+                    "column": 10
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 14
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 16
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 23
                 }
             ]
+        },
+        {
+            "kind": "tracks",
+            "dir": "right",
+            "speed": 1.909999966621399,
+            "objects": [
+                {
+                    "pieceId": "freight",
+                    "offset": 47.439998626708987,
+                    "spacing": 18.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.6699999570846558,
+            "objects": [
+                {
+                    "pieceId": "log-long",
+                    "offset": 24.299999237060548,
+                    "spacing": 10.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-062.json
+++ b/Assets/Resources/Levels/level-062.json
@@ -1,17 +1,17 @@
 {
     "id": "level-062",
     "name": "level-062",
-    "columns": 11,
+    "columns": 30,
     "medal": {
-        "gold": 16.700000762939454,
-        "silver": 24.200000762939454,
-        "bronze": 35.0
+        "gold": 24.0,
+        "silver": 34.79999923706055,
+        "bronze": 50.5
     },
-    "startColumn": 6,
+    "startColumn": 22,
     "bays": [
-        2,
-        6,
-        8
+        10,
+        11,
+        27
     ],
     "rows": [
         {
@@ -22,27 +22,48 @@
             "obstructions": []
         },
         {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.4800000190734864,
+            "objects": [
+                {
+                    "pieceId": "log-long",
+                    "offset": 34.0099983215332,
+                    "spacing": 21.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log",
+                    "offset": 2.509999990463257,
+                    "spacing": 21.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.7000000476837159,
             "objects": [],
             "obstructions": []
         },
         {
-            "kind": "road",
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.5499999523162842,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
             "dir": "right",
-            "speed": 2.559999942779541,
+            "speed": 2.299999952316284,
             "objects": [
                 {
-                    "pieceId": "car",
-                    "offset": 7.730000019073486,
-                    "spacing": 19.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "bus",
-                    "offset": 17.229999542236329,
-                    "spacing": 19.0,
+                    "pieceId": "freight",
+                    "offset": 47.459999084472659,
+                    "spacing": 18.0,
                     "phase": 0
                 }
             ],
@@ -51,38 +72,38 @@
         {
             "kind": "swamp",
             "dir": "left",
-            "speed": 1.2599999904632569,
+            "speed": 1.6100000143051148,
             "objects": [
                 {
-                    "pieceId": "log",
-                    "offset": 3.990000009536743,
-                    "spacing": 23.0,
+                    "pieceId": "log-long",
+                    "offset": 0.25,
+                    "spacing": 21.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "log-long",
-                    "offset": 15.489999771118164,
-                    "spacing": 23.0,
-                    "phase": 0
+                    "pieceId": "gator",
+                    "offset": 10.75,
+                    "spacing": 21.0,
+                    "phase": 130
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.3399999141693117,
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.7300000190734864,
             "objects": [
                 {
-                    "pieceId": "convertible",
-                    "offset": 13.630000114440918,
-                    "spacing": 17.0,
+                    "pieceId": "raft",
+                    "offset": 10.4399995803833,
+                    "spacing": 21.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "car",
-                    "offset": 5.130000114440918,
-                    "spacing": 17.0,
+                    "pieceId": "log-long",
+                    "offset": 20.940000534057618,
+                    "spacing": 21.0,
                     "phase": 0
                 }
             ],
@@ -91,66 +112,26 @@
         {
             "kind": "river",
             "dir": "right",
-            "speed": 1.2899999618530274,
+            "speed": 1.559999942779541,
             "objects": [
                 {
                     "pieceId": "turtle-log",
-                    "offset": 14.079999923706055,
-                    "spacing": 21.0,
-                    "phase": 54
-                },
-                {
-                    "pieceId": "log",
-                    "offset": 3.5799999237060549,
-                    "spacing": 21.0,
-                    "phase": 0
+                    "offset": 38.16999816894531,
+                    "spacing": 8.0,
+                    "phase": 68
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.309999942779541,
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.4299999475479127,
             "objects": [
                 {
-                    "pieceId": "convertible",
-                    "offset": 3.25,
-                    "spacing": 5.670000076293945,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.5299999713897707,
-            "objects": [
-                {
-                    "pieceId": "cyclist",
-                    "offset": 4.260000228881836,
-                    "spacing": 15.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "skater",
-                    "offset": 11.760000228881836,
-                    "spacing": 15.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 2.259999990463257,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 4.659999847412109,
-                    "spacing": 17.5,
+                    "pieceId": "log-long",
+                    "offset": 17.360000610351564,
+                    "spacing": 10.5,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-063.json
+++ b/Assets/Resources/Levels/level-063.json
@@ -1,17 +1,17 @@
 {
     "id": "level-063",
     "name": "level-063",
-    "columns": 11,
+    "columns": 29,
     "medal": {
-        "gold": 17.399999618530275,
-        "silver": 25.299999237060548,
-        "bronze": 36.599998474121097
+        "gold": 26.100000381469728,
+        "silver": 37.79999923706055,
+        "bronze": 54.79999923706055
     },
     "startColumn": 1,
     "bays": [
         1,
-        4,
-        5
+        23,
+        27
     ],
     "rows": [
         {
@@ -35,8 +35,8 @@
             "objects": [
                 {
                     "pieceId": "passenger",
-                    "offset": 24.65999984741211,
-                    "spacing": 17.5,
+                    "offset": 37.34000015258789,
+                    "spacing": 17.670000076293947,
                     "phase": 0
                 }
             ],
@@ -55,86 +55,122 @@
                 {
                     "pieceId": "tree",
                     "column": 7
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 18
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 19
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 23
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 24
                 }
             ]
         },
         {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.609999895095825,
-            "objects": [
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
                 {
-                    "pieceId": "runner",
-                    "offset": 5.710000038146973,
-                    "spacing": 5.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.2999999523162842,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 2.8299999237060549,
-                    "spacing": 21.0,
-                    "phase": 0
+                    "pieceId": "bench",
+                    "column": 5
                 },
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 13.329999923706055,
-                    "spacing": 21.0,
-                    "phase": 197
+                    "pieceId": "planter-succulent",
+                    "column": 7
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 9
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 13
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 22
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 28
+                }
+            ]
+        },
+        {
+            "kind": "tracks",
+            "dir": "right",
+            "speed": 2.5199999809265138,
+            "objects": [
+                {
+                    "pieceId": "passenger",
+                    "offset": 42.599998474121097,
+                    "spacing": 17.670000076293947,
+                    "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "road",
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 5
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 8
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 13
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 15
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 17
+                }
+            ]
+        },
+        {
+            "kind": "swamp",
             "dir": "right",
-            "speed": 2.299999952316284,
+            "speed": 1.4800000190734864,
             "objects": [
                 {
-                    "pieceId": "bus",
-                    "offset": 14.319999694824219,
-                    "spacing": 9.5,
-                    "phase": 0
+                    "pieceId": "turtle-log",
+                    "offset": 11.4399995803833,
+                    "spacing": 6.5,
+                    "phase": 50
                 }
             ],
             "obstructions": []
         },
         {
             "kind": "tracks",
-            "dir": "right",
-            "speed": 2.430000066757202,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 4.260000228881836,
-                    "spacing": 17.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
             "dir": "left",
-            "speed": 1.9700000286102296,
+            "speed": 2.2799999713897707,
             "objects": [
                 {
-                    "pieceId": "convertible",
-                    "offset": 10.65999984741211,
-                    "spacing": 19.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "bus",
-                    "offset": 1.159999966621399,
-                    "spacing": 19.0,
+                    "pieceId": "freight",
+                    "offset": 42.0099983215332,
+                    "spacing": 17.670000076293947,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-064.json
+++ b/Assets/Resources/Levels/level-064.json
@@ -1,17 +1,17 @@
 {
     "id": "level-064",
     "name": "level-064",
-    "columns": 12,
+    "columns": 29,
     "medal": {
-        "gold": 22.600000381469728,
-        "silver": 32.79999923706055,
-        "bronze": 47.5
+        "gold": 24.799999237060548,
+        "silver": 35.900001525878909,
+        "bronze": 52.0
     },
-    "startColumn": 1,
+    "startColumn": 24,
     "bays": [
         4,
-        5,
-        9
+        11,
+        26
     ],
     "rows": [
         {
@@ -22,41 +22,14 @@
             "obstructions": []
         },
         {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.3200000524520875,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.049999952316284,
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.600000023841858,
             "objects": [
                 {
-                    "pieceId": "passenger",
-                    "offset": 15.65999984741211,
-                    "spacing": 18.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.5899999141693117,
-            "objects": [
-                {
-                    "pieceId": "runner",
-                    "offset": 8.970000267028809,
-                    "spacing": 16.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "cyclist",
-                    "offset": 0.9700000286102295,
-                    "spacing": 16.0,
+                    "pieceId": "raft",
+                    "offset": 26.420000076293947,
+                    "spacing": 7.800000190734863,
                     "phase": 0
                 }
             ],
@@ -69,10 +42,40 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "lamp",
-                    "column": 0
+                    "pieceId": "bush",
+                    "column": 2
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 19
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 24
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 26
                 }
             ]
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.399999976158142,
+            "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 0.7300000190734863,
+                    "spacing": 7.800000190734863,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
         },
         {
             "kind": "concrete",
@@ -81,59 +84,73 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "tree",
+                    "pieceId": "planter-daisy",
                     "column": 1
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 12
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 18
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 19
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 24
                 }
             ]
         },
         {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 1.9600000381469727,
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.4700000286102296,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 1.9700000286102296,
             "objects": [
                 {
-                    "pieceId": "passenger",
-                    "offset": 22.18000030517578,
-                    "spacing": 18.0,
+                    "pieceId": "truck",
+                    "offset": 9.479999542236329,
+                    "spacing": 13.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "convertible",
+                    "offset": 15.979999542236329,
+                    "spacing": 13.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "planter-daisy",
-                    "column": 4
-                },
-                {
-                    "pieceId": "planter-lavender",
-                    "column": 6
-                }
-            ]
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.600000023841858,
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.2999999523162842,
             "objects": [
                 {
-                    "pieceId": "raft",
-                    "offset": 3.9200000762939455,
-                    "spacing": 22.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log-short",
-                    "offset": 14.920000076293946,
-                    "spacing": 22.0,
-                    "phase": 0
+                    "pieceId": "gator",
+                    "offset": 36.65999984741211,
+                    "spacing": 7.800000190734863,
+                    "phase": 310
                 }
             ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.3700000047683716,
+            "objects": [],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-065.json
+++ b/Assets/Resources/Levels/level-065.json
@@ -1,17 +1,17 @@
 {
     "id": "level-065",
     "name": "level-065",
-    "columns": 11,
+    "columns": 29,
     "medal": {
-        "gold": 19.399999618530275,
-        "silver": 28.100000381469728,
-        "bronze": 40.70000076293945
+        "gold": 23.200000762939454,
+        "silver": 33.599998474121097,
+        "bronze": 48.70000076293945
     },
-    "startColumn": 8,
+    "startColumn": 1,
     "bays": [
-        0,
-        1,
-        8
+        3,
+        10,
+        28
     ],
     "rows": [
         {
@@ -22,21 +22,14 @@
             "obstructions": []
         },
         {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.590000033378601,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
+            "kind": "road",
             "dir": "left",
-            "speed": 1.7400000095367432,
+            "speed": 2.3499999046325685,
             "objects": [
                 {
-                    "pieceId": "log",
-                    "offset": 5.440000057220459,
-                    "spacing": 7.0,
+                    "pieceId": "bus",
+                    "offset": 19.15999984741211,
+                    "spacing": 7.400000095367432,
                     "phase": 0
                 }
             ],
@@ -50,40 +43,85 @@
             "obstructions": [
                 {
                     "pieceId": "planter-daisy",
-                    "column": 2
+                    "column": 4
                 },
                 {
-                    "pieceId": "planter-tulip",
-                    "column": 5
+                    "pieceId": "bush",
+                    "column": 9
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 14
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 20
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 28
                 }
             ]
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.559999942779541,
+            "objects": [
+                {
+                    "pieceId": "truck",
+                    "offset": 12.260000228881836,
+                    "spacing": 7.800000190734863,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 2.6500000953674318,
+            "objects": [
+                {
+                    "pieceId": "truck",
+                    "offset": 31.579999923706056,
+                    "spacing": 19.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "bus",
+                    "offset": 2.3299999237060549,
+                    "spacing": 19.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
         },
         {
             "kind": "swamp",
             "dir": "right",
-            "speed": 1.6699999570846558,
+            "speed": 1.309999942779541,
             "objects": [
                 {
                     "pieceId": "turtle-log",
-                    "offset": 7.920000076293945,
-                    "spacing": 7.0,
-                    "phase": 315
+                    "offset": 24.940000534057618,
+                    "spacing": 19.5,
+                    "phase": 86
+                },
+                {
+                    "pieceId": "log",
+                    "offset": 34.689998626708987,
+                    "spacing": 19.5,
+                    "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.1700000762939455,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 25.93000030517578,
-                    "spacing": 17.5,
-                    "phase": 0
-                }
-            ],
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.4500000476837159,
+            "objects": [],
             "obstructions": []
         },
         {
@@ -93,40 +131,50 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-tulip",
+                    "pieceId": "planter-succulent",
+                    "column": 4
+                },
+                {
+                    "pieceId": "planter-daisy",
                     "column": 6
                 },
                 {
-                    "pieceId": "bush",
+                    "pieceId": "planter-tulip",
                     "column": 8
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 13
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 23
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 27
                 }
             ]
         },
         {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.5899999141693117,
+            "kind": "road",
+            "dir": "right",
+            "speed": 2.619999885559082,
             "objects": [
                 {
-                    "pieceId": "freight",
-                    "offset": 23.770000457763673,
-                    "spacing": 17.5,
+                    "pieceId": "car",
+                    "offset": 30.809999465942384,
+                    "spacing": 11.670000076293946,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 1.649999976158142,
+                    "spacing": 11.670000076293946,
                     "phase": 0
                 }
             ],
             "obstructions": []
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "bush",
-                    "column": 1
-                }
-            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-066.json
+++ b/Assets/Resources/Levels/level-066.json
@@ -1,18 +1,18 @@
 {
     "id": "level-066",
     "name": "level-066",
-    "columns": 13,
+    "columns": 30,
     "medal": {
-        "gold": 33.20000076293945,
-        "silver": 48.20000076293945,
-        "bronze": 69.80000305175781
+        "gold": 22.299999237060548,
+        "silver": 32.29999923706055,
+        "bronze": 46.79999923706055
     },
-    "startColumn": 4,
+    "startColumn": 24,
     "bays": [
-        1,
-        3,
-        7,
-        9
+        4,
+        23,
+        25,
+        26
     ],
     "rows": [
         {
@@ -23,149 +23,138 @@
             "obstructions": []
         },
         {
-            "kind": "swamp",
+            "kind": "bike",
             "dir": "left",
-            "speed": 1.590000033378601,
+            "speed": 2.3399999141693117,
             "objects": [
                 {
-                    "pieceId": "raft",
-                    "offset": 2.549999952316284,
-                    "spacing": 7.670000076293945,
+                    "pieceId": "runner",
+                    "offset": 33.560001373291019,
+                    "spacing": 4.860000133514404,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.690000057220459,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 5.519999980926514,
-                    "spacing": 7.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.6699999570846558,
-            "objects": [
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 6.639999866485596,
-                    "spacing": 23.0,
-                    "phase": 99
-                },
-                {
-                    "pieceId": "log",
-                    "offset": 18.139999389648439,
-                    "spacing": 23.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "bush",
-                    "column": 1
-                },
-                {
-                    "pieceId": "bench",
-                    "column": 6
-                },
-                {
-                    "pieceId": "planter-lavender",
-                    "column": 9
-                },
-                {
-                    "pieceId": "planter-fern",
-                    "column": 10
-                }
-            ]
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.8200000524520875,
-            "objects": [
-                {
-                    "pieceId": "raft",
-                    "offset": 8.680000305175782,
-                    "spacing": 23.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log-short",
-                    "offset": 20.18000030517578,
-                    "spacing": 23.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.5399999618530274,
-            "objects": [
-                {
-                    "pieceId": "raft",
-                    "offset": 3.2899999618530275,
-                    "spacing": 25.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log-long",
-                    "offset": 15.789999961853028,
-                    "spacing": 25.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "grass",
+            "kind": "concrete",
             "dir": "",
             "speed": 0.0,
             "objects": [],
             "obstructions": [
                 {
                     "pieceId": "planter-succulent",
-                    "column": 0
+                    "column": 3
                 },
                 {
-                    "pieceId": "planter-lavender",
-                    "column": 10
+                    "pieceId": "bench",
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 21
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 29
                 }
             ]
         },
         {
             "kind": "river",
-            "dir": "right",
-            "speed": 1.559999942779541,
+            "dir": "left",
+            "speed": 1.4800000190734864,
             "objects": [
                 {
-                    "pieceId": "log",
-                    "offset": 11.420000076293946,
-                    "spacing": 23.0,
+                    "pieceId": "log-long",
+                    "offset": 37.869998931884769,
+                    "spacing": 21.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "gator",
-                    "offset": 22.920000076293947,
-                    "spacing": 23.0,
-                    "phase": 298
+                    "pieceId": "log-long",
+                    "offset": 6.369999885559082,
+                    "spacing": 21.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.649999976158142,
+            "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 0.6399999856948853,
+                    "spacing": 8.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "tree",
+                    "column": 0
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 11
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 17
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 21
+                }
+            ]
+        },
+        {
+            "kind": "tracks",
+            "dir": "right",
+            "speed": 2.5999999046325685,
+            "objects": [
+                {
+                    "pieceId": "passenger",
+                    "offset": 48.2599983215332,
+                    "spacing": 18.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.4199999570846558,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.8299999237060549,
+            "objects": [
+                {
+                    "pieceId": "skater",
+                    "offset": 18.8700008392334,
+                    "spacing": 8.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "skater",
+                    "offset": 23.1200008392334,
+                    "spacing": 8.5,
+                    "phase": 0
                 }
             ],
             "obstructions": []

--- a/Assets/Resources/Levels/level-067.json
+++ b/Assets/Resources/Levels/level-067.json
@@ -1,18 +1,18 @@
 {
     "id": "level-067",
     "name": "level-067",
-    "columns": 12,
+    "columns": 32,
     "medal": {
-        "gold": 35.70000076293945,
-        "silver": 51.79999923706055,
-        "bronze": 75.0
+        "gold": 34.79999923706055,
+        "silver": 50.400001525878909,
+        "bronze": 73.0
     },
-    "startColumn": 6,
+    "startColumn": 26,
     "bays": [
-        5,
         6,
-        7,
-        11
+        8,
+        14,
+        15
     ],
     "rows": [
         {
@@ -23,132 +23,109 @@
             "obstructions": []
         },
         {
-            "kind": "swamp",
+            "kind": "bike",
             "dir": "right",
-            "speed": 1.309999942779541,
+            "speed": 2.640000104904175,
             "objects": [
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 1.9900000095367432,
-                    "spacing": 22.0,
-                    "phase": 119
-                },
-                {
-                    "pieceId": "raft",
-                    "offset": 12.989999771118164,
-                    "spacing": 22.0,
+                    "pieceId": "runner",
+                    "offset": 25.329999923706056,
+                    "spacing": 4.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.609999895095825,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 20.020000457763673,
-                    "spacing": 18.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
+            "kind": "walkway",
             "dir": "right",
-            "speed": 1.7400000095367432,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 6.760000228881836,
-                    "spacing": 22.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "raft",
-                    "offset": 17.760000228881837,
-                    "spacing": 22.0,
-                    "phase": 0
-                }
-            ],
+            "speed": 1.6299999952316285,
+            "objects": [],
             "obstructions": []
         },
         {
-            "kind": "concrete",
+            "kind": "grass",
             "dir": "",
             "speed": 0.0,
             "objects": [],
             "obstructions": [
                 {
                     "pieceId": "bush",
-                    "column": 6
-                }
-            ]
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
+                    "column": 2
+                },
                 {
-                    "pieceId": "planter-lavender",
-                    "column": 0
+                    "pieceId": "bush",
+                    "column": 13
                 },
                 {
                     "pieceId": "planter-lavender",
-                    "column": 10
+                    "column": 16
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 17
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 18
                 }
             ]
         },
         {
-            "kind": "river",
+            "kind": "tracks",
             "dir": "right",
-            "speed": 1.75,
+            "speed": 2.609999895095825,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 4.059999942779541,
-                    "spacing": 22.0,
+                    "pieceId": "freight",
+                    "offset": 30.0,
+                    "spacing": 18.670000076293947,
                     "phase": 0
-                },
-                {
-                    "pieceId": "gator",
-                    "offset": 15.0600004196167,
-                    "spacing": 22.0,
-                    "phase": 120
                 }
             ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.5,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.4700000286102296,
+            "objects": [
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 25.989999771118165,
+                    "spacing": 7.0,
+                    "phase": 20
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.5399999618530274,
+            "objects": [],
             "obstructions": []
         },
         {
             "kind": "river",
             "dir": "left",
-            "speed": 1.3200000524520875,
+            "speed": 1.7799999713897706,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 4.070000171661377,
-                    "spacing": 12.0,
-                    "phase": 0
+                    "pieceId": "gator",
+                    "offset": 3.450000047683716,
+                    "spacing": 7.0,
+                    "phase": 137
                 }
             ],
             "obstructions": []
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "lamp",
-                    "column": 9
-                }
-            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-068.json
+++ b/Assets/Resources/Levels/level-068.json
@@ -1,18 +1,18 @@
 {
     "id": "level-068",
     "name": "level-068",
-    "columns": 13,
+    "columns": 32,
     "medal": {
-        "gold": 23.399999618530275,
-        "silver": 34.0,
-        "bronze": 49.20000076293945
+        "gold": 31.100000381469728,
+        "silver": 45.099998474121097,
+        "bronze": 65.4000015258789
     },
-    "startColumn": 2,
+    "startColumn": 23,
     "bays": [
-        0,
-        2,
-        5,
-        10
+        1,
+        3,
+        11,
+        16
     ],
     "rows": [
         {
@@ -23,20 +23,27 @@
             "obstructions": []
         },
         {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.590000033378601,
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.5299999713897706,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "right",
+            "speed": 2.5199999809265138,
             "objects": [
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 21.030000686645509,
-                    "spacing": 25.0,
-                    "phase": 30
+                    "pieceId": "runner",
+                    "offset": 11.149999618530274,
+                    "spacing": 9.0,
+                    "phase": 0
                 },
                 {
-                    "pieceId": "log-long",
-                    "offset": 8.529999732971192,
-                    "spacing": 25.0,
+                    "pieceId": "runner",
+                    "offset": 15.649999618530274,
+                    "spacing": 9.0,
                     "phase": 0
                 }
             ],
@@ -45,71 +52,79 @@
         {
             "kind": "river",
             "dir": "right",
-            "speed": 1.3600000143051148,
+            "speed": 1.590000033378601,
             "objects": [
                 {
-                    "pieceId": "log",
-                    "offset": 4.28000020980835,
-                    "spacing": 7.670000076293945,
+                    "pieceId": "log-long",
+                    "offset": 39.5,
+                    "spacing": 22.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 6.5,
+                    "spacing": 22.0,
+                    "phase": 134
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 2.3499999046325685,
+            "objects": [
+                {
+                    "pieceId": "bus",
+                    "offset": 8.020000457763672,
+                    "spacing": 6.670000076293945,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
+            "kind": "bike",
+            "dir": "right",
+            "speed": 2.4000000953674318,
+            "objects": [
                 {
-                    "pieceId": "planter-lavender",
-                    "column": 0
+                    "pieceId": "cyclist",
+                    "offset": 30.350000381469728,
+                    "spacing": 9.0,
+                    "phase": 0
                 },
                 {
-                    "pieceId": "planter-fern",
-                    "column": 5
-                },
-                {
-                    "pieceId": "bush",
-                    "column": 11
+                    "pieceId": "cyclist",
+                    "offset": 34.849998474121097,
+                    "spacing": 9.0,
+                    "phase": 0
                 }
-            ]
+            ],
+            "obstructions": []
         },
         {
             "kind": "bike",
             "dir": "left",
-            "speed": 2.369999885559082,
+            "speed": 2.7899999618530275,
             "objects": [
                 {
                     "pieceId": "skater",
-                    "offset": 7.0,
-                    "spacing": 5.670000076293945,
+                    "offset": 25.1299991607666,
+                    "spacing": 4.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "tree",
-                    "column": 4
-                }
-            ]
-        },
-        {
-            "kind": "swamp",
+            "kind": "river",
             "dir": "left",
-            "speed": 1.5,
+            "speed": 1.7599999904632569,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 12.649999618530274,
+                    "pieceId": "log",
+                    "offset": 40.68000030517578,
                     "spacing": 7.0,
                     "phase": 0
                 }
@@ -117,41 +132,10 @@
             "obstructions": []
         },
         {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "planter-succulent",
-                    "column": 1
-                },
-                {
-                    "pieceId": "planter-succulent",
-                    "column": 4
-                },
-                {
-                    "pieceId": "bush",
-                    "column": 5
-                },
-                {
-                    "pieceId": "tree",
-                    "column": 11
-                }
-            ]
-        },
-        {
-            "kind": "swamp",
+            "kind": "walkway",
             "dir": "right",
-            "speed": 1.3899999856948853,
-            "objects": [
-                {
-                    "pieceId": "log",
-                    "offset": 19.170000076293947,
-                    "spacing": 7.670000076293945,
-                    "phase": 0
-                }
-            ],
+            "speed": 1.4700000286102296,
+            "objects": [],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-069.json
+++ b/Assets/Resources/Levels/level-069.json
@@ -1,18 +1,18 @@
 {
     "id": "level-069",
     "name": "level-069",
-    "columns": 13,
+    "columns": 29,
     "medal": {
-        "gold": 39.79999923706055,
-        "silver": 57.70000076293945,
-        "bronze": 83.5999984741211
+        "gold": 29.700000762939454,
+        "silver": 43.0,
+        "bronze": 62.29999923706055
     },
-    "startColumn": 6,
+    "startColumn": 18,
     "bays": [
-        5,
-        8,
-        9,
-        11
+        13,
+        14,
+        15,
+        20
     ],
     "rows": [
         {
@@ -23,86 +23,97 @@
             "obstructions": []
         },
         {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.6500000953674318,
-            "objects": [
-                {
-                    "pieceId": "runner",
-                    "offset": 3.799999952316284,
-                    "spacing": 8.5,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "runner",
-                    "offset": 8.050000190734864,
-                    "spacing": 8.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "left",
-            "speed": 2.5,
-            "objects": [
-                {
-                    "pieceId": "convertible",
-                    "offset": 11.880000114440918,
-                    "spacing": 21.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "bus",
-                    "offset": 1.3799999952316285,
-                    "spacing": 21.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
             "kind": "concrete",
             "dir": "",
             "speed": 0.0,
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-fern",
+                    "pieceId": "tree",
+                    "column": 1
+                },
+                {
+                    "pieceId": "bench",
                     "column": 2
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 3
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 6
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 17
                 }
             ]
         },
         {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.7400000095367432,
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.5,
             "objects": [
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 17.770000457763673,
-                    "spacing": 23.0,
-                    "phase": 316
-                },
-                {
-                    "pieceId": "gator",
-                    "offset": 6.269999980926514,
-                    "spacing": 23.0,
-                    "phase": 229
+                    "pieceId": "raft",
+                    "offset": 15.970000267028809,
+                    "spacing": 7.800000190734863,
+                    "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.299999952316284,
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.6799999475479127,
             "objects": [
                 {
-                    "pieceId": "skater",
-                    "offset": 15.079999923706055,
-                    "spacing": 5.670000076293945,
+                    "pieceId": "log-long",
+                    "offset": 22.649999618530275,
+                    "spacing": 20.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "raft",
+                    "offset": 32.900001525878909,
+                    "spacing": 20.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.3899999856948853,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "left",
+            "speed": 2.1700000762939455,
+            "objects": [
+                {
+                    "pieceId": "freight",
+                    "offset": 24.1299991607666,
+                    "spacing": 17.670000076293947,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "right",
+            "speed": 2.2200000286102297,
+            "objects": [
+                {
+                    "pieceId": "passenger",
+                    "offset": 45.880001068115237,
+                    "spacing": 17.670000076293947,
                     "phase": 0
                 }
             ],
@@ -115,44 +126,42 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-daisy",
-                    "column": 0
+                    "pieceId": "planter-succulent",
+                    "column": 1
                 },
                 {
-                    "pieceId": "planter-lavender",
-                    "column": 10
+                    "pieceId": "tree",
+                    "column": 2
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 17
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 20
                 }
             ]
         },
         {
             "kind": "river",
             "dir": "left",
-            "speed": 1.659999966621399,
+            "speed": 1.3200000524520875,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 23.989999771118165,
-                    "spacing": 25.0,
+                    "pieceId": "log-short",
+                    "offset": 24.690000534057618,
+                    "spacing": 19.5,
                     "phase": 0
                 },
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 11.489999771118164,
-                    "spacing": 25.0,
-                    "phase": 29
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 1.9900000095367432,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 24.280000686645509,
-                    "spacing": 18.5,
+                    "pieceId": "log",
+                    "offset": 34.439998626708987,
+                    "spacing": 19.5,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-070.json
+++ b/Assets/Resources/Levels/level-070.json
@@ -1,18 +1,18 @@
 {
     "id": "level-070",
     "name": "level-070",
-    "columns": 11,
+    "columns": 32,
     "medal": {
-        "gold": 26.5,
-        "silver": 38.400001525878909,
-        "bronze": 55.599998474121097
+        "gold": 26.899999618530275,
+        "silver": 39.099998474121097,
+        "bronze": 56.599998474121097
     },
-    "startColumn": 6,
+    "startColumn": 10,
     "bays": [
-        4,
-        7,
-        8,
-        10
+        3,
+        19,
+        22,
+        26
     ],
     "rows": [
         {
@@ -23,21 +23,36 @@
             "obstructions": []
         },
         {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.3499999046325685,
+            "kind": "tracks",
+            "dir": "left",
+            "speed": 2.180000066757202,
             "objects": [
                 {
-                    "pieceId": "runner",
-                    "offset": 14.619999885559082,
-                    "spacing": 15.0,
+                    "pieceId": "passenger",
+                    "offset": 44.0099983215332,
+                    "spacing": 18.670000076293947,
                     "phase": 0
-                },
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.8300000429153443,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.7200000286102296,
+            "objects": [
                 {
-                    "pieceId": "cyclist",
-                    "offset": 7.119999885559082,
-                    "spacing": 15.0,
-                    "phase": 0
+                    "pieceId": "gator",
+                    "offset": 38.0,
+                    "spacing": 7.0,
+                    "phase": 72
                 }
             ],
             "obstructions": []
@@ -49,97 +64,100 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "bush",
-                    "column": 1
+                    "pieceId": "bench",
+                    "column": 0
                 },
                 {
-                    "pieceId": "lamp",
-                    "column": 7
+                    "pieceId": "planter-tulip",
+                    "column": 10
                 }
             ]
         },
         {
-            "kind": "river",
+            "kind": "road",
             "dir": "right",
-            "speed": 1.3899999856948853,
+            "speed": 2.619999885559082,
             "objects": [
                 {
-                    "pieceId": "raft",
-                    "offset": 4.800000190734863,
-                    "spacing": 21.0,
+                    "pieceId": "convertible",
+                    "offset": 21.059999465942384,
+                    "spacing": 14.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 15.300000190734864,
-                    "spacing": 21.0,
-                    "phase": 328
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.3799999952316285,
-            "objects": [
-                {
-                    "pieceId": "log-long",
-                    "offset": 17.389999389648439,
-                    "spacing": 11.5,
+                    "pieceId": "truck",
+                    "offset": 28.059999465942384,
+                    "spacing": 14.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "tracks",
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.059999942779541,
+            "objects": [
+                {
+                    "pieceId": "car",
+                    "offset": 0.41999998688697817,
+                    "spacing": 12.670000076293946,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 6.75,
+                    "spacing": 12.670000076293946,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
             "dir": "right",
-            "speed": 2.509999990463257,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 23.469999313354493,
-                    "spacing": 17.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.4500000476837159,
+            "speed": 1.4600000381469727,
             "objects": [
                 {
                     "pieceId": "turtle-log",
-                    "offset": 3.390000104904175,
+                    "offset": 15.3100004196167,
                     "spacing": 7.0,
-                    "phase": 69
+                    "phase": 79
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.880000114440918,
-            "objects": [
-                {
-                    "pieceId": "skater",
-                    "offset": 9.029999732971192,
-                    "spacing": 5.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.840000033378601,
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
             "objects": [],
-            "obstructions": []
+            "obstructions": [
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 0
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 7
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 8
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 11
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 30
+                }
+            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-071.json
+++ b/Assets/Resources/Levels/level-071.json
@@ -1,18 +1,18 @@
 {
     "id": "level-071",
     "name": "level-071",
-    "columns": 11,
+    "columns": 29,
     "medal": {
-        "gold": 43.900001525878909,
-        "silver": 63.70000076293945,
-        "bronze": 92.19999694824219
+        "gold": 31.600000381469728,
+        "silver": 45.900001525878909,
+        "bronze": 66.4000015258789
     },
-    "startColumn": 2,
+    "startColumn": 6,
     "bays": [
         4,
-        5,
-        8,
-        9
+        7,
+        15,
+        28
     ],
     "rows": [
         {
@@ -23,75 +23,141 @@
             "obstructions": []
         },
         {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 1
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 12
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 13
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 18
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 19
+                }
+            ]
+        },
+        {
             "kind": "swamp",
-            "dir": "right",
-            "speed": 1.3200000524520875,
+            "dir": "left",
+            "speed": 1.850000023841858,
             "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 28.760000228881837,
+                    "spacing": 7.800000190734863,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "bench",
+                    "column": 1
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 3
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 11
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 15
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 17
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 20
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 22
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 24
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 28
+                }
+            ]
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.7200000286102296,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.690000057220459,
+            "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 31.239999771118165,
+                    "spacing": 19.5,
+                    "phase": 0
+                },
                 {
                     "pieceId": "gator",
-                    "offset": 2.180000066757202,
-                    "spacing": 23.0,
-                    "phase": 119
-                },
-                {
-                    "pieceId": "log-long",
-                    "offset": 13.680000305175782,
-                    "spacing": 23.0,
-                    "phase": 0
+                    "offset": 1.9900000095367432,
+                    "spacing": 19.5,
+                    "phase": 113
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.7999999523162842,
-            "objects": [
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 3.869999885559082,
-                    "spacing": 10.5,
-                    "phase": 26
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.8200000524520875,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.4900000095367432,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
+            "kind": "road",
             "dir": "right",
-            "speed": 1.3799999952316285,
-            "objects": [],
+            "speed": 2.180000066757202,
+            "objects": [
+                {
+                    "pieceId": "car",
+                    "offset": 21.049999237060548,
+                    "spacing": 5.0,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {
-            "kind": "swamp",
+            "kind": "tracks",
             "dir": "left",
-            "speed": 1.5399999618530274,
+            "speed": 2.0399999618530275,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 12.390000343322754,
-                    "spacing": 23.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log-long",
-                    "offset": 0.8899999856948853,
-                    "spacing": 23.0,
+                    "pieceId": "freight",
+                    "offset": 8.319999694824219,
+                    "spacing": 17.670000076293947,
                     "phase": 0
                 }
             ],
@@ -100,46 +166,32 @@
         {
             "kind": "river",
             "dir": "right",
-            "speed": 1.7599999904632569,
+            "speed": 1.5499999523162842,
             "objects": [
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 8.65999984741211,
-                    "spacing": 10.5,
-                    "phase": 318
+                    "pieceId": "gator",
+                    "offset": 29.309999465942384,
+                    "spacing": 20.5,
+                    "phase": 125
+                },
+                {
+                    "pieceId": "log-long",
+                    "offset": 39.560001373291019,
+                    "spacing": 20.5,
+                    "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "bench",
-                    "column": 2
-                },
-                {
-                    "pieceId": "bench",
-                    "column": 7
-                },
-                {
-                    "pieceId": "planter-fern",
-                    "column": 8
-                }
-            ]
-        },
-        {
-            "kind": "swamp",
+            "kind": "road",
             "dir": "right",
-            "speed": 1.840000033378601,
+            "speed": 2.700000047683716,
             "objects": [
                 {
-                    "pieceId": "raft",
-                    "offset": 8.119999885559082,
-                    "spacing": 7.0,
+                    "pieceId": "bus",
+                    "offset": 1.7300000190734864,
+                    "spacing": 7.400000095367432,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-072.json
+++ b/Assets/Resources/Levels/level-072.json
@@ -1,18 +1,18 @@
 {
     "id": "level-072",
     "name": "level-072",
-    "columns": 13,
+    "columns": 29,
     "medal": {
-        "gold": 38.5,
-        "silver": 55.79999923706055,
-        "bronze": 80.80000305175781
+        "gold": 27.5,
+        "silver": 39.79999923706055,
+        "bronze": 57.70000076293945
     },
-    "startColumn": 1,
+    "startColumn": 11,
     "bays": [
-        2,
-        7,
+        0,
         8,
-        10
+        26,
+        28
     ],
     "rows": [
         {
@@ -23,68 +23,94 @@
             "obstructions": []
         },
         {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.3499999046325685,
-            "objects": [
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
                 {
-                    "pieceId": "skater",
-                    "offset": 8.109999656677246,
-                    "spacing": 8.5,
-                    "phase": 0
+                    "pieceId": "planter-succulent",
+                    "column": 12
                 },
                 {
-                    "pieceId": "runner",
-                    "offset": 12.359999656677246,
-                    "spacing": 8.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.340000033378601,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 12.960000038146973,
-                    "spacing": 23.0,
-                    "phase": 0
+                    "pieceId": "lamp",
+                    "column": 14
                 },
                 {
-                    "pieceId": "raft",
-                    "offset": 1.4600000381469727,
-                    "spacing": 23.0,
-                    "phase": 0
+                    "pieceId": "planter-fern",
+                    "column": 27
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
-            "kind": "road",
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "lamp",
+                    "column": 6
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 15
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 17
+                }
+            ]
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 8
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 11
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 15
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 21
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 23
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 28
+                }
+            ]
+        },
+        {
+            "kind": "tracks",
             "dir": "left",
-            "speed": 2.759999990463257,
+            "speed": 2.180000066757202,
             "objects": [
                 {
-                    "pieceId": "convertible",
-                    "offset": 4.519999980926514,
-                    "spacing": 4.75,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.3799999952316285,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 0.8799999952316284,
-                    "spacing": 7.0,
+                    "pieceId": "freight",
+                    "offset": 21.34000015258789,
+                    "spacing": 17.670000076293947,
                     "phase": 0
                 }
             ],
@@ -93,18 +119,72 @@
         {
             "kind": "river",
             "dir": "left",
-            "speed": 1.7200000286102296,
+            "speed": 1.4600000381469727,
             "objects": [
                 {
                     "pieceId": "raft",
-                    "offset": 9.0600004196167,
-                    "spacing": 25.0,
+                    "offset": 28.59000015258789,
+                    "spacing": 7.800000190734863,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.75,
+            "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 37.95000076293945,
+                    "spacing": 19.5,
                     "phase": 0
                 },
                 {
-                    "pieceId": "log-long",
-                    "offset": 21.559999465942384,
-                    "spacing": 25.0,
+                    "pieceId": "gator",
+                    "offset": 8.699999809265137,
+                    "spacing": 19.5,
+                    "phase": 298
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 2.130000114440918,
+            "objects": [
+                {
+                    "pieceId": "convertible",
+                    "offset": 23.489999771118165,
+                    "spacing": 11.670000076293946,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "convertible",
+                    "offset": 29.329999923706056,
+                    "spacing": 11.670000076293946,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 2.059999942779541,
+            "objects": [
+                {
+                    "pieceId": "convertible",
+                    "offset": 31.3700008392334,
+                    "spacing": 19.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "truck",
+                    "offset": 2.119999885559082,
+                    "spacing": 19.5,
                     "phase": 0
                 }
             ],
@@ -117,78 +197,30 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-lavender",
-                    "column": 2
+                    "pieceId": "planter-tulip",
+                    "column": 1
                 },
                 {
                     "pieceId": "planter-succulent",
-                    "column": 9
+                    "column": 6
                 },
                 {
-                    "pieceId": "tree",
-                    "column": 11
+                    "pieceId": "planter-lavender",
+                    "column": 8
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 16
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 21
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 26
                 }
             ]
-        },
-        {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.7899999618530275,
-            "objects": [
-                {
-                    "pieceId": "runner",
-                    "offset": 3.990000009536743,
-                    "spacing": 17.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "runner",
-                    "offset": 12.489999771118164,
-                    "spacing": 17.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.6399999856948853,
-            "objects": [
-                {
-                    "pieceId": "raft",
-                    "offset": 15.0,
-                    "spacing": 23.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "gator",
-                    "offset": 3.5,
-                    "spacing": 23.0,
-                    "phase": 319
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.3399999141693117,
-            "objects": [
-                {
-                    "pieceId": "runner",
-                    "offset": 16.139999389648439,
-                    "spacing": 8.5,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "cyclist",
-                    "offset": 3.390000104904175,
-                    "spacing": 8.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-073.json
+++ b/Assets/Resources/Levels/level-073.json
@@ -1,18 +1,18 @@
 {
     "id": "level-073",
     "name": "level-073",
-    "columns": 13,
+    "columns": 32,
     "medal": {
-        "gold": 31.200000762939454,
-        "silver": 45.20000076293945,
-        "bronze": 65.4000015258789
+        "gold": 25.600000381469728,
+        "silver": 37.099998474121097,
+        "bronze": 53.79999923706055
     },
-    "startColumn": 6,
+    "startColumn": 17,
     "bays": [
-        0,
-        2,
-        5,
-        11
+        9,
+        11,
+        23,
+        29
     ],
     "rows": [
         {
@@ -23,130 +23,184 @@
             "obstructions": []
         },
         {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.8600000143051148,
-            "objects": [
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
                 {
-                    "pieceId": "log",
-                    "offset": 2.940000057220459,
-                    "spacing": 7.670000076293945,
-                    "phase": 0
+                    "pieceId": "bench",
+                    "column": 0
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 16
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 17
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 20
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 21
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 26
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
             "kind": "bike",
-            "dir": "right",
-            "speed": 2.7799999713897707,
+            "dir": "left",
+            "speed": 2.509999990463257,
             "objects": [
                 {
                     "pieceId": "runner",
-                    "offset": 15.460000038146973,
-                    "spacing": 4.25,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.4500000476837159,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.490000009536743,
-            "objects": [
-                {
-                    "pieceId": "convertible",
-                    "offset": 6.090000152587891,
-                    "spacing": 9.5,
+                    "offset": 15.5600004196167,
+                    "spacing": 9.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "car",
-                    "offset": 10.84000015258789,
-                    "spacing": 9.5,
+                    "pieceId": "runner",
+                    "offset": 20.059999465942384,
+                    "spacing": 9.0,
                     "phase": 0
                 }
             ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.7200000286102296,
-            "objects": [
-                {
-                    "pieceId": "raft",
-                    "offset": 6.289999961853027,
-                    "spacing": 23.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "raft",
-                    "offset": 17.790000915527345,
-                    "spacing": 23.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.6799999475479127,
-            "objects": [
-                {
-                    "pieceId": "raft",
-                    "offset": 12.210000038146973,
-                    "spacing": 7.670000076293945,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.5299999713897706,
-            "objects": [],
             "obstructions": []
         },
         {
             "kind": "tracks",
             "dir": "left",
-            "speed": 2.3499999046325685,
+            "speed": 2.569999933242798,
             "objects": [
                 {
                     "pieceId": "freight",
-                    "offset": 23.420000076293947,
-                    "spacing": 18.5,
+                    "offset": 44.2599983215332,
+                    "spacing": 14.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.649999976158142,
+            "kind": "road",
+            "dir": "right",
+            "speed": 2.759999990463257,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 4.800000190734863,
-                    "spacing": 25.0,
+                    "pieceId": "truck",
+                    "offset": 27.93000030517578,
+                    "spacing": 7.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "lamp",
+                    "column": 1
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 25
+                }
+            ]
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.590000033378601,
+            "objects": [
+                {
+                    "pieceId": "log-short",
+                    "offset": 1.9299999475479127,
+                    "spacing": 6.670000076293945,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 1
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 5
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 6
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 13
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 21
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 30
+                }
+            ]
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.7599999904632569,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 33.09000015258789,
+                    "spacing": 14.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "log-long",
-                    "offset": 17.299999237060548,
-                    "spacing": 25.0,
+                    "pieceId": "log",
+                    "offset": 40.09000015258789,
+                    "spacing": 14.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.340000033378601,
+            "objects": [
+                {
+                    "pieceId": "log-short",
+                    "offset": 4.820000171661377,
+                    "spacing": 6.670000076293945,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-074.json
+++ b/Assets/Resources/Levels/level-074.json
@@ -1,18 +1,18 @@
 {
     "id": "level-074",
     "name": "level-074",
-    "columns": 13,
+    "columns": 29,
     "medal": {
-        "gold": 19.600000381469728,
-        "silver": 28.399999618530275,
-        "bronze": 41.20000076293945
+        "gold": 28.5,
+        "silver": 41.29999923706055,
+        "bronze": 59.79999923706055
     },
-    "startColumn": 8,
+    "startColumn": 10,
     "bays": [
-        1,
-        3,
-        7,
-        10
+        0,
+        5,
+        19,
+        23
     ],
     "rows": [
         {
@@ -23,14 +23,14 @@
             "obstructions": []
         },
         {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.359999895095825,
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.5299999713897707,
             "objects": [
                 {
-                    "pieceId": "skater",
-                    "offset": 12.25,
-                    "spacing": 4.25,
+                    "pieceId": "car",
+                    "offset": 24.860000610351564,
+                    "spacing": 4.380000114440918,
                     "phase": 0
                 }
             ],
@@ -43,75 +43,50 @@
             "objects": [],
             "obstructions": [
                 {
+                    "pieceId": "planter-tulip",
+                    "column": 4
+                },
+                {
                     "pieceId": "planter-fern",
-                    "column": 3
+                    "column": 5
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 12
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 13
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 22
                 }
             ]
         },
         {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.4600000381469727,
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.809999942779541,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 12.5600004196167,
-                    "spacing": 7.0,
+                    "pieceId": "raft",
+                    "offset": 24.399999618530275,
+                    "spacing": 7.800000190734863,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "planter-fern",
-                    "column": 2
-                },
-                {
-                    "pieceId": "lamp",
-                    "column": 8
-                },
-                {
-                    "pieceId": "lamp",
-                    "column": 10
-                },
-                {
-                    "pieceId": "bench",
-                    "column": 11
-                },
-                {
-                    "pieceId": "planter-succulent",
-                    "column": 12
-                }
-            ]
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.4500000476837159,
-            "objects": [],
-            "obstructions": []
-        },
-        {
             "kind": "road",
-            "dir": "right",
-            "speed": 2.1600000858306886,
+            "dir": "left",
+            "speed": 2.609999895095825,
             "objects": [
                 {
-                    "pieceId": "truck",
-                    "offset": 3.069999933242798,
-                    "spacing": 23.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "convertible",
-                    "offset": 14.569999694824219,
-                    "spacing": 23.0,
+                    "pieceId": "car",
+                    "offset": 21.309999465942384,
+                    "spacing": 5.0,
                     "phase": 0
                 }
             ],
@@ -119,27 +94,27 @@
         },
         {
             "kind": "tracks",
-            "dir": "left",
-            "speed": 2.359999895095825,
+            "dir": "right",
+            "speed": 2.2300000190734865,
             "objects": [
                 {
                     "pieceId": "freight",
-                    "offset": 7.269999980926514,
-                    "spacing": 18.5,
+                    "offset": 51.59000015258789,
+                    "spacing": 17.670000076293947,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.840000033378601,
+            "kind": "tracks",
+            "dir": "right",
+            "speed": 2.2100000381469728,
             "objects": [
                 {
-                    "pieceId": "log",
-                    "offset": 6.820000171661377,
-                    "spacing": 7.670000076293945,
+                    "pieceId": "passenger",
+                    "offset": 10.760000228881836,
+                    "spacing": 17.670000076293947,
                     "phase": 0
                 }
             ],
@@ -147,9 +122,53 @@
         },
         {
             "kind": "walkway",
-            "dir": "right",
-            "speed": 1.5700000524520875,
+            "dir": "left",
+            "speed": 1.7599999904632569,
             "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "bush",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 21
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 24
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 27
+                }
+            ]
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.5399999618530275,
+            "objects": [
+                {
+                    "pieceId": "truck",
+                    "offset": 38.290000915527347,
+                    "spacing": 19.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 9.039999961853028,
+                    "spacing": 19.5,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-075.json
+++ b/Assets/Resources/Levels/level-075.json
@@ -1,18 +1,18 @@
 {
     "id": "level-075",
     "name": "level-075",
-    "columns": 13,
+    "columns": 32,
     "medal": {
-        "gold": 21.799999237060548,
-        "silver": 31.600000381469728,
-        "bronze": 45.79999923706055
+        "gold": 29.899999618530275,
+        "silver": 43.400001525878909,
+        "bronze": 62.79999923706055
     },
-    "startColumn": 11,
+    "startColumn": 18,
     "bays": [
-        0,
-        7,
-        8,
-        11
+        9,
+        13,
+        14,
+        25
     ],
     "rows": [
         {
@@ -23,118 +23,28 @@
             "obstructions": []
         },
         {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "planter-daisy",
-                    "column": 1
-                }
-            ]
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "bush",
-                    "column": 6
-                },
-                {
-                    "pieceId": "lamp",
-                    "column": 7
-                }
-            ]
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.809999942779541,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "planter-lavender",
-                    "column": 3
-                },
-                {
-                    "pieceId": "planter-succulent",
-                    "column": 8
-                }
-            ]
-        },
-        {
             "kind": "river",
-            "dir": "right",
-            "speed": 1.649999976158142,
-            "objects": [
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 20.65999984741211,
-                    "spacing": 23.0,
-                    "phase": 83
-                },
-                {
-                    "pieceId": "gator",
-                    "offset": 9.15999984741211,
-                    "spacing": 23.0,
-                    "phase": 49
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
             "dir": "left",
-            "speed": 2.9200000762939455,
+            "speed": 1.8600000143051148,
             "objects": [
                 {
-                    "pieceId": "runner",
-                    "offset": 15.760000228881836,
-                    "spacing": 17.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "cyclist",
-                    "offset": 7.260000228881836,
-                    "spacing": 17.0,
+                    "pieceId": "log-long",
+                    "offset": 24.68000030517578,
+                    "spacing": 8.800000190734864,
                     "phase": 0
                 }
             ],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.600000023841858,
-            "objects": [],
             "obstructions": []
         },
         {
             "kind": "road",
-            "dir": "right",
-            "speed": 2.690000057220459,
+            "dir": "left",
+            "speed": 2.190000057220459,
             "objects": [
                 {
                     "pieceId": "truck",
-                    "offset": 2.8299999237060549,
-                    "spacing": 23.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "truck",
-                    "offset": 14.329999923706055,
-                    "spacing": 23.0,
+                    "offset": 39.95000076293945,
+                    "spacing": 7.0,
                     "phase": 0
                 }
             ],
@@ -142,13 +52,146 @@
         },
         {
             "kind": "tracks",
-            "dir": "right",
-            "speed": 2.680000066757202,
+            "dir": "left",
+            "speed": 2.3299999237060549,
             "objects": [
                 {
                     "pieceId": "freight",
-                    "offset": 28.75,
-                    "spacing": 18.5,
+                    "offset": 15.369999885559082,
+                    "spacing": 18.670000076293947,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.5499999523162842,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "right",
+            "speed": 2.4800000190734865,
+            "objects": [
+                {
+                    "pieceId": "freight",
+                    "offset": 8.109999656677246,
+                    "spacing": 18.670000076293947,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.759999990463257,
+            "objects": [
+                {
+                    "pieceId": "skater",
+                    "offset": 30.18000030517578,
+                    "spacing": 9.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "runner",
+                    "offset": 34.68000030517578,
+                    "spacing": 9.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.440000057220459,
+            "objects": [
+                {
+                    "pieceId": "log-short",
+                    "offset": 30.420000076293947,
+                    "spacing": 14.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 37.41999816894531,
+                    "spacing": 14.0,
+                    "phase": 250
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "tree",
+                    "column": 0
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 3
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 5
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 6
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 12
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 18
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 21
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 24
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 25
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 30
+                }
+            ]
+        },
+        {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.380000114440918,
+            "objects": [
+                {
+                    "pieceId": "cyclist",
+                    "offset": 5.690000057220459,
+                    "spacing": 9.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "skater",
+                    "offset": 10.1899995803833,
+                    "spacing": 9.0,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-076.json
+++ b/Assets/Resources/Levels/level-076.json
@@ -1,19 +1,19 @@
 {
     "id": "level-076",
     "name": "level-076",
-    "columns": 11,
+    "columns": 32,
     "medal": {
-        "gold": 41.900001525878909,
-        "silver": 60.79999923706055,
-        "bronze": 88.0
+        "gold": 34.400001525878909,
+        "silver": 49.79999923706055,
+        "bronze": 72.19999694824219
     },
-    "startColumn": 4,
+    "startColumn": 2,
     "bays": [
-        0,
-        1,
         4,
         7,
-        10
+        9,
+        20,
+        22
     ],
     "rows": [
         {
@@ -24,6 +24,34 @@
             "obstructions": []
         },
         {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.5399999618530275,
+            "objects": [
+                {
+                    "pieceId": "convertible",
+                    "offset": 5.460000038146973,
+                    "spacing": 4.75,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "left",
+            "speed": 2.3399999141693117,
+            "objects": [
+                {
+                    "pieceId": "freight",
+                    "offset": 0.17000000178813935,
+                    "spacing": 18.670000076293947,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
             "kind": "grass",
             "dir": "",
             "speed": 0.0,
@@ -31,93 +59,104 @@
             "obstructions": [
                 {
                     "pieceId": "bush",
-                    "column": 5
-                },
-                {
-                    "pieceId": "bush",
                     "column": 8
-                }
-            ]
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "planter-daisy",
-                    "column": 4
                 },
                 {
-                    "pieceId": "bush",
-                    "column": 5
+                    "pieceId": "planter-tulip",
+                    "column": 22
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 24
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 30
                 }
             ]
         },
         {
             "kind": "bike",
             "dir": "left",
-            "speed": 2.559999942779541,
+            "speed": 2.7200000286102297,
             "objects": [
                 {
-                    "pieceId": "cyclist",
-                    "offset": 11.779999732971192,
-                    "spacing": 15.0,
+                    "pieceId": "runner",
+                    "offset": 17.1200008392334,
+                    "spacing": 9.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "skater",
+                    "offset": 21.6200008392334,
+                    "spacing": 9.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.4200000762939455,
+            "objects": [
+                {
+                    "pieceId": "runner",
+                    "offset": 15.149999618530274,
+                    "spacing": 9.0,
                     "phase": 0
                 },
                 {
                     "pieceId": "cyclist",
-                    "offset": 4.28000020980835,
-                    "spacing": 15.0,
+                    "offset": 19.649999618530275,
+                    "spacing": 9.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "walkway",
+            "kind": "bike",
             "dir": "left",
-            "speed": 1.8700000047683716,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.490000009536743,
+            "speed": 2.4000000953674318,
             "objects": [
                 {
-                    "pieceId": "freight",
-                    "offset": 9.279999732971192,
-                    "spacing": 17.5,
+                    "pieceId": "cyclist",
+                    "offset": 20.850000381469728,
+                    "spacing": 9.0,
                     "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.7899999618530275,
-            "objects": [
+                },
                 {
-                    "pieceId": "passenger",
-                    "offset": 34.290000915527347,
-                    "spacing": 17.5,
+                    "pieceId": "runner",
+                    "offset": 25.350000381469728,
+                    "spacing": 9.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.3899999856948853,
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.5800000429153443,
             "objects": [
                 {
                     "pieceId": "raft",
-                    "offset": 4.21999979019165,
+                    "offset": 12.279999732971192,
+                    "spacing": 6.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.559999942779541,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 29.559999465942384,
                     "spacing": 7.0,
                     "phase": 0
                 }
@@ -125,50 +164,24 @@
             "obstructions": []
         },
         {
-            "kind": "tracks",
+            "kind": "road",
             "dir": "right",
-            "speed": 2.119999885559082,
+            "speed": 2.5299999713897707,
             "objects": [
                 {
-                    "pieceId": "passenger",
-                    "offset": 2.059999942779541,
-                    "spacing": 17.5,
+                    "pieceId": "convertible",
+                    "offset": 19.459999084472658,
+                    "spacing": 14.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "truck",
+                    "offset": 26.459999084472658,
+                    "spacing": 14.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "planter-lavender",
-                    "column": 1
-                },
-                {
-                    "pieceId": "bush",
-                    "column": 3
-                },
-                {
-                    "pieceId": "planter-tulip",
-                    "column": 5
-                },
-                {
-                    "pieceId": "planter-tulip",
-                    "column": 6
-                },
-                {
-                    "pieceId": "planter-fern",
-                    "column": 7
-                },
-                {
-                    "pieceId": "planter-fern",
-                    "column": 8
-                }
-            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-077.json
+++ b/Assets/Resources/Levels/level-077.json
@@ -1,19 +1,19 @@
 {
     "id": "level-077",
     "name": "level-077",
-    "columns": 11,
+    "columns": 29,
     "medal": {
-        "gold": 33.099998474121097,
-        "silver": 48.0,
-        "bronze": 69.5
+        "gold": 29.200000762939454,
+        "silver": 42.29999923706055,
+        "bronze": 61.20000076293945
     },
-    "startColumn": 6,
+    "startColumn": 8,
     "bays": [
-        3,
         4,
-        6,
-        7,
-        8
+        5,
+        13,
+        20,
+        23
     ],
     "rows": [
         {
@@ -30,8 +30,8 @@
             "objects": [
                 {
                     "pieceId": "freight",
-                    "offset": 2.2699999809265138,
-                    "spacing": 17.5,
+                    "offset": 3.440000057220459,
+                    "spacing": 17.670000076293947,
                     "phase": 0
                 }
             ],
@@ -42,51 +42,55 @@
             "dir": "",
             "speed": 0.0,
             "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.659999966621399,
-            "objects": [
+            "obstructions": [
                 {
-                    "pieceId": "log",
-                    "offset": 3.359999895095825,
-                    "spacing": 21.0,
-                    "phase": 0
+                    "pieceId": "planter-fern",
+                    "column": 16
                 },
                 {
+                    "pieceId": "lamp",
+                    "column": 17
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 19
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 26
+                }
+            ]
+        },
+        {
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.8300000429153443,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.409999966621399,
+            "objects": [
+                {
                     "pieceId": "log",
-                    "offset": 13.859999656677246,
-                    "spacing": 21.0,
+                    "offset": 23.65999984741211,
+                    "spacing": 6.5,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "swamp",
+            "kind": "tracks",
             "dir": "left",
-            "speed": 1.440000057220459,
+            "speed": 2.25,
             "objects": [
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 13.420000076293946,
-                    "spacing": 7.0,
-                    "phase": 172
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.4700000286102297,
-            "objects": [
-                {
-                    "pieceId": "runner",
-                    "offset": 10.8100004196167,
-                    "spacing": 5.0,
+                    "pieceId": "freight",
+                    "offset": 39.119998931884769,
+                    "spacing": 17.670000076293947,
                     "phase": 0
                 }
             ],
@@ -100,54 +104,111 @@
             "obstructions": [
                 {
                     "pieceId": "planter-tulip",
-                    "column": 1
+                    "column": 5
                 },
                 {
                     "pieceId": "bush",
-                    "column": 2
+                    "column": 13
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 18
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 20
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 21
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 28
                 }
             ]
         },
         {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.5499999523162842,
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
             "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.8299999237060549,
-            "objects": [
+            "obstructions": [
                 {
-                    "pieceId": "cyclist",
-                    "offset": 14.520000457763672,
-                    "spacing": 5.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.880000114440918,
-            "objects": [
-                {
-                    "pieceId": "skater",
-                    "offset": 2.430000066757202,
-                    "spacing": 7.5,
-                    "phase": 0
+                    "pieceId": "lamp",
+                    "column": 5
                 },
                 {
-                    "pieceId": "runner",
-                    "offset": 6.179999828338623,
-                    "spacing": 7.5,
+                    "pieceId": "planter-daisy",
+                    "column": 12
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 17
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 24
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 25
+                }
+            ]
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 2.069999933242798,
+            "objects": [
+                {
+                    "pieceId": "truck",
+                    "offset": 25.389999389648439,
+                    "spacing": 6.5,
                     "phase": 0
                 }
             ],
             "obstructions": []
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 5
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 12
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 13
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 17
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 20
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 23
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 27
+                }
+            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-078.json
+++ b/Assets/Resources/Levels/level-078.json
@@ -1,19 +1,19 @@
 {
     "id": "level-078",
     "name": "level-078",
-    "columns": 12,
+    "columns": 29,
     "medal": {
-        "gold": 34.79999923706055,
-        "silver": 50.5,
-        "bronze": 73.0999984741211
+        "gold": 28.0,
+        "silver": 40.599998474121097,
+        "bronze": 58.70000076293945
     },
-    "startColumn": 8,
+    "startColumn": 14,
     "bays": [
-        3,
-        4,
-        5,
-        7,
-        8
+        6,
+        10,
+        11,
+        21,
+        24
     ],
     "rows": [
         {
@@ -24,74 +24,46 @@
             "obstructions": []
         },
         {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 2.8499999046325685,
-            "objects": [
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
                 {
-                    "pieceId": "passenger",
-                    "offset": 26.969999313354493,
-                    "spacing": 18.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.7799999713897707,
-            "objects": [
-                {
-                    "pieceId": "skater",
-                    "offset": 14.229999542236329,
-                    "spacing": 8.0,
-                    "phase": 0
+                    "pieceId": "planter-lavender",
+                    "column": 2
                 },
                 {
-                    "pieceId": "cyclist",
-                    "offset": 2.2300000190734865,
-                    "spacing": 8.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.509999990463257,
-            "objects": [
-                {
-                    "pieceId": "bus",
-                    "offset": 1.7999999523162842,
-                    "spacing": 20.0,
-                    "phase": 0
+                    "pieceId": "planter-lavender",
+                    "column": 8
                 },
                 {
-                    "pieceId": "bus",
-                    "offset": 11.800000190734864,
-                    "spacing": 20.0,
-                    "phase": 0
+                    "pieceId": "planter-tulip",
+                    "column": 15
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 18
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 20
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 28
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
             "kind": "swamp",
-            "dir": "left",
+            "dir": "right",
             "speed": 1.5199999809265137,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 10.630000114440918,
-                    "spacing": 22.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "raft",
-                    "offset": 21.6299991607666,
-                    "spacing": 22.0,
+                    "pieceId": "log",
+                    "offset": 19.239999771118165,
+                    "spacing": 7.800000190734863,
                     "phase": 0
                 }
             ],
@@ -105,53 +77,103 @@
             "obstructions": [
                 {
                     "pieceId": "bench",
-                    "column": 6
-                },
-                {
-                    "pieceId": "planter-tulip",
                     "column": 10
                 },
                 {
-                    "pieceId": "planter-succulent",
+                    "pieceId": "planter-tulip",
                     "column": 11
-                }
-            ]
-        },
-        {
-            "kind": "grass",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
+                },
                 {
                     "pieceId": "planter-fern",
-                    "column": 4
+                    "column": 14
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 17
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 18
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 23
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 28
                 }
             ]
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.7200000286102296,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 7.190000057220459,
-                    "spacing": 6.670000076293945,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
         },
         {
             "kind": "tracks",
-            "dir": "left",
-            "speed": 2.569999933242798,
+            "dir": "right",
+            "speed": 2.5799999237060549,
             "objects": [
                 {
                     "pieceId": "freight",
-                    "offset": 24.149999618530275,
-                    "spacing": 18.0,
+                    "offset": 40.529998779296878,
+                    "spacing": 17.670000076293947,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.7799999713897707,
+            "objects": [
+                {
+                    "pieceId": "runner",
+                    "offset": 26.559999465942384,
+                    "spacing": 11.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "runner",
+                    "offset": 32.060001373291019,
+                    "spacing": 11.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 2.25,
+            "objects": [
+                {
+                    "pieceId": "convertible",
+                    "offset": 31.360000610351564,
+                    "spacing": 11.670000076293946,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 2.190000057220459,
+                    "spacing": 11.670000076293946,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.2100000381469728,
+            "objects": [
+                {
+                    "pieceId": "truck",
+                    "offset": 24.670000076293947,
+                    "spacing": 19.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 34.41999816894531,
+                    "spacing": 19.5,
                     "phase": 0
                 }
             ],
@@ -164,20 +186,48 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-lavender",
-                    "column": 0
+                    "pieceId": "bench",
+                    "column": 3
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 10
                 },
                 {
                     "pieceId": "planter-fern",
+                    "column": 21
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 25
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 28
+                }
+            ]
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-succulent",
                     "column": 1
                 },
                 {
-                    "pieceId": "lamp",
-                    "column": 5
+                    "pieceId": "tree",
+                    "column": 11
                 },
                 {
-                    "pieceId": "lamp",
-                    "column": 6
+                    "pieceId": "planter-succulent",
+                    "column": 22
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 28
                 }
             ]
         },

--- a/Assets/Resources/Levels/level-079.json
+++ b/Assets/Resources/Levels/level-079.json
@@ -1,19 +1,19 @@
 {
     "id": "level-079",
     "name": "level-079",
-    "columns": 11,
+    "columns": 30,
     "medal": {
-        "gold": 19.399999618530275,
-        "silver": 28.200000762939454,
-        "bronze": 40.79999923706055
+        "gold": 29.600000381469728,
+        "silver": 43.0,
+        "bronze": 62.20000076293945
     },
-    "startColumn": 4,
+    "startColumn": 21,
     "bays": [
-        0,
-        2,
-        4,
-        6,
-        10
+        3,
+        9,
+        13,
+        18,
+        24
     ],
     "rows": [
         {
@@ -24,28 +24,84 @@
             "obstructions": []
         },
         {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.7999999523162842,
+            "objects": [],
+            "obstructions": []
+        },
+        {
             "kind": "grass",
             "dir": "",
             "speed": 0.0,
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-daisy",
-                    "column": 3
+                    "pieceId": "planter-succulent",
+                    "column": 4
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 9
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 10
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 14
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 18
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 20
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 27
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 29
                 }
             ]
         },
         {
             "kind": "walkway",
-            "dir": "left",
-            "speed": 1.8600000143051148,
+            "dir": "right",
+            "speed": 1.809999942779541,
             "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.7999999523162842,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "left",
+            "speed": 2.569999933242798,
+            "objects": [
+                {
+                    "pieceId": "freight",
+                    "offset": 1.75,
+                    "spacing": 18.0,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {
             "kind": "walkway",
             "dir": "right",
-            "speed": 1.590000033378601,
+            "speed": 1.7100000381469727,
             "objects": [],
             "obstructions": []
         },
@@ -56,71 +112,69 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-fern",
-                    "column": 1
-                }
-            ]
-        },
-        {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.899999976158142,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.4500000476837159,
-            "objects": [
+                    "pieceId": "tree",
+                    "column": 0
+                },
                 {
-                    "pieceId": "raft",
-                    "offset": 8.170000076293946,
-                    "spacing": 7.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.8700000047683716,
-            "objects": [
+                    "pieceId": "bush",
+                    "column": 4
+                },
                 {
-                    "pieceId": "raft",
-                    "offset": 17.329999923706056,
-                    "spacing": 7.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "bench",
-                    "column": 1
+                    "pieceId": "planter-lavender",
+                    "column": 6
                 },
                 {
                     "pieceId": "tree",
-                    "column": 2
+                    "column": 9
                 },
                 {
-                    "pieceId": "planter-tulip",
-                    "column": 8
+                    "pieceId": "planter-lavender",
+                    "column": 10
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 11
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 18
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 26
                 }
             ]
         },
         {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.9000000953674318,
+            "objects": [
+                {
+                    "pieceId": "runner",
+                    "offset": 5.059999942779541,
+                    "spacing": 4.860000133514404,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.850000023841858,
+            "objects": [
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 11.34000015258789,
+                    "spacing": 6.670000076293945,
+                    "phase": 72
+                }
+            ],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-080.json
+++ b/Assets/Resources/Levels/level-080.json
@@ -1,19 +1,19 @@
 {
     "id": "level-080",
     "name": "level-080",
-    "columns": 13,
+    "columns": 32,
     "medal": {
-        "gold": 37.79999923706055,
-        "silver": 54.900001525878909,
-        "bronze": 79.4000015258789
+        "gold": 30.700000762939454,
+        "silver": 44.5,
+        "bronze": 64.4000015258789
     },
-    "startColumn": 1,
+    "startColumn": 10,
     "bays": [
-        2,
+        3,
         4,
-        5,
-        7,
-        12
+        8,
+        21,
+        25
     ],
     "rows": [
         {
@@ -24,10 +24,51 @@
             "obstructions": []
         },
         {
-            "kind": "walkway",
+            "kind": "bike",
             "dir": "left",
-            "speed": 1.7000000476837159,
-            "objects": [],
+            "speed": 2.5799999237060549,
+            "objects": [
+                {
+                    "pieceId": "runner",
+                    "offset": 14.109999656677246,
+                    "spacing": 4.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.5899999141693117,
+            "objects": [
+                {
+                    "pieceId": "cyclist",
+                    "offset": 2.3299999237060549,
+                    "spacing": 9.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "runner",
+                    "offset": 6.829999923706055,
+                    "spacing": 9.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "right",
+            "speed": 2.319999933242798,
+            "objects": [
+                {
+                    "pieceId": "freight",
+                    "offset": 5.25,
+                    "spacing": 18.670000076293947,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {
@@ -38,126 +79,166 @@
             "obstructions": [
                 {
                     "pieceId": "planter-daisy",
-                    "column": 3
+                    "column": 7
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 8
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 10
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 17
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 19
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 20
                 },
                 {
                     "pieceId": "tree",
-                    "column": 4
+                    "column": 21
                 },
                 {
-                    "pieceId": "planter-lavender",
-                    "column": 5
+                    "pieceId": "planter-fern",
+                    "column": 22
+                }
+            ]
+        },
+        {
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 3
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 19
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 22
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 23
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 25
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 31
                 }
             ]
         },
         {
             "kind": "tracks",
-            "dir": "left",
-            "speed": 2.25,
+            "dir": "right",
+            "speed": 2.1700000762939455,
             "objects": [
                 {
-                    "pieceId": "freight",
-                    "offset": 13.479999542236329,
-                    "spacing": 18.5,
+                    "pieceId": "passenger",
+                    "offset": 1.4800000190734864,
+                    "spacing": 18.670000076293947,
                     "phase": 0
                 }
             ],
             "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "tree",
+                    "column": 0
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 7
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 13
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 19
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 20
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 22
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 27
+                }
+            ]
         },
         {
             "kind": "walkway",
             "dir": "right",
-            "speed": 1.5800000429153443,
+            "speed": 1.840000033378601,
             "objects": [],
             "obstructions": []
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.890000104904175,
-            "objects": [
+            "kind": "grass",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
                 {
-                    "pieceId": "car",
-                    "offset": 14.350000381469727,
-                    "spacing": 19.0,
-                    "phase": 0
+                    "pieceId": "tree",
+                    "column": 5
                 },
                 {
-                    "pieceId": "convertible",
-                    "offset": 4.849999904632568,
-                    "spacing": 19.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.7699999809265137,
-            "objects": [
-                {
-                    "pieceId": "log",
-                    "offset": 3.4600000381469728,
-                    "spacing": 23.0,
-                    "phase": 0
+                    "pieceId": "planter-fern",
+                    "column": 7
                 },
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 14.960000038146973,
-                    "spacing": 23.0,
-                    "phase": 19
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.619999885559082,
-            "objects": [
-                {
-                    "pieceId": "bus",
-                    "offset": 15.039999961853028,
-                    "spacing": 7.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 2.3499999046325685,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 33.90999984741211,
-                    "spacing": 18.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.5299999713897706,
-            "objects": [
-                {
-                    "pieceId": "log-long",
-                    "offset": 8.539999961853028,
-                    "spacing": 25.0,
-                    "phase": 0
+                    "pieceId": "planter-lavender",
+                    "column": 10
                 },
                 {
-                    "pieceId": "log-long",
-                    "offset": 21.040000915527345,
-                    "spacing": 25.0,
-                    "phase": 0
+                    "pieceId": "planter-lavender",
+                    "column": 14
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 21
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 28
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-081.json
+++ b/Assets/Resources/Levels/level-081.json
@@ -1,18 +1,19 @@
 {
     "id": "level-081",
     "name": "level-081",
-    "columns": 11,
+    "columns": 34,
     "medal": {
-        "gold": 18.5,
-        "silver": 26.799999237060548,
-        "bronze": 38.79999923706055
+        "gold": 52.599998474121097,
+        "silver": 76.30000305175781,
+        "bronze": 110.5
     },
-    "startColumn": 9,
+    "startColumn": 6,
     "bays": [
-        1,
-        3,
-        6,
-        7
+        0,
+        9,
+        14,
+        18,
+        21
     ],
     "rows": [
         {
@@ -25,42 +26,48 @@
         {
             "kind": "walkway",
             "dir": "right",
-            "speed": 1.8899999856948853,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.5499999523162842,
+            "speed": 1.840000033378601,
             "objects": [],
             "obstructions": []
         },
         {
             "kind": "bike",
             "dir": "right",
-            "speed": 2.4700000286102297,
+            "speed": 2.9100000858306886,
             "objects": [
                 {
-                    "pieceId": "runner",
-                    "offset": 12.40999984741211,
-                    "spacing": 15.0,
+                    "pieceId": "cyclist",
+                    "offset": 4.170000076293945,
+                    "spacing": 9.5,
                     "phase": 0
                 },
                 {
                     "pieceId": "runner",
-                    "offset": 4.909999847412109,
-                    "spacing": 15.0,
+                    "offset": 8.920000076293946,
+                    "spacing": 9.5,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "walkway",
+            "kind": "bike",
             "dir": "right",
-            "speed": 1.7699999809265137,
-            "objects": [],
+            "speed": 2.6600000858306886,
+            "objects": [
+                {
+                    "pieceId": "runner",
+                    "offset": 2.5799999237060549,
+                    "spacing": 9.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "runner",
+                    "offset": 7.329999923706055,
+                    "spacing": 9.5,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {
@@ -70,58 +77,101 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-fern",
-                    "column": 9
-                }
-            ]
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "bench",
-                    "column": 0
+                    "pieceId": "planter-daisy",
+                    "column": 4
                 },
                 {
                     "pieceId": "lamp",
-                    "column": 2
+                    "column": 8
                 },
                 {
-                    "pieceId": "bench",
-                    "column": 3
+                    "pieceId": "planter-lavender",
+                    "column": 19
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 23
                 }
             ]
         },
         {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.7899999618530274,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.7799999713897706,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.450000047683716,
+            "kind": "tracks",
+            "dir": "left",
+            "speed": 2.7100000381469728,
             "objects": [
                 {
-                    "pieceId": "truck",
-                    "offset": 15.0,
-                    "spacing": 7.0,
+                    "pieceId": "freight",
+                    "offset": 17.219999313354493,
+                    "spacing": 14.5,
                     "phase": 0
                 }
             ],
             "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "left",
+            "speed": 2.140000104904175,
+            "objects": [
+                {
+                    "pieceId": "freight",
+                    "offset": 49.040000915527347,
+                    "spacing": 14.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.409999966621399,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.8300000429153443,
+            "objects": [
+                {
+                    "pieceId": "log-short",
+                    "offset": 17.139999389648439,
+                    "spacing": 14.670000076293946,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 24.469999313354493,
+                    "spacing": 14.670000076293946,
+                    "phase": 274
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 17
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 18
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 19
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 29
+                }
+            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-082.json
+++ b/Assets/Resources/Levels/level-082.json
@@ -1,18 +1,19 @@
 {
     "id": "level-082",
     "name": "level-082",
-    "columns": 13,
+    "columns": 32,
     "medal": {
-        "gold": 20.200000762939454,
-        "silver": 29.299999237060548,
-        "bronze": 42.400001525878909
+        "gold": 29.399999618530275,
+        "silver": 42.70000076293945,
+        "bronze": 61.79999923706055
     },
-    "startColumn": 1,
+    "startColumn": 15,
     "bays": [
-        2,
         5,
-        8,
-        12
+        9,
+        10,
+        19,
+        30
     ],
     "rows": [
         {
@@ -23,25 +24,48 @@
             "obstructions": []
         },
         {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.649999976158142,
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
             "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 3.0,
-            "objects": [
+            "obstructions": [
                 {
-                    "pieceId": "runner",
-                    "offset": 10.609999656677246,
-                    "spacing": 5.670000076293945,
-                    "phase": 0
+                    "pieceId": "planter-succulent",
+                    "column": 1
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 4
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 6
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 11
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 15
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 16
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 17
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 20
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 22
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
             "kind": "concrete",
@@ -50,26 +74,71 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "tree",
-                    "column": 3
+                    "pieceId": "lamp",
+                    "column": 2
                 },
                 {
                     "pieceId": "planter-fern",
-                    "column": 5
+                    "column": 3
                 },
                 {
-                    "pieceId": "planter-daisy",
-                    "column": 6
+                    "pieceId": "tree",
+                    "column": 21
                 },
                 {
                     "pieceId": "bush",
-                    "column": 7
+                    "column": 23
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 28
                 },
                 {
                     "pieceId": "planter-daisy",
-                    "column": 11
+                    "column": 31
                 }
             ]
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.8200000524520875,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.3899999856948853,
+            "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 40.2599983215332,
+                    "spacing": 7.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.559999942779541,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 21.309999465942384,
+                    "spacing": 14.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "gator",
+                    "offset": 28.309999465942384,
+                    "spacing": 14.0,
+                    "phase": 120
+                }
+            ],
+            "obstructions": []
         },
         {
             "kind": "walkway",
@@ -79,92 +148,42 @@
             "obstructions": []
         },
         {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.8899999856948853,
+            "objects": [
+                {
+                    "pieceId": "log-long",
+                    "offset": 26.280000686645509,
+                    "spacing": 8.800000190734864,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "left",
+            "speed": 2.7300000190734865,
+            "objects": [
+                {
+                    "pieceId": "passenger",
+                    "offset": 53.900001525878909,
+                    "spacing": 14.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
             "kind": "river",
             "dir": "left",
-            "speed": 1.559999942779541,
+            "speed": 1.4299999475479127,
             "objects": [
                 {
-                    "pieceId": "log",
-                    "offset": 8.970000267028809,
-                    "spacing": 23.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "raft",
-                    "offset": 20.469999313354493,
-                    "spacing": 23.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "planter-lavender",
-                    "column": 7
-                },
-                {
-                    "pieceId": "planter-lavender",
-                    "column": 10
-                }
-            ]
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "bush",
-                    "column": 0
-                },
-                {
-                    "pieceId": "planter-fern",
-                    "column": 5
-                }
-            ]
-        },
-        {
-            "kind": "road",
-            "dir": "left",
-            "speed": 2.2899999618530275,
-            "objects": [
-                {
-                    "pieceId": "convertible",
-                    "offset": 1.8200000524520875,
-                    "spacing": 19.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "convertible",
-                    "offset": 11.319999694824219,
-                    "spacing": 19.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "left",
-            "speed": 2.359999895095825,
-            "objects": [
-                {
-                    "pieceId": "car",
-                    "offset": 11.3100004196167,
-                    "spacing": 19.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "car",
-                    "offset": 1.809999942779541,
-                    "spacing": 19.0,
+                    "pieceId": "log-long",
+                    "offset": 34.040000915527347,
+                    "spacing": 8.800000190734864,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-083.json
+++ b/Assets/Resources/Levels/level-083.json
@@ -1,18 +1,19 @@
 {
     "id": "level-083",
     "name": "level-083",
-    "columns": 11,
+    "columns": 32,
     "medal": {
-        "gold": 57.0,
-        "silver": 82.69999694824219,
-        "bronze": 119.80000305175781
+        "gold": 28.5,
+        "silver": 41.29999923706055,
+        "bronze": 59.79999923706055
     },
-    "startColumn": 8,
+    "startColumn": 16,
     "bays": [
-        4,
-        7,
-        8,
-        9
+        2,
+        11,
+        12,
+        14,
+        26
     ],
     "rows": [
         {
@@ -23,54 +24,40 @@
             "obstructions": []
         },
         {
-            "kind": "road",
+            "kind": "bike",
             "dir": "right",
-            "speed": 2.740000009536743,
+            "speed": 2.990000009536743,
             "objects": [
                 {
-                    "pieceId": "truck",
-                    "offset": 6.190000057220459,
-                    "spacing": 7.0,
+                    "pieceId": "skater",
+                    "offset": 13.329999923706055,
+                    "spacing": 9.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "skater",
+                    "offset": 17.829999923706056,
+                    "spacing": 9.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "road",
+            "kind": "bike",
             "dir": "left",
-            "speed": 2.7699999809265138,
+            "speed": 2.619999885559082,
             "objects": [
                 {
-                    "pieceId": "truck",
-                    "offset": 6.329999923706055,
-                    "spacing": 21.0,
+                    "pieceId": "runner",
+                    "offset": 33.70000076293945,
+                    "spacing": 9.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "truck",
-                    "offset": 16.829999923706056,
-                    "spacing": 21.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.3899999856948853,
-            "objects": [
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 8.369999885559082,
-                    "spacing": 21.0,
-                    "phase": 302
-                },
-                {
-                    "pieceId": "raft",
-                    "offset": 18.8700008392334,
-                    "spacing": 21.0,
+                    "pieceId": "skater",
+                    "offset": 2.200000047683716,
+                    "spacing": 9.0,
                     "phase": 0
                 }
             ],
@@ -83,31 +70,33 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "lamp",
-                    "column": 5
+                    "pieceId": "planter-succulent",
+                    "column": 23
                 },
                 {
-                    "pieceId": "planter-lavender",
-                    "column": 6
+                    "pieceId": "planter-tulip",
+                    "column": 25
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 26
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 27
                 }
             ]
         },
         {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.4199999570846558,
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.569999933242798,
             "objects": [
                 {
-                    "pieceId": "raft",
-                    "offset": 1.8300000429153443,
-                    "spacing": 21.0,
+                    "pieceId": "cyclist",
+                    "offset": 25.459999084472658,
+                    "spacing": 4.0,
                     "phase": 0
-                },
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 12.329999923706055,
-                    "spacing": 21.0,
-                    "phase": 128
                 }
             ],
             "obstructions": []
@@ -115,60 +104,60 @@
         {
             "kind": "swamp",
             "dir": "left",
-            "speed": 1.4700000286102296,
+            "speed": 1.6399999856948853,
             "objects": [
                 {
-                    "pieceId": "turtle-log",
-                    "offset": 9.90999984741211,
-                    "spacing": 21.0,
-                    "phase": 310
+                    "pieceId": "gator",
+                    "offset": 24.010000228881837,
+                    "spacing": 7.0,
+                    "phase": 419
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.430000066757202,
+            "objects": [
+                {
+                    "pieceId": "convertible",
+                    "offset": 17.059999465942384,
+                    "spacing": 4.75,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.4700000286102296,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.9299999475479127,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.600000023841858,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 11.989999771118164,
+                    "spacing": 14.0,
+                    "phase": 0
                 },
                 {
                     "pieceId": "raft",
-                    "offset": 20.40999984741211,
-                    "spacing": 21.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 2.369999885559082,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 33.560001373291019,
-                    "spacing": 17.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.759999990463257,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 10.890000343322754,
-                    "spacing": 17.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.609999895095825,
-            "objects": [
-                {
-                    "pieceId": "skater",
-                    "offset": 11.930000305175782,
-                    "spacing": 5.0,
+                    "offset": 18.989999771118165,
+                    "spacing": 14.0,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-084.json
+++ b/Assets/Resources/Levels/level-084.json
@@ -1,18 +1,19 @@
 {
     "id": "level-084",
     "name": "level-084",
-    "columns": 11,
+    "columns": 35,
     "medal": {
-        "gold": 61.599998474121097,
-        "silver": 89.30000305175781,
-        "bronze": 129.3000030517578
+        "gold": 29.0,
+        "silver": 42.099998474121097,
+        "bronze": 61.0
     },
-    "startColumn": 8,
+    "startColumn": 29,
     "bays": [
-        0,
-        3,
-        8,
-        9
+        18,
+        20,
+        25,
+        31,
+        33
     ],
     "rows": [
         {
@@ -23,29 +24,48 @@
             "obstructions": []
         },
         {
-            "kind": "swamp",
+            "kind": "walkway",
             "dir": "left",
-            "speed": 1.850000023841858,
+            "speed": 1.600000023841858,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.8600000143051148,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 20.40999984741211,
-                    "spacing": 11.5,
+                    "pieceId": "log",
+                    "offset": 20.829999923706056,
+                    "spacing": 15.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log-short",
+                    "offset": 28.329999923706056,
+                    "spacing": 15.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.740000009536743,
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.9199999570846558,
             "objects": [
                 {
-                    "pieceId": "freight",
-                    "offset": 6.239999771118164,
-                    "spacing": 17.5,
+                    "pieceId": "log-long",
+                    "offset": 31.940000534057618,
+                    "spacing": 23.5,
                     "phase": 0
+                },
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 43.689998626708987,
+                    "spacing": 23.5,
+                    "phase": 300
                 }
             ],
             "obstructions": []
@@ -53,18 +73,32 @@
         {
             "kind": "road",
             "dir": "left",
-            "speed": 2.5399999618530275,
+            "speed": 2.4600000381469728,
             "objects": [
                 {
-                    "pieceId": "truck",
-                    "offset": 12.739999771118164,
-                    "spacing": 21.0,
+                    "pieceId": "car",
+                    "offset": 25.360000610351564,
+                    "spacing": 4.559999942779541,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.640000104904175,
+            "objects": [
+                {
+                    "pieceId": "cyclist",
+                    "offset": 17.709999084472658,
+                    "spacing": 7.800000190734863,
                     "phase": 0
                 },
                 {
-                    "pieceId": "car",
-                    "offset": 2.240000009536743,
-                    "spacing": 21.0,
+                    "pieceId": "cyclist",
+                    "offset": 21.610000610351564,
+                    "spacing": 7.800000190734863,
                     "phase": 0
                 }
             ],
@@ -73,53 +107,39 @@
         {
             "kind": "river",
             "dir": "left",
-            "speed": 1.600000023841858,
+            "speed": 1.4299999475479127,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 8.630000114440918,
-                    "spacing": 23.0,
+                    "pieceId": "log",
+                    "offset": 13.859999656677246,
+                    "spacing": 15.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "raft",
-                    "offset": 20.1299991607666,
-                    "spacing": 23.0,
-                    "phase": 0
+                    "pieceId": "gator",
+                    "offset": 21.360000610351564,
+                    "spacing": 15.0,
+                    "phase": 340
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.299999952316284,
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.399999976158142,
             "objects": [
                 {
-                    "pieceId": "car",
-                    "offset": 1.2899999618530274,
-                    "spacing": 17.0,
+                    "pieceId": "log",
+                    "offset": 40.779998779296878,
+                    "spacing": 15.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "car",
-                    "offset": 9.789999961853028,
-                    "spacing": 17.0,
-                    "phase": 0
+                    "pieceId": "turtle-log",
+                    "offset": 3.2799999713897707,
+                    "spacing": 15.0,
+                    "phase": 80
                 }
             ],
             "obstructions": []
@@ -131,36 +151,58 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "bush",
-                    "column": 0
+                    "pieceId": "bench",
+                    "column": 7
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 21
                 },
                 {
                     "pieceId": "bush",
-                    "column": 1
+                    "column": 23
                 },
                 {
-                    "pieceId": "planter-tulip",
-                    "column": 4
+                    "pieceId": "planter-fern",
+                    "column": 30
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 31
                 },
                 {
                     "pieceId": "lamp",
-                    "column": 8
+                    "column": 32
                 }
             ]
         },
         {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.509999990463257,
-            "objects": [
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
                 {
-                    "pieceId": "runner",
-                    "offset": 12.979999542236329,
-                    "spacing": 5.0,
-                    "phase": 0
+                    "pieceId": "planter-lavender",
+                    "column": 1
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 5
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 10
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 22
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 32
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-085.json
+++ b/Assets/Resources/Levels/level-085.json
@@ -1,18 +1,19 @@
 {
     "id": "level-085",
     "name": "level-085",
-    "columns": 11,
+    "columns": 32,
     "medal": {
-        "gold": 26.299999237060548,
-        "silver": 38.099998474121097,
-        "bronze": 55.20000076293945
+        "gold": 30.100000381469728,
+        "silver": 43.599998474121097,
+        "bronze": 63.20000076293945
     },
-    "startColumn": 8,
+    "startColumn": 24,
     "bays": [
-        1,
         7,
-        9,
-        10
+        21,
+        23,
+        27,
+        29
     ],
     "rows": [
         {
@@ -23,14 +24,69 @@
             "obstructions": []
         },
         {
-            "kind": "bike",
+            "kind": "walkway",
             "dir": "left",
-            "speed": 3.0,
+            "speed": 1.7999999523162842,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "right",
+            "speed": 2.2300000190734865,
             "objects": [
                 {
-                    "pieceId": "cyclist",
-                    "offset": 7.210000038146973,
-                    "spacing": 3.75,
+                    "pieceId": "freight",
+                    "offset": 52.029998779296878,
+                    "spacing": 18.670000076293947,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "right",
+            "speed": 2.6700000762939455,
+            "objects": [
+                {
+                    "pieceId": "runner",
+                    "offset": 9.260000228881836,
+                    "spacing": 9.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "runner",
+                    "offset": 13.760000228881836,
+                    "spacing": 9.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "left",
+            "speed": 2.4700000286102297,
+            "objects": [
+                {
+                    "pieceId": "freight",
+                    "offset": 40.459999084472659,
+                    "spacing": 14.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.990000009536743,
+            "objects": [
+                {
+                    "pieceId": "runner",
+                    "offset": 6.630000114440918,
+                    "spacing": 4.0,
                     "phase": 0
                 }
             ],
@@ -43,116 +99,104 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-succulent",
-                    "column": 0
+                    "pieceId": "planter-lavender",
+                    "column": 2
                 },
                 {
-                    "pieceId": "tree",
-                    "column": 5
+                    "pieceId": "bench",
+                    "column": 13
                 },
                 {
-                    "pieceId": "planter-succulent",
-                    "column": 6
+                    "pieceId": "planter-lavender",
+                    "column": 19
                 },
                 {
-                    "pieceId": "bush",
-                    "column": 7
-                },
-                {
-                    "pieceId": "bush",
-                    "column": 9
+                    "pieceId": "lamp",
+                    "column": 23
                 }
             ]
         },
         {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.8200000524520875,
-            "objects": [],
-            "obstructions": []
-        },
-        {
             "kind": "tracks",
             "dir": "left",
-            "speed": 2.190000057220459,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 25.15999984741211,
-                    "spacing": 17.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.5,
-            "objects": [
-                {
-                    "pieceId": "log",
-                    "offset": 18.09000015258789,
-                    "spacing": 7.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.4299999475479127,
-            "objects": [
-                {
-                    "pieceId": "log",
-                    "offset": 12.1899995803833,
-                    "spacing": 7.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 2.7100000381469728,
+            "speed": 2.799999952316284,
             "objects": [
                 {
                     "pieceId": "passenger",
-                    "offset": 30.260000228881837,
-                    "spacing": 17.5,
+                    "offset": 6.230000019073486,
+                    "spacing": 18.670000076293947,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.7200000286102296,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
+            "kind": "bike",
             "dir": "right",
-            "speed": 1.6799999475479127,
+            "speed": 3.0299999713897707,
             "objects": [
                 {
-                    "pieceId": "log",
-                    "offset": 20.40999984741211,
-                    "spacing": 21.0,
+                    "pieceId": "skater",
+                    "offset": 29.93000030517578,
+                    "spacing": 9.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "gator",
-                    "offset": 9.90999984741211,
-                    "spacing": 21.0,
-                    "phase": 131
+                    "pieceId": "skater",
+                    "offset": 34.43000030517578,
+                    "spacing": 9.0,
+                    "phase": 0
                 }
             ],
             "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 5
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 7
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 8
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 13
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 17
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 19
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 25
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 27
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 29
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 31
+                }
+            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-086.json
+++ b/Assets/Resources/Levels/level-086.json
@@ -1,18 +1,19 @@
 {
     "id": "level-086",
     "name": "level-086",
-    "columns": 13,
+    "columns": 35,
     "medal": {
-        "gold": 24.200000762939454,
-        "silver": 35.0,
-        "bronze": 50.70000076293945
+        "gold": 38.599998474121097,
+        "silver": 56.0,
+        "bronze": 81.0999984741211
     },
-    "startColumn": 11,
+    "startColumn": 8,
     "bays": [
-        4,
-        5,
-        8,
-        10
+        0,
+        2,
+        6,
+        23,
+        27
     ],
     "rows": [
         {
@@ -23,9 +24,110 @@
             "obstructions": []
         },
         {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.659999966621399,
+            "objects": [
+                {
+                    "pieceId": "gator",
+                    "offset": 11.75,
+                    "spacing": 15.0,
+                    "phase": 13
+                },
+                {
+                    "pieceId": "raft",
+                    "offset": 19.25,
+                    "spacing": 15.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "left",
+            "speed": 2.200000047683716,
+            "objects": [
+                {
+                    "pieceId": "freight",
+                    "offset": 6.150000095367432,
+                    "spacing": 14.75,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 2.8499999046325685,
+            "objects": [
+                {
+                    "pieceId": "truck",
+                    "offset": 35.810001373291019,
+                    "spacing": 7.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "bush",
+                    "column": 1
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 4
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 7
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 9
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 19
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 33
+                }
+            ]
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.9199999570846558,
+            "objects": [],
+            "obstructions": []
+        },
+        {
             "kind": "walkway",
             "dir": "right",
-            "speed": 1.850000023841858,
+            "speed": 1.4900000095367432,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.600000023841858,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.590000033378601,
             "objects": [],
             "obstructions": []
         },
@@ -37,99 +139,29 @@
             "obstructions": [
                 {
                     "pieceId": "bush",
-                    "column": 12
-                }
-            ]
-        },
-        {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.869999885559082,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 4.059999942779541,
-                    "spacing": 18.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.7200000286102297,
-            "objects": [
-                {
-                    "pieceId": "car",
-                    "offset": 14.90999984741211,
-                    "spacing": 4.75,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 2.640000104904175,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 28.8799991607666,
-                    "spacing": 18.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.7300000190734864,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.899999976158142,
-            "objects": [
-                {
-                    "pieceId": "log-long",
-                    "offset": 0.7599999904632568,
-                    "spacing": 25.0,
-                    "phase": 0
+                    "column": 0
                 },
                 {
-                    "pieceId": "gator",
-                    "offset": 13.260000228881836,
-                    "spacing": 25.0,
-                    "phase": 34
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.5800000429153443,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.950000047683716,
-            "objects": [
+                    "pieceId": "planter-tulip",
+                    "column": 2
+                },
                 {
-                    "pieceId": "skater",
-                    "offset": 12.850000381469727,
-                    "spacing": 4.25,
-                    "phase": 0
+                    "pieceId": "lamp",
+                    "column": 7
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 17
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 21
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 24
                 }
-            ],
-            "obstructions": []
+            ]
         },
         {
             "kind": "bank",

--- a/Assets/Resources/Levels/level-087.json
+++ b/Assets/Resources/Levels/level-087.json
@@ -1,18 +1,19 @@
 {
     "id": "level-087",
     "name": "level-087",
-    "columns": 13,
+    "columns": 32,
     "medal": {
-        "gold": 21.399999618530275,
-        "silver": 31.0,
-        "bronze": 44.900001525878909
+        "gold": 22.799999237060548,
+        "silver": 33.099998474121097,
+        "bronze": 48.0
     },
-    "startColumn": 3,
+    "startColumn": 11,
     "bays": [
-        5,
-        6,
-        9,
-        12
+        4,
+        7,
+        10,
+        12,
+        14
     ],
     "rows": [
         {
@@ -25,83 +26,52 @@
         {
             "kind": "bike",
             "dir": "left",
-            "speed": 3.0,
+            "speed": 3.049999952316284,
             "objects": [
                 {
                     "pieceId": "cyclist",
-                    "offset": 15.539999961853028,
-                    "spacing": 4.25,
+                    "offset": 17.989999771118165,
+                    "spacing": 9.0,
                     "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.4700000286102296,
-            "objects": [
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 21.90999984741211,
-                    "spacing": 7.670000076293945,
-                    "phase": 295
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "bush",
-                    "column": 0
                 },
                 {
-                    "pieceId": "bush",
-                    "column": 9
-                }
-            ]
-        },
-        {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.819999933242798,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 19.190000534057618,
-                    "spacing": 18.5,
+                    "pieceId": "runner",
+                    "offset": 22.489999771118165,
+                    "spacing": 9.0,
                     "phase": 0
                 }
             ],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.7300000190734864,
-            "objects": [],
             "obstructions": []
         },
         {
             "kind": "bike",
             "dir": "left",
-            "speed": 2.8299999237060549,
+            "speed": 2.690000057220459,
             "objects": [
                 {
-                    "pieceId": "skater",
-                    "offset": 13.65999984741211,
-                    "spacing": 17.0,
+                    "pieceId": "runner",
+                    "offset": 4.260000228881836,
+                    "spacing": 4.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 2.4700000286102297,
+            "objects": [
+                {
+                    "pieceId": "convertible",
+                    "offset": 4.03000020980835,
+                    "spacing": 12.670000076293946,
                     "phase": 0
                 },
                 {
-                    "pieceId": "skater",
-                    "offset": 5.159999847412109,
-                    "spacing": 17.0,
+                    "pieceId": "convertible",
+                    "offset": 10.359999656677246,
+                    "spacing": 12.670000076293946,
                     "phase": 0
                 }
             ],
@@ -114,48 +84,101 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "lamp",
-                    "column": 0
+                    "pieceId": "planter-fern",
+                    "column": 8
                 },
                 {
                     "pieceId": "planter-tulip",
-                    "column": 3
+                    "column": 10
                 },
                 {
-                    "pieceId": "planter-fern",
-                    "column": 5
+                    "pieceId": "tree",
+                    "column": 13
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 16
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 27
                 }
             ]
         },
         {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.7799999713897707,
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.5700000524520875,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.8899999856948853,
             "objects": [
                 {
-                    "pieceId": "runner",
-                    "offset": 10.739999771118164,
-                    "spacing": 8.5,
-                    "phase": 0
+                    "pieceId": "turtle-log",
+                    "offset": 35.29999923706055,
+                    "spacing": 22.0,
+                    "phase": 231
                 },
                 {
-                    "pieceId": "runner",
-                    "offset": 14.989999771118164,
-                    "spacing": 8.5,
+                    "pieceId": "log-long",
+                    "offset": 2.299999952316284,
+                    "spacing": 22.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "swamp",
+            "kind": "bike",
             "dir": "left",
-            "speed": 1.4199999570846558,
+            "speed": 2.799999952316284,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 12.40999984741211,
-                    "spacing": 7.0,
+                    "pieceId": "skater",
+                    "offset": 35.34000015258789,
+                    "spacing": 12.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "cyclist",
+                    "offset": 5.340000152587891,
+                    "spacing": 12.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.9200000762939455,
+            "objects": [
+                {
+                    "pieceId": "runner",
+                    "offset": 4.269999980926514,
+                    "spacing": 4.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.75,
+            "objects": [
+                {
+                    "pieceId": "car",
+                    "offset": 3.5,
+                    "spacing": 4.75,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-088.json
+++ b/Assets/Resources/Levels/level-088.json
@@ -1,18 +1,19 @@
 {
     "id": "level-088",
     "name": "level-088",
-    "columns": 11,
+    "columns": 32,
     "medal": {
-        "gold": 30.899999618530275,
-        "silver": 44.79999923706055,
-        "bronze": 64.9000015258789
+        "gold": 31.799999237060548,
+        "silver": 46.20000076293945,
+        "bronze": 66.80000305175781
     },
-    "startColumn": 3,
+    "startColumn": 20,
     "bays": [
-        0,
-        2,
-        3,
-        9
+        16,
+        21,
+        23,
+        25,
+        31
     ],
     "rows": [
         {
@@ -23,96 +24,36 @@
             "obstructions": []
         },
         {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.700000047683716,
-            "objects": [
-                {
-                    "pieceId": "cyclist",
-                    "offset": 9.460000038146973,
-                    "spacing": 3.75,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
+            "kind": "tracks",
             "dir": "left",
-            "speed": 2.880000114440918,
+            "speed": 2.2200000286102297,
             "objects": [
                 {
-                    "pieceId": "bus",
-                    "offset": 4.860000133514404,
-                    "spacing": 19.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "car",
-                    "offset": 14.359999656677246,
-                    "spacing": 19.0,
+                    "pieceId": "passenger",
+                    "offset": 34.7400016784668,
+                    "spacing": 18.670000076293947,
                     "phase": 0
                 }
             ],
             "obstructions": []
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "planter-fern",
-                    "column": 3
-                },
-                {
-                    "pieceId": "lamp",
-                    "column": 4
-                },
-                {
-                    "pieceId": "lamp",
-                    "column": 6
-                }
-            ]
         },
         {
             "kind": "walkway",
-            "dir": "right",
-            "speed": 1.6100000143051148,
+            "dir": "left",
+            "speed": 1.8799999952316285,
             "objects": [],
             "obstructions": []
         },
         {
             "kind": "river",
-            "dir": "right",
-            "speed": 1.809999942779541,
+            "dir": "left",
+            "speed": 1.399999976158142,
             "objects": [
                 {
-                    "pieceId": "log-short",
-                    "offset": 16.0,
-                    "spacing": 21.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log",
-                    "offset": 5.5,
-                    "spacing": 21.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 2.4100000858306886,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 23.15999984741211,
-                    "spacing": 17.5,
-                    "phase": 0
+                    "pieceId": "gator",
+                    "offset": 19.860000610351564,
+                    "spacing": 7.0,
+                    "phase": 286
                 }
             ],
             "obstructions": []
@@ -123,32 +64,8 @@
             "speed": 0.0,
             "objects": [],
             "obstructions": [
-                {
-                    "pieceId": "planter-tulip",
-                    "column": 0
-                },
-                {
-                    "pieceId": "bench",
-                    "column": 1
-                },
                 {
                     "pieceId": "lamp",
-                    "column": 3
-                },
-                {
-                    "pieceId": "planter-daisy",
-                    "column": 10
-                }
-            ]
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "bench",
                     "column": 0
                 },
                 {
@@ -156,27 +73,107 @@
                     "column": 2
                 },
                 {
-                    "pieceId": "planter-lavender",
-                    "column": 4
+                    "pieceId": "bush",
+                    "column": 6
                 },
                 {
-                    "pieceId": "planter-daisy",
-                    "column": 5
+                    "pieceId": "tree",
+                    "column": 11
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 17
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 25
                 }
             ]
         },
         {
-            "kind": "bike",
+            "kind": "tracks",
             "dir": "right",
-            "speed": 2.700000047683716,
+            "speed": 2.3399999141693117,
             "objects": [
                 {
-                    "pieceId": "skater",
-                    "offset": 11.029999732971192,
-                    "spacing": 3.75,
+                    "pieceId": "freight",
+                    "offset": 29.100000381469728,
+                    "spacing": 18.670000076293947,
                     "phase": 0
                 }
             ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.6699999570846558,
+            "objects": [
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 20.700000762939454,
+                    "spacing": 7.0,
+                    "phase": 14
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.8300000429153443,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 5
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 7
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 9
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 18
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 24
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 25
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 29
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 31
+                }
+            ]
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.9700000286102296,
+            "objects": [],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-089.json
+++ b/Assets/Resources/Levels/level-089.json
@@ -1,18 +1,19 @@
 {
     "id": "level-089",
     "name": "level-089",
-    "columns": 13,
+    "columns": 35,
     "medal": {
-        "gold": 21.799999237060548,
-        "silver": 31.600000381469728,
-        "bronze": 45.79999923706055
+        "gold": 29.100000381469728,
+        "silver": 42.20000076293945,
+        "bronze": 61.099998474121097
     },
-    "startColumn": 11,
+    "startColumn": 14,
     "bays": [
-        0,
-        3,
         5,
-        12
+        13,
+        17,
+        24,
+        29
     ],
     "rows": [
         {
@@ -23,56 +24,41 @@
             "obstructions": []
         },
         {
-            "kind": "tracks",
-            "dir": "left",
+            "kind": "road",
+            "dir": "right",
             "speed": 2.7100000381469728,
             "objects": [
                 {
-                    "pieceId": "freight",
-                    "offset": 28.959999084472658,
-                    "spacing": 18.5,
+                    "pieceId": "truck",
+                    "offset": 35.2400016784668,
+                    "spacing": 15.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 42.7400016784668,
+                    "spacing": 15.0,
                     "phase": 0
                 }
             ],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.9800000190734864,
-            "objects": [],
             "obstructions": []
         },
         {
             "kind": "walkway",
             "dir": "right",
-            "speed": 1.7799999713897706,
+            "speed": 1.5299999713897706,
             "objects": [],
             "obstructions": []
         },
         {
-            "kind": "road",
-            "dir": "left",
-            "speed": 2.4200000762939455,
+            "kind": "bike",
+            "dir": "right",
+            "speed": 3.0,
             "objects": [
                 {
-                    "pieceId": "car",
-                    "offset": 3.4000000953674318,
-                    "spacing": 4.75,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.9200000762939455,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 10.350000381469727,
-                    "spacing": 18.5,
+                    "pieceId": "runner",
+                    "offset": 4.900000095367432,
+                    "spacing": 3.9000000953674318,
                     "phase": 0
                 }
             ],
@@ -80,13 +66,59 @@
         },
         {
             "kind": "swamp",
-            "dir": "right",
-            "speed": 1.440000057220459,
+            "dir": "left",
+            "speed": 1.600000023841858,
             "objects": [
                 {
                     "pieceId": "raft",
-                    "offset": 16.729999542236329,
-                    "spacing": 7.670000076293945,
+                    "offset": 23.489999771118165,
+                    "spacing": 15.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log",
+                    "offset": 30.989999771118165,
+                    "spacing": 15.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.840000033378601,
+            "objects": [
+                {
+                    "pieceId": "gator",
+                    "offset": 2.4000000953674318,
+                    "spacing": 15.0,
+                    "phase": 360
+                },
+                {
+                    "pieceId": "log-short",
+                    "offset": 9.899999618530274,
+                    "spacing": 15.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.440000057220459,
+            "objects": [
+                {
+                    "pieceId": "truck",
+                    "offset": 24.399999618530275,
+                    "spacing": 15.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "truck",
+                    "offset": 31.899999618530275,
+                    "spacing": 15.0,
                     "phase": 0
                 }
             ],
@@ -94,41 +126,34 @@
         },
         {
             "kind": "walkway",
-            "dir": "right",
-            "speed": 1.5800000429153443,
+            "dir": "left",
+            "speed": 1.809999942779541,
             "objects": [],
             "obstructions": []
         },
         {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.6699999570846558,
             "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "bush",
-                    "column": 4
-                },
-                {
-                    "pieceId": "planter-fern",
-                    "column": 5
-                },
-                {
-                    "pieceId": "planter-succulent",
-                    "column": 7
-                }
-            ]
+            "obstructions": []
         },
         {
-            "kind": "bike",
+            "kind": "swamp",
             "dir": "left",
-            "speed": 2.609999895095825,
+            "speed": 1.909999966621399,
             "objects": [
                 {
-                    "pieceId": "runner",
-                    "offset": 2.869999885559082,
-                    "spacing": 4.25,
-                    "phase": 0
+                    "pieceId": "turtle-log",
+                    "offset": 44.86000061035156,
+                    "spacing": 15.0,
+                    "phase": 140
+                },
+                {
+                    "pieceId": "gator",
+                    "offset": 7.360000133514404,
+                    "spacing": 15.0,
+                    "phase": 254
                 }
             ],
             "obstructions": []

--- a/Assets/Resources/Levels/level-090.json
+++ b/Assets/Resources/Levels/level-090.json
@@ -1,18 +1,19 @@
 {
     "id": "level-090",
     "name": "level-090",
-    "columns": 11,
+    "columns": 33,
     "medal": {
-        "gold": 20.299999237060548,
-        "silver": 29.5,
-        "bronze": 42.70000076293945
+        "gold": 26.799999237060548,
+        "silver": 38.79999923706055,
+        "bronze": 56.20000076293945
     },
-    "startColumn": 4,
+    "startColumn": 23,
     "bays": [
-        0,
-        2,
-        3,
-        4
+        8,
+        17,
+        25,
+        29,
+        30
     ],
     "rows": [
         {
@@ -23,159 +24,138 @@
             "obstructions": []
         },
         {
-            "kind": "bike",
+            "kind": "walkway",
             "dir": "right",
-            "speed": 2.7100000381469728,
-            "objects": [
-                {
-                    "pieceId": "cyclist",
-                    "offset": 9.420000076293946,
-                    "spacing": 7.5,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "runner",
-                    "offset": 13.170000076293946,
-                    "spacing": 7.5,
-                    "phase": 0
-                }
-            ],
+            "speed": 1.840000033378601,
+            "objects": [],
             "obstructions": []
         },
         {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.7799999713897707,
-            "objects": [
-                {
-                    "pieceId": "cyclist",
-                    "offset": 13.970000267028809,
-                    "spacing": 15.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "runner",
-                    "offset": 6.46999979019165,
-                    "spacing": 15.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.6799999475479127,
-            "objects": [
-                {
-                    "pieceId": "log-long",
-                    "offset": 20.979999542236329,
-                    "spacing": 23.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 9.479999542236329,
-                    "spacing": 23.0,
-                    "phase": 199
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 2.390000104904175,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 2.5899999141693117,
-                    "spacing": 17.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 3.0199999809265138,
-            "objects": [
-                {
-                    "pieceId": "skater",
-                    "offset": 3.75,
-                    "spacing": 3.75,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.5299999713897707,
-            "objects": [
-                {
-                    "pieceId": "cyclist",
-                    "offset": 10.760000228881836,
-                    "spacing": 15.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "runner",
-                    "offset": 3.259999990463257,
-                    "spacing": 15.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "left",
-            "speed": 2.549999952316284,
-            "objects": [
-                {
-                    "pieceId": "convertible",
-                    "offset": 0.2199999988079071,
-                    "spacing": 5.670000076293945,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
+            "kind": "walkway",
             "dir": "left",
             "speed": 1.7999999523162842,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "tree",
+                    "column": 2
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 17
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 22
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 27
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 29
+                }
+            ]
+        },
+        {
+            "kind": "bike",
+            "dir": "right",
+            "speed": 2.9200000762939455,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 19.520000457763673,
-                    "spacing": 11.5,
+                    "pieceId": "runner",
+                    "offset": 8.350000381469727,
+                    "spacing": 9.25,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "cyclist",
+                    "offset": 12.979999542236329,
+                    "spacing": 9.25,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.6699999570846558,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "lamp",
+                    "column": 1
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 5
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 8
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 19
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 29
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 30
+                }
+            ]
+        },
+        {
             "kind": "bike",
             "dir": "right",
-            "speed": 2.8299999237060549,
+            "speed": 2.759999990463257,
             "objects": [
                 {
-                    "pieceId": "cyclist",
-                    "offset": 6.519999980926514,
-                    "spacing": 7.5,
+                    "pieceId": "skater",
+                    "offset": 13.850000381469727,
+                    "spacing": 9.25,
                     "phase": 0
                 },
                 {
-                    "pieceId": "skater",
-                    "offset": 10.270000457763672,
-                    "spacing": 7.5,
+                    "pieceId": "cyclist",
+                    "offset": 18.479999542236329,
+                    "spacing": 9.25,
                     "phase": 0
                 }
             ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.5499999523162842,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.6799999475479127,
+            "objects": [],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-091.json
+++ b/Assets/Resources/Levels/level-091.json
@@ -1,19 +1,19 @@
 {
     "id": "level-091",
     "name": "level-091",
-    "columns": 12,
+    "columns": 33,
     "medal": {
-        "gold": 60.0,
-        "silver": 87.0,
-        "bronze": 125.9000015258789
+        "gold": 29.600000381469728,
+        "silver": 43.0,
+        "bronze": 62.20000076293945
     },
-    "startColumn": 5,
+    "startColumn": 22,
     "bays": [
-        2,
         3,
-        4,
-        6,
-        8
+        15,
+        19,
+        21,
+        25
     ],
     "rows": [
         {
@@ -24,20 +24,85 @@
             "obstructions": []
         },
         {
-            "kind": "bike",
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 4
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 5
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 6
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 14
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 22
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 23
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 26
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 27
+                }
+            ]
+        },
+        {
+            "kind": "swamp",
             "dir": "left",
-            "speed": 3.009999990463257,
+            "speed": 1.8899999856948853,
             "objects": [
                 {
-                    "pieceId": "runner",
-                    "offset": 6.070000171661377,
-                    "spacing": 16.0,
+                    "pieceId": "raft",
+                    "offset": 26.950000762939454,
+                    "spacing": 22.5,
                     "phase": 0
                 },
                 {
-                    "pieceId": "cyclist",
-                    "offset": 14.069999694824219,
-                    "spacing": 16.0,
+                    "pieceId": "log-long",
+                    "offset": 38.20000076293945,
+                    "spacing": 22.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.6399999856948853,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "right",
+            "speed": 2.630000114440918,
+            "objects": [
+                {
+                    "pieceId": "passenger",
+                    "offset": 46.029998779296878,
+                    "spacing": 19.0,
                     "phase": 0
                 }
             ],
@@ -46,19 +111,13 @@
         {
             "kind": "swamp",
             "dir": "left",
-            "speed": 1.9199999570846558,
+            "speed": 1.4700000286102296,
             "objects": [
                 {
-                    "pieceId": "log",
-                    "offset": 20.479999542236329,
-                    "spacing": 22.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "gator",
-                    "offset": 9.479999542236329,
-                    "spacing": 22.0,
-                    "phase": 182
+                    "pieceId": "turtle-log",
+                    "offset": 28.350000381469728,
+                    "spacing": 7.170000076293945,
+                    "phase": 26
                 }
             ],
             "obstructions": []
@@ -71,122 +130,63 @@
             "obstructions": [
                 {
                     "pieceId": "planter-fern",
-                    "column": 1
-                },
-                {
-                    "pieceId": "planter-daisy",
-                    "column": 4
+                    "column": 2
                 },
                 {
                     "pieceId": "tree",
-                    "column": 5
+                    "column": 8
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 9
                 },
                 {
                     "pieceId": "planter-succulent",
-                    "column": 9
+                    "column": 10
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 15
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 19
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 20
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 23
                 }
             ]
         },
         {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.630000114440918,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 28.959999084472658,
-                    "spacing": 18.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.7100000381469727,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 14.859999656677246,
-                    "spacing": 6.670000076293945,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
+            "kind": "bike",
             "dir": "right",
-            "speed": 2.9800000190734865,
+            "speed": 2.75,
             "objects": [
                 {
-                    "pieceId": "freight",
-                    "offset": 8.729999542236329,
-                    "spacing": 18.0,
+                    "pieceId": "skater",
+                    "offset": 16.1299991607666,
+                    "spacing": 9.25,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "cyclist",
+                    "offset": 20.75,
+                    "spacing": 9.25,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "swamp",
+            "kind": "walkway",
             "dir": "right",
-            "speed": 1.6100000143051148,
-            "objects": [
-                {
-                    "pieceId": "raft",
-                    "offset": 3.609999895095825,
-                    "spacing": 24.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log-long",
-                    "offset": 15.609999656677246,
-                    "spacing": 24.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.909999966621399,
-            "objects": [
-                {
-                    "pieceId": "gator",
-                    "offset": 10.399999618530274,
-                    "spacing": 22.0,
-                    "phase": 27
-                },
-                {
-                    "pieceId": "log",
-                    "offset": 21.399999618530275,
-                    "spacing": 22.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.7699999809265137,
-            "objects": [
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 0.4699999988079071,
-                    "spacing": 24.0,
-                    "phase": 168
-                },
-                {
-                    "pieceId": "log-long",
-                    "offset": 12.470000267028809,
-                    "spacing": 24.0,
-                    "phase": 0
-                }
-            ],
+            "speed": 1.75,
+            "objects": [],
             "obstructions": []
         },
         {
@@ -196,16 +196,68 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "tree",
-                    "column": 4
+                    "pieceId": "planter-daisy",
+                    "column": 2
                 },
                 {
-                    "pieceId": "planter-daisy",
-                    "column": 8
+                    "pieceId": "planter-succulent",
+                    "column": 10
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 14
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 20
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 23
                 },
                 {
                     "pieceId": "planter-lavender",
-                    "column": 11
+                    "column": 24
+                }
+            ]
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 0
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 3
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 4
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 12
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 13
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 14
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 23
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 26
                 }
             ]
         },

--- a/Assets/Resources/Levels/level-092.json
+++ b/Assets/Resources/Levels/level-092.json
@@ -1,19 +1,19 @@
 {
     "id": "level-092",
     "name": "level-092",
-    "columns": 13,
+    "columns": 32,
     "medal": {
-        "gold": 39.900001525878909,
-        "silver": 57.900001525878909,
-        "bronze": 83.80000305175781
+        "gold": 28.899999618530275,
+        "silver": 42.0,
+        "bronze": 60.79999923706055
     },
-    "startColumn": 4,
+    "startColumn": 21,
     "bays": [
-        1,
-        3,
-        4,
-        7,
-        10
+        9,
+        11,
+        18,
+        23,
+        29
     ],
     "rows": [
         {
@@ -24,34 +24,126 @@
             "obstructions": []
         },
         {
-            "kind": "bike",
+            "kind": "road",
             "dir": "right",
-            "speed": 2.7100000381469728,
+            "speed": 2.4000000953674318,
             "objects": [
                 {
-                    "pieceId": "runner",
-                    "offset": 2.2100000381469728,
-                    "spacing": 8.5,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "skater",
-                    "offset": 6.460000038146973,
-                    "spacing": 8.5,
+                    "pieceId": "car",
+                    "offset": 28.309999465942384,
+                    "spacing": 5.429999828338623,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "river",
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 7
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 19
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 20
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 24
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 27
+                }
+            ]
+        },
+        {
+            "kind": "road",
             "dir": "right",
-            "speed": 1.6200000047683716,
+            "speed": 2.9600000381469728,
             "objects": [
                 {
-                    "pieceId": "log",
-                    "offset": 15.920000076293946,
-                    "spacing": 7.670000076293945,
+                    "pieceId": "convertible",
+                    "offset": 15.420000076293946,
+                    "spacing": 4.75,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "bush",
+                    "column": 0
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 6
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 8
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 11
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 13
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 20
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 27
+                }
+            ]
+        },
+        {
+            "kind": "tracks",
+            "dir": "left",
+            "speed": 2.309999942779541,
+            "objects": [
+                {
+                    "pieceId": "freight",
+                    "offset": 37.34000015258789,
+                    "spacing": 18.670000076293947,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.6699999570846558,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 41.43000030517578,
+                    "spacing": 14.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log-short",
+                    "offset": 6.429999828338623,
+                    "spacing": 14.0,
                     "phase": 0
                 }
             ],
@@ -65,15 +157,31 @@
             "obstructions": [
                 {
                     "pieceId": "lamp",
-                    "column": 1
-                },
-                {
-                    "pieceId": "planter-lavender",
                     "column": 7
                 },
                 {
+                    "pieceId": "lamp",
+                    "column": 9
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 17
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 19
+                },
+                {
                     "pieceId": "tree",
-                    "column": 8
+                    "column": 25
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 26
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 29
                 }
             ]
         },
@@ -84,116 +192,60 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "planter-lavender",
-                    "column": 5
+                    "pieceId": "planter-tulip",
+                    "column": 1
                 },
                 {
-                    "pieceId": "planter-tulip",
-                    "column": 7
+                    "pieceId": "lamp",
+                    "column": 8
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 15
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 17
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 19
                 },
                 {
                     "pieceId": "planter-daisy",
-                    "column": 10
+                    "column": 20
                 }
             ]
         },
         {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 3.109999895095825,
-            "objects": [
-                {
-                    "pieceId": "runner",
-                    "offset": 0.3400000035762787,
-                    "spacing": 5.670000076293945,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.690000057220459,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 5.0,
-                    "spacing": 21.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log-short",
-                    "offset": 15.5,
-                    "spacing": 21.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 2.430000066757202,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 34.2599983215332,
-                    "spacing": 18.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.5099999904632569,
-            "objects": [
-                {
-                    "pieceId": "gator",
-                    "offset": 8.869999885559082,
-                    "spacing": 23.0,
-                    "phase": 198
-                },
-                {
-                    "pieceId": "log",
-                    "offset": 20.3700008392334,
-                    "spacing": 23.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
             "kind": "road",
             "dir": "left",
-            "speed": 2.6700000762939455,
+            "speed": 2.5799999237060549,
             "objects": [
                 {
                     "pieceId": "truck",
-                    "offset": 7.440000057220459,
-                    "spacing": 7.670000076293945,
+                    "offset": 1.2400000095367432,
+                    "spacing": 14.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "convertible",
+                    "offset": 8.239999771118164,
+                    "spacing": 14.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "swamp",
+            "kind": "river",
             "dir": "left",
-            "speed": 1.7400000095367432,
+            "speed": 1.4199999570846558,
             "objects": [
                 {
-                    "pieceId": "log-long",
-                    "offset": 6.650000095367432,
-                    "spacing": 25.0,
-                    "phase": 0
-                },
-                {
                     "pieceId": "raft",
-                    "offset": 19.149999618530275,
-                    "spacing": 25.0,
+                    "offset": 1.4800000190734864,
+                    "spacing": 7.0,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-093.json
+++ b/Assets/Resources/Levels/level-093.json
@@ -1,19 +1,19 @@
 {
     "id": "level-093",
     "name": "level-093",
-    "columns": 11,
+    "columns": 32,
     "medal": {
-        "gold": 27.399999618530275,
-        "silver": 39.70000076293945,
-        "bronze": 57.5
+        "gold": 32.599998474121097,
+        "silver": 47.29999923706055,
+        "bronze": 68.5
     },
-    "startColumn": 3,
+    "startColumn": 14,
     "bays": [
-        1,
-        2,
-        4,
-        5,
-        6
+        7,
+        11,
+        16,
+        17,
+        21
     ],
     "rows": [
         {
@@ -24,107 +24,50 @@
             "obstructions": []
         },
         {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.6699999570846558,
+            "objects": [
+                {
+                    "pieceId": "gator",
+                    "offset": 28.489999771118165,
+                    "spacing": 7.0,
+                    "phase": 86
+                }
+            ],
+            "obstructions": []
+        },
+        {
             "kind": "tracks",
             "dir": "left",
-            "speed": 3.0299999713897707,
+            "speed": 2.299999952316284,
             "objects": [
                 {
-                    "pieceId": "passenger",
-                    "offset": 0.8899999856948853,
-                    "spacing": 17.5,
+                    "pieceId": "freight",
+                    "offset": 31.6299991607666,
+                    "spacing": 18.670000076293947,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "road",
+            "kind": "walkway",
             "dir": "left",
-            "speed": 2.259999990463257,
-            "objects": [
-                {
-                    "pieceId": "convertible",
-                    "offset": 8.550000190734864,
-                    "spacing": 19.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "bus",
-                    "offset": 18.049999237060548,
-                    "spacing": 19.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "bench",
-                    "column": 2
-                }
-            ]
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "bush",
-                    "column": 0
-                },
-                {
-                    "pieceId": "planter-lavender",
-                    "column": 2
-                },
-                {
-                    "pieceId": "bench",
-                    "column": 3
-                },
-                {
-                    "pieceId": "lamp",
-                    "column": 4
-                },
-                {
-                    "pieceId": "planter-daisy",
-                    "column": 6
-                },
-                {
-                    "pieceId": "planter-succulent",
-                    "column": 8
-                }
-            ]
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.9500000476837159,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 2.059999942779541,
+            "speed": 1.7100000381469727,
             "objects": [],
             "obstructions": []
         },
         {
             "kind": "river",
-            "dir": "left",
-            "speed": 1.7000000476837159,
+            "dir": "right",
+            "speed": 1.809999942779541,
             "objects": [
                 {
-                    "pieceId": "gator",
-                    "offset": 0.10999999940395355,
-                    "spacing": 7.0,
-                    "phase": 311
+                    "pieceId": "raft",
+                    "offset": 19.760000228881837,
+                    "spacing": 6.0,
+                    "phase": 0
                 }
             ],
             "obstructions": []
@@ -136,42 +79,127 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "lamp",
+                    "pieceId": "planter-tulip",
                     "column": 1
                 },
                 {
-                    "pieceId": "bush",
-                    "column": 9
+                    "pieceId": "planter-fern",
+                    "column": 7
                 },
                 {
-                    "pieceId": "planter-lavender",
-                    "column": 10
+                    "pieceId": "lamp",
+                    "column": 11
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 15
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 16
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 20
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 27
                 }
             ]
         },
         {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.759999990463257,
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.5999999046325685,
             "objects": [
                 {
-                    "pieceId": "convertible",
-                    "offset": 13.4399995803833,
-                    "spacing": 4.25,
+                    "pieceId": "cyclist",
+                    "offset": 27.90999984741211,
+                    "spacing": 9.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "runner",
+                    "offset": 32.40999984741211,
+                    "spacing": 9.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.930000066757202,
+            "kind": "road",
+            "dir": "right",
+            "speed": 2.390000104904175,
             "objects": [
                 {
-                    "pieceId": "cyclist",
-                    "offset": 1.350000023841858,
-                    "spacing": 5.0,
+                    "pieceId": "truck",
+                    "offset": 34.45000076293945,
+                    "spacing": 14.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "truck",
+                    "offset": 41.45000076293945,
+                    "spacing": 14.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.8799999952316285,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 5
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 15
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 21
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 23
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 27
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 30
+                }
+            ]
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.740000009536743,
+            "objects": [
+                {
+                    "pieceId": "bus",
+                    "offset": 19.600000381469728,
+                    "spacing": 6.670000076293945,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-094.json
+++ b/Assets/Resources/Levels/level-094.json
@@ -1,19 +1,19 @@
 {
     "id": "level-094",
     "name": "level-094",
-    "columns": 13,
+    "columns": 32,
     "medal": {
-        "gold": 25.399999618530275,
-        "silver": 36.79999923706055,
-        "bronze": 53.29999923706055
+        "gold": 31.200000762939454,
+        "silver": 45.29999923706055,
+        "bronze": 65.5999984741211
     },
-    "startColumn": 7,
+    "startColumn": 12,
     "bays": [
         0,
-        3,
-        7,
-        8,
-        9
+        6,
+        10,
+        16,
+        26
     ],
     "rows": [
         {
@@ -24,14 +24,61 @@
             "obstructions": []
         },
         {
-            "kind": "bike",
+            "kind": "road",
             "dir": "left",
-            "speed": 2.7100000381469728,
+            "speed": 2.690000057220459,
+            "objects": [
+                {
+                    "pieceId": "car",
+                    "offset": 2.0899999141693117,
+                    "spacing": 4.75,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.940000057220459,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "right",
+            "speed": 3.009999990463257,
             "objects": [
                 {
                     "pieceId": "runner",
-                    "offset": 15.829999923706055,
-                    "spacing": 4.25,
+                    "offset": 19.59000015258789,
+                    "spacing": 9.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "skater",
+                    "offset": 24.09000015258789,
+                    "spacing": 9.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.2799999713897707,
+            "objects": [
+                {
+                    "pieceId": "truck",
+                    "offset": 25.079999923706056,
+                    "spacing": 14.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "convertible",
+                    "offset": 32.08000183105469,
+                    "spacing": 14.0,
                     "phase": 0
                 }
             ],
@@ -39,53 +86,46 @@
         },
         {
             "kind": "bike",
+            "dir": "right",
+            "speed": 3.109999895095825,
+            "objects": [
+                {
+                    "pieceId": "skater",
+                    "offset": 17.049999237060548,
+                    "spacing": 9.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "runner",
+                    "offset": 21.549999237060548,
+                    "spacing": 9.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.5700000524520875,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
             "dir": "right",
             "speed": 2.6600000858306886,
             "objects": [
                 {
-                    "pieceId": "skater",
-                    "offset": 10.180000305175782,
-                    "spacing": 4.25,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.7799999713897706,
-            "objects": [
-                {
-                    "pieceId": "gator",
-                    "offset": 6.320000171661377,
-                    "spacing": 23.0,
-                    "phase": 111
-                },
-                {
-                    "pieceId": "log",
-                    "offset": 17.81999969482422,
-                    "spacing": 23.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 3.059999942779541,
-            "objects": [
-                {
-                    "pieceId": "skater",
-                    "offset": 9.6899995803833,
-                    "spacing": 8.5,
+                    "pieceId": "convertible",
+                    "offset": 24.81999969482422,
+                    "spacing": 14.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "skater",
-                    "offset": 13.9399995803833,
-                    "spacing": 8.5,
+                    "pieceId": "truck",
+                    "offset": 31.81999969482422,
+                    "spacing": 14.0,
                     "phase": 0
                 }
             ],
@@ -98,83 +138,67 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "lamp",
-                    "column": 11
+                    "pieceId": "planter-tulip",
+                    "column": 12
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 18
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 20
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 22
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 28
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 29
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 30
                 }
             ]
         },
         {
-            "kind": "walkway",
+            "kind": "tracks",
             "dir": "right",
-            "speed": 1.6299999952316285,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.619999885559082,
+            "speed": 2.859999895095825,
             "objects": [
                 {
-                    "pieceId": "convertible",
-                    "offset": 3.2799999713897707,
-                    "spacing": 23.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "truck",
-                    "offset": 14.779999732971192,
-                    "spacing": 23.0,
+                    "pieceId": "passenger",
+                    "offset": 5.340000152587891,
+                    "spacing": 14.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "bike",
+            "kind": "river",
             "dir": "right",
-            "speed": 2.9200000762939455,
+            "speed": 1.8700000047683716,
             "objects": [
                 {
-                    "pieceId": "cyclist",
-                    "offset": 10.670000076293946,
-                    "spacing": 17.0,
+                    "pieceId": "log",
+                    "offset": 30.309999465942384,
+                    "spacing": 14.0,
                     "phase": 0
                 },
                 {
-                    "pieceId": "skater",
-                    "offset": 2.1700000762939455,
-                    "spacing": 17.0,
+                    "pieceId": "raft",
+                    "offset": 37.310001373291019,
+                    "spacing": 14.0,
                     "phase": 0
                 }
             ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.9500000476837159,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 4.079999923706055,
-                    "spacing": 10.5,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log-short",
-                    "offset": 9.329999923706055,
-                    "spacing": 10.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 2.0899999141693117,
-            "objects": [],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-095.json
+++ b/Assets/Resources/Levels/level-095.json
@@ -1,19 +1,19 @@
 {
     "id": "level-095",
     "name": "level-095",
-    "columns": 11,
+    "columns": 32,
     "medal": {
-        "gold": 35.400001525878909,
-        "silver": 51.400001525878909,
-        "bronze": 74.4000015258789
+        "gold": 71.30000305175781,
+        "silver": 103.4000015258789,
+        "bronze": 149.6999969482422
     },
-    "startColumn": 7,
+    "startColumn": 30,
     "bays": [
-        0,
-        1,
-        2,
-        6,
-        8
+        7,
+        17,
+        20,
+        22,
+        25
     ],
     "rows": [
         {
@@ -24,14 +24,149 @@
             "obstructions": []
         },
         {
+            "kind": "bike",
+            "dir": "right",
+            "speed": 2.940000057220459,
+            "objects": [
+                {
+                    "pieceId": "runner",
+                    "offset": 6.380000114440918,
+                    "spacing": 9.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "runner",
+                    "offset": 10.880000114440918,
+                    "spacing": 9.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 0
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 6
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 10
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 11
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 19
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 21
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 23
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 25
+                }
+            ]
+        },
+        {
+            "kind": "bike",
+            "dir": "right",
+            "speed": 3.0399999618530275,
+            "objects": [
+                {
+                    "pieceId": "runner",
+                    "offset": 2.9000000953674318,
+                    "spacing": 9.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "skater",
+                    "offset": 7.400000095367432,
+                    "spacing": 9.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "left",
+            "speed": 2.9800000190734865,
+            "objects": [
+                {
+                    "pieceId": "passenger",
+                    "offset": 23.329999923706056,
+                    "spacing": 18.670000076293947,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.600000023841858,
+            "objects": [
+                {
+                    "pieceId": "gator",
+                    "offset": 9.5600004196167,
+                    "spacing": 14.0,
+                    "phase": 176
+                },
+                {
+                    "pieceId": "log-short",
+                    "offset": 16.559999465942384,
+                    "spacing": 14.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 1.8200000524520875,
+            "objects": [],
+            "obstructions": []
+        },
+        {
             "kind": "tracks",
             "dir": "right",
-            "speed": 2.9100000858306886,
+            "speed": 2.509999990463257,
             "objects": [
                 {
                     "pieceId": "freight",
-                    "offset": 30.889999389648439,
-                    "spacing": 17.5,
+                    "offset": 42.040000915527347,
+                    "spacing": 14.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "right",
+            "speed": 2.359999895095825,
+            "objects": [
+                {
+                    "pieceId": "passenger",
+                    "offset": 34.310001373291019,
+                    "spacing": 14.0,
                     "phase": 0
                 }
             ],
@@ -40,46 +175,12 @@
         {
             "kind": "bike",
             "dir": "left",
-            "speed": 2.75,
+            "speed": 2.690000057220459,
             "objects": [
                 {
-                    "pieceId": "skater",
-                    "offset": 1.7999999523162842,
-                    "spacing": 7.5,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "skater",
-                    "offset": 5.550000190734863,
-                    "spacing": 7.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.9600000381469727,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.840000033378601,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 2.4800000190734865,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 16.93000030517578,
-                    "spacing": 17.5,
+                    "pieceId": "cyclist",
+                    "offset": 7.840000152587891,
+                    "spacing": 4.0,
                     "phase": 0
                 }
             ],
@@ -88,82 +189,8 @@
         {
             "kind": "walkway",
             "dir": "left",
-            "speed": 2.0999999046325685,
+            "speed": 1.9700000286102296,
             "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.2899999618530275,
-            "objects": [
-                {
-                    "pieceId": "convertible",
-                    "offset": 11.210000038146973,
-                    "spacing": 21.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "truck",
-                    "offset": 0.7099999785423279,
-                    "spacing": 21.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.5,
-            "objects": [
-                {
-                    "pieceId": "raft",
-                    "offset": 9.880000114440918,
-                    "spacing": 21.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log-short",
-                    "offset": 20.3799991607666,
-                    "spacing": 21.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "right",
-            "speed": 2.380000114440918,
-            "objects": [
-                {
-                    "pieceId": "truck",
-                    "offset": 3.759999990463257,
-                    "spacing": 7.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.5499999523162842,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 1.940000057220459,
-                    "spacing": 21.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 12.4399995803833,
-                    "spacing": 21.0,
-                    "phase": 11
-                }
-            ],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-096.json
+++ b/Assets/Resources/Levels/level-096.json
@@ -1,19 +1,19 @@
 {
     "id": "level-096",
     "name": "level-096",
-    "columns": 11,
+    "columns": 33,
     "medal": {
-        "gold": 34.70000076293945,
-        "silver": 50.29999923706055,
-        "bronze": 72.9000015258789
+        "gold": 36.599998474121097,
+        "silver": 53.0,
+        "bronze": 76.80000305175781
     },
-    "startColumn": 1,
+    "startColumn": 21,
     "bays": [
-        2,
-        3,
-        5,
-        8,
-        10
+        6,
+        15,
+        25,
+        26,
+        27
     ],
     "rows": [
         {
@@ -24,40 +24,68 @@
             "obstructions": []
         },
         {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.930000066757202,
+            "kind": "road",
+            "dir": "left",
+            "speed": 3.0399999618530275,
             "objects": [
                 {
-                    "pieceId": "skater",
-                    "offset": 3.609999895095825,
-                    "spacing": 15.0,
+                    "pieceId": "bus",
+                    "offset": 18.84000015258789,
+                    "spacing": 13.670000076293946,
                     "phase": 0
                 },
                 {
-                    "pieceId": "cyclist",
-                    "offset": 11.109999656677246,
-                    "spacing": 15.0,
+                    "pieceId": "convertible",
+                    "offset": 25.68000030517578,
+                    "spacing": 13.670000076293946,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.590000033378601,
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.819999933242798,
             "objects": [
                 {
-                    "pieceId": "log",
-                    "offset": 16.530000686645509,
-                    "spacing": 21.0,
+                    "pieceId": "skater",
+                    "offset": 10.630000114440918,
+                    "spacing": 9.25,
                     "phase": 0
                 },
                 {
-                    "pieceId": "log-short",
-                    "offset": 6.03000020980835,
-                    "spacing": 21.0,
+                    "pieceId": "cyclist",
+                    "offset": 15.260000228881836,
+                    "spacing": 9.25,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "right",
+            "speed": 2.6500000953674318,
+            "objects": [
+                {
+                    "pieceId": "passenger",
+                    "offset": 42.63999938964844,
+                    "spacing": 14.25,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.490000009536743,
+            "objects": [
+                {
+                    "pieceId": "truck",
+                    "offset": 20.469999313354493,
+                    "spacing": 7.170000076293945,
                     "phase": 0
                 }
             ],
@@ -70,24 +98,52 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "bush",
+                    "pieceId": "planter-tulip",
                     "column": 0
                 },
                 {
-                    "pieceId": "bench",
+                    "pieceId": "planter-fern",
                     "column": 2
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 9
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 10
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 11
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 12
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 13
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 17
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 31
                 }
             ]
         },
         {
-            "kind": "road",
-            "dir": "left",
-            "speed": 2.890000104904175,
+            "kind": "tracks",
+            "dir": "right",
+            "speed": 2.9200000762939455,
             "objects": [
                 {
-                    "pieceId": "truck",
-                    "offset": 6.289999961853027,
-                    "spacing": 7.0,
+                    "pieceId": "freight",
+                    "offset": 53.290000915527347,
+                    "spacing": 14.25,
                     "phase": 0
                 }
             ],
@@ -96,81 +152,47 @@
         {
             "kind": "walkway",
             "dir": "left",
-            "speed": 2.0,
+            "speed": 1.840000033378601,
             "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.7799999713897706,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "left",
+            "speed": 2.9700000286102297,
+            "objects": [
+                {
+                    "pieceId": "passenger",
+                    "offset": 7.150000095367432,
+                    "spacing": 14.25,
+                    "phase": 0
+                }
+            ],
             "obstructions": []
         },
         {
             "kind": "bike",
-            "dir": "left",
-            "speed": 2.75,
+            "dir": "right",
+            "speed": 2.880000114440918,
             "objects": [
                 {
                     "pieceId": "skater",
-                    "offset": 7.570000171661377,
-                    "spacing": 5.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 2.0299999713897707,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.9700000286102296,
-            "objects": [
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 14.289999961853028,
-                    "spacing": 21.0,
-                    "phase": 27
-                },
-                {
-                    "pieceId": "log-short",
-                    "offset": 3.7899999618530275,
-                    "spacing": 21.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "left",
-            "speed": 3.049999952316284,
-            "objects": [
-                {
-                    "pieceId": "truck",
-                    "offset": 1.7100000381469727,
-                    "spacing": 21.0,
+                    "offset": 26.549999237060548,
+                    "spacing": 7.400000095367432,
                     "phase": 0
                 },
                 {
-                    "pieceId": "truck",
-                    "offset": 12.210000038146973,
-                    "spacing": 21.0,
+                    "pieceId": "cyclist",
+                    "offset": 30.25,
+                    "spacing": 7.400000095367432,
                     "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "right",
-            "speed": 1.7599999904632569,
-            "objects": [
-                {
-                    "pieceId": "gator",
-                    "offset": 8.039999961853028,
-                    "spacing": 7.0,
-                    "phase": 394
                 }
             ],
             "obstructions": []

--- a/Assets/Resources/Levels/level-097.json
+++ b/Assets/Resources/Levels/level-097.json
@@ -1,19 +1,19 @@
 {
     "id": "level-097",
     "name": "level-097",
-    "columns": 13,
+    "columns": 32,
     "medal": {
-        "gold": 37.79999923706055,
-        "silver": 54.79999923706055,
-        "bronze": 79.30000305175781
+        "gold": 26.600000381469728,
+        "silver": 38.5,
+        "bronze": 55.79999923706055
     },
     "startColumn": 9,
     "bays": [
-        1,
-        2,
-        4,
         5,
-        6
+        10,
+        14,
+        16,
+        23
     ],
     "rows": [
         {
@@ -24,122 +24,14 @@
             "obstructions": []
         },
         {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 3.059999942779541,
+            "kind": "bike",
+            "dir": "right",
+            "speed": 2.6500000953674318,
             "objects": [
                 {
-                    "pieceId": "freight",
-                    "offset": 28.229999542236329,
-                    "spacing": 18.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "bench",
-                    "column": 4
-                },
-                {
-                    "pieceId": "tree",
-                    "column": 8
-                }
-            ]
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "bush",
-                    "column": 2
-                },
-                {
-                    "pieceId": "lamp",
-                    "column": 11
-                }
-            ]
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "planter-tulip",
-                    "column": 1
-                },
-                {
-                    "pieceId": "bench",
-                    "column": 11
-                }
-            ]
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "lamp",
-                    "column": 2
-                },
-                {
-                    "pieceId": "bench",
-                    "column": 7
-                },
-                {
-                    "pieceId": "planter-tulip",
-                    "column": 8
-                },
-                {
-                    "pieceId": "planter-daisy",
-                    "column": 10
-                },
-                {
-                    "pieceId": "bush",
-                    "column": 11
-                },
-                {
-                    "pieceId": "planter-tulip",
-                    "column": 12
-                }
-            ]
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.6200000047683716,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 1.850000023841858,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 3.0299999713897707,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 25.809999465942384,
-                    "spacing": 18.5,
+                    "pieceId": "skater",
+                    "offset": 33.349998474121097,
+                    "spacing": 4.5,
                     "phase": 0
                 }
             ],
@@ -147,33 +39,215 @@
         },
         {
             "kind": "swamp",
-            "dir": "left",
-            "speed": 1.809999942779541,
+            "dir": "right",
+            "speed": 1.6200000047683716,
             "objects": [
                 {
-                    "pieceId": "raft",
-                    "offset": 1.7599999904632569,
-                    "spacing": 23.0,
+                    "pieceId": "log-long",
+                    "offset": 23.1299991607666,
+                    "spacing": 8.800000190734864,
                     "phase": 0
-                },
-                {
-                    "pieceId": "gator",
-                    "offset": 13.260000228881836,
-                    "spacing": 23.0,
-                    "phase": 56
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "tracks",
+            "kind": "river",
             "dir": "left",
-            "speed": 2.700000047683716,
+            "speed": 1.7200000286102296,
             "objects": [
                 {
-                    "pieceId": "freight",
-                    "offset": 23.899999618530275,
-                    "spacing": 18.5,
+                    "pieceId": "raft",
+                    "offset": 16.3799991607666,
+                    "spacing": 7.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "swamp",
+            "dir": "right",
+            "speed": 1.9800000190734864,
+            "objects": [
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 33.93000030517578,
+                    "spacing": 14.0,
+                    "phase": 2
+                },
+                {
+                    "pieceId": "log-short",
+                    "offset": 40.93000030517578,
+                    "spacing": 14.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.9299999475479127,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 41.02000045776367,
+                    "spacing": 7.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "bush",
+                    "column": 0
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 3
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 6
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 11
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 14
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 16
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 20
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 24
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 31
+                }
+            ]
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "tree",
+                    "column": 1
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 12
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 14
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 15
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 16
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 18
+                },
+                {
+                    "pieceId": "planter-daisy",
+                    "column": 19
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 22
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 27
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 31
+                }
+            ]
+        },
+        {
+            "kind": "bike",
+            "dir": "left",
+            "speed": 2.809999942779541,
+            "objects": [
+                {
+                    "pieceId": "cyclist",
+                    "offset": 20.079999923706056,
+                    "spacing": 4.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 3
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 21
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 23
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 29
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 31
+                }
+            ]
+        },
+        {
+            "kind": "bike",
+            "dir": "right",
+            "speed": 2.940000057220459,
+            "objects": [
+                {
+                    "pieceId": "skater",
+                    "offset": 25.6200008392334,
+                    "spacing": 9.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "cyclist",
+                    "offset": 30.1200008392334,
+                    "spacing": 9.0,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-098.json
+++ b/Assets/Resources/Levels/level-098.json
@@ -1,19 +1,19 @@
 {
     "id": "level-098",
     "name": "level-098",
-    "columns": 11,
+    "columns": 35,
     "medal": {
-        "gold": 29.0,
-        "silver": 42.099998474121097,
-        "bronze": 61.0
+        "gold": 31.399999618530275,
+        "silver": 45.5,
+        "bronze": 65.9000015258789
     },
-    "startColumn": 2,
+    "startColumn": 6,
     "bays": [
-        0,
-        3,
-        4,
-        8,
-        10
+        2,
+        7,
+        13,
+        24,
+        25
     ],
     "rows": [
         {
@@ -24,20 +24,198 @@
             "obstructions": []
         },
         {
-            "kind": "bike",
-            "dir": "right",
-            "speed": 2.930000066757202,
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.7599999904632569,
             "objects": [
                 {
-                    "pieceId": "cyclist",
-                    "offset": 11.149999618530274,
+                    "pieceId": "gator",
+                    "offset": 23.84000015258789,
                     "spacing": 7.5,
+                    "phase": 335
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "right",
+            "speed": 2.0,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "right",
+            "speed": 2.6500000953674318,
+            "objects": [
+                {
+                    "pieceId": "convertible",
+                    "offset": 14.039999961853028,
+                    "spacing": 10.25,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 19.170000076293947,
+                    "spacing": 10.25,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 9
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 12
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 21
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 26
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 27
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 29
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 31
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 32
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 33
+                }
+            ]
+        },
+        {
+            "kind": "swamp",
+            "dir": "left",
+            "speed": 1.5399999618530274,
+            "objects": [
+                {
+                    "pieceId": "raft",
+                    "offset": 32.060001373291019,
+                    "spacing": 23.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log-long",
+                    "offset": 43.810001373291019,
+                    "spacing": 23.5,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "tree",
+                    "column": 2
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 6
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 9
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 11
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 15
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 17
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 21
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 23
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 24
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 26
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 30
+                }
+            ]
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.6200000047683716,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "right",
+            "speed": 2.9600000381469728,
+            "objects": [
+                {
+                    "pieceId": "runner",
+                    "offset": 1.090000033378601,
+                    "spacing": 3.549999952316284,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "bike",
+            "dir": "right",
+            "speed": 2.680000066757202,
+            "objects": [
+                {
+                    "pieceId": "skater",
+                    "offset": 5.409999847412109,
+                    "spacing": 9.75,
                     "phase": 0
                 },
                 {
                     "pieceId": "runner",
-                    "offset": 14.899999618530274,
-                    "spacing": 7.5,
+                    "offset": 10.289999961853028,
+                    "spacing": 9.75,
                     "phase": 0
                 }
             ],
@@ -46,152 +224,8 @@
         {
             "kind": "walkway",
             "dir": "left",
-            "speed": 1.6699999570846558,
+            "speed": 1.6299999952316285,
             "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.7599999904632569,
-            "objects": [
-                {
-                    "pieceId": "raft",
-                    "offset": 12.15999984741211,
-                    "spacing": 7.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "planter-succulent",
-                    "column": 1
-                },
-                {
-                    "pieceId": "lamp",
-                    "column": 5
-                },
-                {
-                    "pieceId": "lamp",
-                    "column": 8
-                },
-                {
-                    "pieceId": "planter-succulent",
-                    "column": 10
-                }
-            ]
-        },
-        {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 2.990000009536743,
-            "objects": [
-                {
-                    "pieceId": "freight",
-                    "offset": 14.170000076293946,
-                    "spacing": 17.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "bench",
-                    "column": 3
-                },
-                {
-                    "pieceId": "lamp",
-                    "column": 5
-                },
-                {
-                    "pieceId": "planter-tulip",
-                    "column": 6
-                }
-            ]
-        },
-        {
-            "kind": "concrete",
-            "dir": "",
-            "speed": 0.0,
-            "objects": [],
-            "obstructions": [
-                {
-                    "pieceId": "planter-lavender",
-                    "column": 4
-                },
-                {
-                    "pieceId": "planter-lavender",
-                    "column": 5
-                },
-                {
-                    "pieceId": "planter-tulip",
-                    "column": 6
-                },
-                {
-                    "pieceId": "lamp",
-                    "column": 9
-                }
-            ]
-        },
-        {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.859999895095825,
-            "objects": [
-                {
-                    "pieceId": "runner",
-                    "offset": 3.4800000190734865,
-                    "spacing": 5.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.6200000047683716,
-            "objects": [
-                {
-                    "pieceId": "log",
-                    "offset": 6.730000019073486,
-                    "spacing": 7.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "right",
-            "speed": 1.6100000143051148,
-            "objects": [
-                {
-                    "pieceId": "log-short",
-                    "offset": 0.5299999713897705,
-                    "spacing": 19.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "log-short",
-                    "offset": 10.029999732971192,
-                    "spacing": 19.0,
-                    "phase": 0
-                }
-            ],
             "obstructions": []
         },
         {

--- a/Assets/Resources/Levels/level-099.json
+++ b/Assets/Resources/Levels/level-099.json
@@ -1,19 +1,19 @@
 {
     "id": "level-099",
     "name": "level-099",
-    "columns": 13,
+    "columns": 34,
     "medal": {
-        "gold": 32.400001525878909,
-        "silver": 46.900001525878909,
-        "bronze": 68.0
+        "gold": 28.899999618530275,
+        "silver": 41.900001525878909,
+        "bronze": 60.70000076293945
     },
-    "startColumn": 2,
+    "startColumn": 14,
     "bays": [
-        0,
-        4,
-        5,
         8,
-        12
+        10,
+        15,
+        16,
+        31
     ],
     "rows": [
         {
@@ -24,138 +24,34 @@
             "obstructions": []
         },
         {
-            "kind": "tracks",
-            "dir": "right",
-            "speed": 2.930000066757202,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 22.940000534057618,
-                    "spacing": 18.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.5299999713897707,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 0.6499999761581421,
-                    "spacing": 18.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "road",
-            "dir": "left",
-            "speed": 2.4700000286102297,
-            "objects": [
-                {
-                    "pieceId": "truck",
-                    "offset": 19.889999389648439,
-                    "spacing": 23.0,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "convertible",
-                    "offset": 8.390000343322754,
-                    "spacing": 23.0,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.549999952316284,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 33.869998931884769,
-                    "spacing": 18.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.990000009536743,
-            "objects": [
-                {
-                    "pieceId": "cyclist",
-                    "offset": 15.579999923706055,
-                    "spacing": 8.5,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "runner",
-                    "offset": 2.8299999237060549,
-                    "spacing": 8.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "swamp",
-            "dir": "left",
-            "speed": 1.7599999904632569,
-            "objects": [
-                {
-                    "pieceId": "turtle-log",
-                    "offset": 8.640000343322754,
-                    "spacing": 7.670000076293945,
-                    "phase": 108
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.609999895095825,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 30.93000030517578,
-                    "spacing": 18.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
             "kind": "road",
             "dir": "right",
-            "speed": 2.6500000953674318,
+            "speed": 3.1600000858306886,
             "objects": [
                 {
                     "pieceId": "bus",
-                    "offset": 17.649999618530275,
-                    "spacing": 7.0,
+                    "offset": 5.590000152587891,
+                    "spacing": 6.0,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.430000066757202,
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.8300000429153443,
             "objects": [
                 {
-                    "pieceId": "freight",
-                    "offset": 34.099998474121097,
-                    "spacing": 18.5,
+                    "pieceId": "log-short",
+                    "offset": 12.90999984741211,
+                    "spacing": 10.5,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "log-short",
+                    "offset": 18.15999984741211,
+                    "spacing": 10.5,
                     "phase": 0
                 }
             ],
@@ -163,19 +59,115 @@
         },
         {
             "kind": "road",
+            "dir": "left",
+            "speed": 2.7899999618530275,
+            "objects": [
+                {
+                    "pieceId": "bus",
+                    "offset": 31.530000686645509,
+                    "spacing": 6.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
             "dir": "right",
+            "speed": 2.059999942779541,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
             "speed": 2.740000009536743,
             "objects": [
                 {
                     "pieceId": "bus",
-                    "offset": 19.440000534057618,
-                    "spacing": 23.0,
+                    "offset": 40.54999923706055,
+                    "spacing": 14.0,
                     "phase": 0
                 },
                 {
+                    "pieceId": "bus",
+                    "offset": 5.550000190734863,
+                    "spacing": 14.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.880000114440918,
+            "objects": [
+                {
+                    "pieceId": "car",
+                    "offset": 31.3700008392334,
+                    "spacing": 5.0,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "right",
+            "speed": 1.5299999713897706,
+            "objects": [
+                {
+                    "pieceId": "gator",
+                    "offset": 21.860000610351564,
+                    "spacing": 14.670000076293946,
+                    "phase": 270
+                },
+                {
+                    "pieceId": "raft",
+                    "offset": 29.190000534057618,
+                    "spacing": 14.670000076293946,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.649999976158142,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.700000047683716,
+            "objects": [
+                {
                     "pieceId": "truck",
-                    "offset": 7.940000057220459,
-                    "spacing": 23.0,
+                    "offset": 22.489999771118165,
+                    "spacing": 6.289999961853027,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "road",
+            "dir": "left",
+            "speed": 2.8499999046325685,
+            "objects": [
+                {
+                    "pieceId": "truck",
+                    "offset": 28.75,
+                    "spacing": 14.670000076293946,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "car",
+                    "offset": 36.08000183105469,
+                    "spacing": 14.670000076293946,
                     "phase": 0
                 }
             ],

--- a/Assets/Resources/Levels/level-100.json
+++ b/Assets/Resources/Levels/level-100.json
@@ -1,19 +1,19 @@
 {
     "id": "level-100",
     "name": "level-100",
-    "columns": 13,
+    "columns": 35,
     "medal": {
-        "gold": 33.099998474121097,
-        "silver": 48.0,
-        "bronze": 69.5999984741211
+        "gold": 31.5,
+        "silver": 45.70000076293945,
+        "bronze": 66.0999984741211
     },
-    "startColumn": 1,
+    "startColumn": 15,
     "bays": [
-        0,
-        4,
-        7,
-        8,
-        11
+        15,
+        20,
+        22,
+        24,
+        30
     ],
     "rows": [
         {
@@ -24,37 +24,43 @@
             "obstructions": []
         },
         {
-            "kind": "river",
-            "dir": "left",
-            "speed": 1.8300000429153443,
+            "kind": "bike",
+            "dir": "right",
+            "speed": 3.1700000762939455,
             "objects": [
                 {
-                    "pieceId": "log",
-                    "offset": 11.680000305175782,
-                    "spacing": 23.0,
+                    "pieceId": "runner",
+                    "offset": 28.329999923706056,
+                    "spacing": 7.800000190734863,
                     "phase": 0
                 },
                 {
-                    "pieceId": "raft",
-                    "offset": 0.18000000715255738,
-                    "spacing": 23.0,
+                    "pieceId": "runner",
+                    "offset": 32.22999954223633,
+                    "spacing": 7.800000190734863,
                     "phase": 0
                 }
             ],
             "obstructions": []
         },
         {
-            "kind": "walkway",
-            "dir": "left",
-            "speed": 2.009999990463257,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
+            "kind": "river",
             "dir": "right",
-            "speed": 1.809999942779541,
-            "objects": [],
+            "speed": 1.9299999475479127,
+            "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 2.009999990463257,
+                    "spacing": 15.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "turtle-log",
+                    "offset": 9.510000228881836,
+                    "spacing": 15.0,
+                    "phase": 254
+                }
+            ],
             "obstructions": []
         },
         {
@@ -64,100 +70,139 @@
             "objects": [],
             "obstructions": [
                 {
-                    "pieceId": "bush",
-                    "column": 1
-                },
-                {
-                    "pieceId": "bush",
+                    "pieceId": "planter-succulent",
                     "column": 8
                 },
                 {
-                    "pieceId": "planter-lavender",
-                    "column": 9
+                    "pieceId": "planter-succulent",
+                    "column": 10
                 },
                 {
-                    "pieceId": "planter-daisy",
-                    "column": 10
+                    "pieceId": "planter-fern",
+                    "column": 11
+                },
+                {
+                    "pieceId": "planter-fern",
+                    "column": 16
+                },
+                {
+                    "pieceId": "bench",
+                    "column": 28
                 }
             ]
         },
         {
+            "kind": "concrete",
+            "dir": "",
+            "speed": 0.0,
+            "objects": [],
+            "obstructions": [
+                {
+                    "pieceId": "bench",
+                    "column": 4
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 9
+                },
+                {
+                    "pieceId": "bush",
+                    "column": 12
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 14
+                },
+                {
+                    "pieceId": "planter-tulip",
+                    "column": 15
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 16
+                },
+                {
+                    "pieceId": "tree",
+                    "column": 22
+                },
+                {
+                    "pieceId": "planter-lavender",
+                    "column": 26
+                },
+                {
+                    "pieceId": "planter-succulent",
+                    "column": 27
+                },
+                {
+                    "pieceId": "lamp",
+                    "column": 28
+                }
+            ]
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.8799999952316285,
+            "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 9.350000381469727,
+                    "spacing": 6.429999828338623,
+                    "phase": 0
+                }
+            ],
+            "obstructions": []
+        },
+        {
             "kind": "walkway",
             "dir": "left",
-            "speed": 1.9199999570846558,
+            "speed": 1.6699999570846558,
             "objects": [],
             "obstructions": []
         },
         {
-            "kind": "tracks",
+            "kind": "walkway",
             "dir": "right",
-            "speed": 3.059999942779541,
+            "speed": 1.690000057220459,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "walkway",
+            "dir": "left",
+            "speed": 1.809999942779541,
+            "objects": [],
+            "obstructions": []
+        },
+        {
+            "kind": "river",
+            "dir": "left",
+            "speed": 1.9800000190734864,
+            "objects": [
+                {
+                    "pieceId": "log",
+                    "offset": 31.100000381469728,
+                    "spacing": 15.0,
+                    "phase": 0
+                },
+                {
+                    "pieceId": "gator",
+                    "offset": 38.599998474121097,
+                    "spacing": 15.0,
+                    "phase": 20
+                }
+            ],
+            "obstructions": []
+        },
+        {
+            "kind": "tracks",
+            "dir": "left",
+            "speed": 3.0,
             "objects": [
                 {
                     "pieceId": "freight",
-                    "offset": 3.5,
-                    "spacing": 18.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 3.119999885559082,
-            "objects": [
-                {
-                    "pieceId": "runner",
-                    "offset": 6.119999885559082,
-                    "spacing": 8.5,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "cyclist",
-                    "offset": 10.369999885559082,
-                    "spacing": 8.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "walkway",
-            "dir": "right",
-            "speed": 1.6100000143051148,
-            "objects": [],
-            "obstructions": []
-        },
-        {
-            "kind": "tracks",
-            "dir": "left",
-            "speed": 2.640000104904175,
-            "objects": [
-                {
-                    "pieceId": "passenger",
-                    "offset": 10.15999984741211,
-                    "spacing": 18.5,
-                    "phase": 0
-                }
-            ],
-            "obstructions": []
-        },
-        {
-            "kind": "bike",
-            "dir": "left",
-            "speed": 2.9700000286102297,
-            "objects": [
-                {
-                    "pieceId": "cyclist",
-                    "offset": 4.289999961853027,
-                    "spacing": 8.5,
-                    "phase": 0
-                },
-                {
-                    "pieceId": "cyclist",
-                    "offset": 8.539999961853028,
-                    "spacing": 8.5,
+                    "offset": 21.520000457763673,
+                    "spacing": 14.75,
                     "phase": 0
                 }
             ],

--- a/Assets/Scripts/Editor/Generator/CurveGenerator.cs
+++ b/Assets/Scripts/Editor/Generator/CurveGenerator.cs
@@ -109,37 +109,38 @@ namespace FrogAcross.Editor.Generator
         {
             new CurveBand
             {
-                label = "first-hop", startLevel = 1, endLevel = 1,
+                label = "first-hop", maxSolverSeconds = 8, startLevel = 1, endLevel = 1,
                 laneKindPool = new[] { "road", "road", "grass" },
                 requiredKinds = new[] { "road" },
                 middleRowsStartEnd = new Vector2Int(3, 3),
                 bayCountStartEnd = new Vector2Int(1, 1), // one bay: one crossing (#64)
-                maxSolverMoves = 7, // near-straight line: rows(5) + 2
-                columnsRange = new Vector2Int(9, 10),
+                maxSolverMoves = 11, // near-straight line: rows(5) + the bay window
+                bayWindow = 3,       // the one bay sits within 3 columns of the start
+                columnsRange = new Vector2Int(14, 15),
                 deadlySpeedStart = new Vector2(1.0f, 1.2f), deadlySpeedEnd = new Vector2(1.0f, 1.2f),
                 spacingSlackStart = new Vector2(3.5f, 4.5f), spacingSlackEnd = new Vector2(3.5f, 4.5f),
                 obstructionChanceStart = 0f, obstructionChanceEnd = 0f,
             },
             new CurveBand
             {
-                label = "teaching-road", startLevel = 2, endLevel = 10,
+                label = "teaching-road", maxSolverSeconds = 14, startLevel = 2, endLevel = 10,
                 laneKindPool = new[] { "road", "road", "grass" },
                 requiredKinds = new[] { "road" },
                 middleRowsStartEnd = new Vector2Int(5, 6),
                 bayCountStartEnd = new Vector2Int(2, 3),
-                columnsRange = new Vector2Int(9, 11),
+                columnsRange = new Vector2Int(20, 23),
                 deadlySpeedStart = new Vector2(1.0f, 1.3f), deadlySpeedEnd = new Vector2(1.4f, 1.8f),
                 spacingSlackStart = new Vector2(3.0f, 4.5f), spacingSlackEnd = new Vector2(2.2f, 3.6f),
                 obstructionChanceStart = 0f, obstructionChanceEnd = 0.08f,
             },
             new CurveBand
             {
-                label = "river", startLevel = 11, endLevel = 20,
+                label = "river", maxSolverSeconds = 20, startLevel = 11, endLevel = 20,
                 laneKindPool = new[] { "road", "grass", "river", "river" },
                 requiredKinds = new[] { "river" },
                 middleRowsStartEnd = new Vector2Int(5, 7),
                 bayCountStartEnd = new Vector2Int(2, 3),
-                columnsRange = new Vector2Int(9, 11),
+                columnsRange = new Vector2Int(20, 26),
                 deadlySpeedStart = new Vector2(1.3f, 1.8f), deadlySpeedEnd = new Vector2(1.5f, 2.1f),
                 waterSpeedStart = new Vector2(0.9f, 1.2f), waterSpeedEnd = new Vector2(1.0f, 1.5f),
                 spacingSlackStart = new Vector2(2.4f, 3.8f), spacingSlackEnd = new Vector2(2.0f, 3.4f),
@@ -147,12 +148,12 @@ namespace FrogAcross.Editor.Generator
             },
             new CurveBand
             {
-                label = "swamp", startLevel = 21, endLevel = 30,
+                label = "swamp", maxSolverSeconds = 22, startLevel = 21, endLevel = 30,
                 laneKindPool = new[] { "road", "grass", "river", "swamp", "swamp" },
                 requiredKinds = new[] { "swamp" },
                 middleRowsStartEnd = new Vector2Int(6, 7),
                 bayCountStartEnd = new Vector2Int(2, 3),
-                columnsRange = new Vector2Int(9, 12),
+                columnsRange = new Vector2Int(23, 26),
                 deadlySpeedStart = new Vector2(1.4f, 1.9f), deadlySpeedEnd = new Vector2(1.6f, 2.2f),
                 waterSpeedStart = new Vector2(1.0f, 1.4f), waterSpeedEnd = new Vector2(1.1f, 1.6f),
                 spacingSlackStart = new Vector2(2.2f, 3.6f), spacingSlackEnd = new Vector2(1.9f, 3.2f),
@@ -160,12 +161,12 @@ namespace FrogAcross.Editor.Generator
             },
             new CurveBand
             {
-                label = "tracks", startLevel = 31, endLevel = 40,
+                label = "tracks", maxSolverSeconds = 24, startLevel = 31, endLevel = 40,
                 laneKindPool = new[] { "road", "grass", "river", "swamp", "tracks", "concrete" },
                 requiredKinds = new[] { "tracks" },
                 middleRowsStartEnd = new Vector2Int(6, 8),
                 bayCountStartEnd = new Vector2Int(2, 4),
-                columnsRange = new Vector2Int(10, 12),
+                columnsRange = new Vector2Int(23, 29),
                 deadlySpeedStart = new Vector2(1.5f, 2.0f), deadlySpeedEnd = new Vector2(1.7f, 2.4f),
                 waterSpeedStart = new Vector2(1.0f, 1.5f), waterSpeedEnd = new Vector2(1.2f, 1.7f),
                 spacingSlackStart = new Vector2(2.0f, 3.4f), spacingSlackEnd = new Vector2(1.8f, 3.0f),
@@ -173,12 +174,12 @@ namespace FrogAcross.Editor.Generator
             },
             new CurveBand
             {
-                label = "bike", startLevel = 41, endLevel = 50,
+                label = "bike", maxSolverSeconds = 26, startLevel = 41, endLevel = 50,
                 laneKindPool = new[] { "road", "grass", "river", "swamp", "tracks", "bike", "bike", "concrete" },
                 requiredKinds = new[] { "bike" },
                 middleRowsStartEnd = new Vector2Int(7, 8),
                 bayCountStartEnd = new Vector2Int(3, 4),
-                columnsRange = new Vector2Int(10, 12),
+                columnsRange = new Vector2Int(26, 29),
                 deadlySpeedStart = new Vector2(1.6f, 2.2f), deadlySpeedEnd = new Vector2(1.8f, 2.5f),
                 waterSpeedStart = new Vector2(1.1f, 1.6f), waterSpeedEnd = new Vector2(1.2f, 1.8f),
                 crashSpeedStart = new Vector2(1.8f, 2.4f), crashSpeedEnd = new Vector2(2.0f, 2.8f),
@@ -187,12 +188,12 @@ namespace FrogAcross.Editor.Generator
             },
             new CurveBand
             {
-                label = "walkway", startLevel = 51, endLevel = 60,
+                label = "walkway", maxSolverSeconds = 28, startLevel = 51, endLevel = 60,
                 laneKindPool = new[] { "road", "grass", "river", "swamp", "tracks", "bike", "walkway", "walkway", "concrete" },
                 requiredKinds = new[] { "walkway" },
                 middleRowsStartEnd = new Vector2Int(7, 9),
                 bayCountStartEnd = new Vector2Int(3, 4),
-                columnsRange = new Vector2Int(10, 13),
+                columnsRange = new Vector2Int(26, 32),
                 deadlySpeedStart = new Vector2(1.7f, 2.3f), deadlySpeedEnd = new Vector2(1.9f, 2.6f),
                 waterSpeedStart = new Vector2(1.1f, 1.7f), waterSpeedEnd = new Vector2(1.3f, 1.8f),
                 crashSpeedStart = new Vector2(2.0f, 2.6f), crashSpeedEnd = new Vector2(2.2f, 2.9f),
@@ -202,11 +203,11 @@ namespace FrogAcross.Editor.Generator
             },
             new CurveBand
             {
-                label = "combination-1", startLevel = 61, endLevel = 80,
+                label = "combination-1", maxSolverSeconds = 30, startLevel = 61, endLevel = 80,
                 laneKindPool = new[] { "road", "river", "swamp", "tracks", "bike", "walkway", "grass", "concrete" },
                 middleRowsStartEnd = new Vector2Int(8, 9),
                 bayCountStartEnd = new Vector2Int(3, 5),
-                columnsRange = new Vector2Int(11, 13),
+                columnsRange = new Vector2Int(29, 32),
                 deadlySpeedStart = new Vector2(1.9f, 2.6f), deadlySpeedEnd = new Vector2(2.1f, 2.9f),
                 waterSpeedStart = new Vector2(1.2f, 1.8f), waterSpeedEnd = new Vector2(1.4f, 1.9f),
                 crashSpeedStart = new Vector2(2.2f, 2.8f), crashSpeedEnd = new Vector2(2.4f, 3.0f),
@@ -216,11 +217,13 @@ namespace FrogAcross.Editor.Generator
             },
             new CurveBand
             {
-                label = "combination-2", startLevel = 81, endLevel = 100,
+                label = "combination-2", maxSolverSeconds = 36, startLevel = 81, endLevel = 100,
                 laneKindPool = new[] { "road", "river", "swamp", "tracks", "bike", "walkway", "concrete" },
                 middleRowsStartEnd = new Vector2Int(9, 10),
-                bayCountStartEnd = new Vector2Int(4, 5),
-                columnsRange = new Vector2Int(11, 13),
+                // picks up where combination-1 leaves off — restarting at 4
+                // put a visible dip in the curve at level 81
+                bayCountStartEnd = new Vector2Int(5, 5),
+                columnsRange = new Vector2Int(32, 35),
                 deadlySpeedStart = new Vector2(2.1f, 2.8f), deadlySpeedEnd = new Vector2(2.3f, 3.2f),
                 waterSpeedStart = new Vector2(1.3f, 1.9f), waterSpeedEnd = new Vector2(1.5f, 2.0f),
                 crashSpeedStart = new Vector2(2.4f, 3.0f), crashSpeedEnd = new Vector2(2.6f, 3.2f),

--- a/Assets/Scripts/Editor/Generator/DifficultyCurve.cs
+++ b/Assets/Scripts/Editor/Generator/DifficultyCurve.cs
@@ -43,6 +43,12 @@ namespace FrogAcross.Editor.Generator
 
         [Tooltip("Reject candidates the solver needs more than this many moves for (0 = unlimited).")]
         public int maxSolverMoves;
+
+        [Tooltip("Bays must land within this many columns of the start (0 = anywhere).")]
+        public int bayWindow;
+
+        [Tooltip("Reject candidates needing more than this many seconds of optimal play (0 = unlimited).")]
+        public float maxSolverSeconds;
     }
 
     /// <summary>
@@ -74,6 +80,8 @@ namespace FrogAcross.Editor.Generator
             p.middleRows = new Vector2Int(rows, rows);
             int bays = Mathf.RoundToInt(Mathf.Lerp(band.bayCountStartEnd.x, band.bayCountStartEnd.y, t));
             p.bayCount = new Vector2Int(bays, bays);
+            p.bayWindow = band.bayWindow;
+            p.maxSolverSeconds = band.maxSolverSeconds;
             p.deadlySpeed = Vector2.Lerp(band.deadlySpeedStart, band.deadlySpeedEnd, t);
             p.waterSpeed = Vector2.Lerp(band.waterSpeedStart, band.waterSpeedEnd, t);
             p.crashSpeed = Vector2.Lerp(band.crashSpeedStart, band.crashSpeedEnd, t);

--- a/Assets/Scripts/Editor/Generator/GeneratorParams.cs
+++ b/Assets/Scripts/Editor/Generator/GeneratorParams.cs
@@ -15,6 +15,10 @@ namespace FrogAcross.Editor.Generator
         public Vector2Int middleRows = new(6, 9);
         public Vector2Int bayCount = new(2, 4);
 
+        [Tooltip("Bays must land within this many columns of the start (0 = anywhere). "
+                 + "Keeps a teaching level a near-straight line on a wide board.")]
+        public int bayWindow;
+
         [Tooltip("Lane kind ids drawn for middle rows (weights by repetition).")]
         public string[] laneKindPool =
         {
@@ -28,6 +32,11 @@ namespace FrogAcross.Editor.Generator
         [Tooltip("Extra spacing beyond size+1.2, in cells.")]
         public Vector2 spacingSlack = new(0.8f, 3.5f);
         [Range(0f, 0.5f)] public float obstructionChance = 0.18f;
+
+        [Tooltip("Reject candidates whose optimal solve runs longer than this many seconds "
+                 + "(0 = unlimited). A wide board makes lateral distance expensive — without "
+                 + "this, a water level can need three minutes of perfect play.")]
+        public float maxSolverSeconds;
 
         public int solverNodeBudget = 250_000;
         public long solverTickBudget = 10_800;

--- a/Assets/Scripts/Editor/Generator/LevelGenerator.cs
+++ b/Assets/Scripts/Editor/Generator/LevelGenerator.cs
@@ -95,6 +95,8 @@ namespace FrogAcross.Editor.Generator
 
             // Provisional medals from the diagonal-free floor (#63 recalibrates).
             float minSec = solve.MinTicks / 60f;
+            if (p.maxSolverSeconds > 0f && minSec > p.maxSolverSeconds)
+                return (null, 0, 0, $"too long: {minSec:0}s of optimal play > {p.maxSolverSeconds:0}s");
             dto.medal = new MedalDto
             {
                 gold = Round1(minSec * 2.0f),
@@ -116,8 +118,14 @@ namespace FrogAcross.Editor.Generator
                 rows.Add(BuildRow(p.laneKindPool[rng.Next(p.laneKindPool.Length)], columns, p, rng, registry));
             rows.Add(new RowDto { kind = "bank" });
 
-            int bayN = Math.Min(rng.Next(p.bayCount.x, p.bayCount.y + 1), columns - 1);
-            var bays = Enumerable.Range(0, columns).OrderBy(_ => rng.Next()).Take(bayN).OrderBy(x => x).ToArray();
+            // start first: on a wide board a banded level can require its bays
+            // near the start, or level 1 becomes a long sideways walk
+            int startColumn = rng.Next(1, columns - 1);
+            int lo = p.bayWindow > 0 ? Math.Max(0, startColumn - p.bayWindow) : 0;
+            int hi = p.bayWindow > 0 ? Math.Min(columns - 1, startColumn + p.bayWindow) : columns - 1;
+            int bayN = Math.Min(rng.Next(p.bayCount.x, p.bayCount.y + 1), hi - lo + 1);
+            var bays = Enumerable.Range(lo, hi - lo + 1)
+                .OrderBy(_ => rng.Next()).Take(bayN).OrderBy(x => x).ToArray();
 
             return new LevelDto
             {
@@ -125,7 +133,7 @@ namespace FrogAcross.Editor.Generator
                 name = id,
                 columns = columns,
                 medal = new MedalDto { gold = 10, silver = 20, bronze = 30 }, // replaced post-solve
-                startColumn = rng.Next(1, columns - 1),
+                startColumn = startColumn,
                 bays = bays,
                 rows = rows.ToArray(),
             };

--- a/Assets/Scripts/Runtime/Levels/LevelValidator.cs
+++ b/Assets/Scripts/Runtime/Levels/LevelValidator.cs
@@ -18,7 +18,7 @@ namespace FrogAcross.Levels
 
             if (dto == null) { Err("level: not parseable as a level object"); return errors; }
             if (string.IsNullOrEmpty(dto.id)) Err("level.id: required");
-            if (dto.columns is < 5 or > 30) Err($"level.columns: {dto.columns} outside 5..30");
+            if (dto.columns is < 5 or > 48) Err($"level.columns: {dto.columns} outside 5..48"); // landscape boards run wide (2026-09-02)
             if (dto.medal == null) Err("level.medal: required");
             else if (!(dto.medal.gold > 0 && dto.medal.gold < dto.medal.silver && dto.medal.silver < dto.medal.bronze))
                 Err($"level.medal: need 0 < gold < silver < bronze (got {dto.medal?.gold}/{dto.medal?.silver}/{dto.medal?.bronze})");

--- a/Assets/Scripts/Runtime/View/GameBootstrap.cs
+++ b/Assets/Scripts/Runtime/View/GameBootstrap.cs
@@ -141,8 +141,16 @@ namespace FrogAcross.View
             // (Fitting rows alone crops the goal and bank once the roll tips
             // the corners in.)
             float roll = Mathf.Abs(BoardRollDegrees) * Mathf.Deg2Rad;
-            cam.orthographicSize = Sim.Level.Columns / 2f * Mathf.Sin(roll)
+            float halfHeight = Sim.Level.Columns / 2f * Mathf.Sin(roll)
                 + rows / 2f * Mathf.Cos(roll) + 0.35f;
+
+            // Boards are sized to fill a 21:9 panel, so on a narrower phone the
+            // width is the binding constraint — fit it too, or the edge columns
+            // fall off the screen. Zooming out here shows more apron, which is
+            // exactly what the apron rows are for.
+            float halfWidth = Sim.Level.Columns / 2f * Mathf.Cos(roll)
+                + rows / 2f * Mathf.Sin(roll) + 0.35f;
+            cam.orthographicSize = Mathf.Max(halfHeight, halfWidth / Mathf.Max(0.1f, cam.aspect));
         }
 
         private void Update()

--- a/Assets/Tests/EditMode/Content/levels-solvability.json
+++ b/Assets/Tests/EditMode/Content/levels-solvability.json
@@ -3,602 +3,602 @@
     "entries": [
         {
             "id": "level-001",
-            "fileHash": "DF16AFF227248BFEE5288A7494898769CDF41E4E9D7C0BED1C6D9E37F34571EF",
+            "fileHash": "0CCC2BA78DD3580B9B221791D545D3B58A28D952B0FC3FA8353AFE2C6275EF06",
             "minTicks": 51,
             "solved": true
         },
         {
             "id": "level-002",
-            "fileHash": "6A645D73334057A528EFF23AC2D9A62E38FCE70111A6C062A8CC9EE4BDDCB63A",
-            "minTicks": 172,
+            "fileHash": "8E30A3BB23D74F53F3CBB31A7C78540AE4129185EF52B57C4DC65F4779EBE503",
+            "minTicks": 232,
             "solved": true
         },
         {
             "id": "level-003",
-            "fileHash": "E28F7E51347738A530186C3530E449968111DBD17CD6883CA86B594ACD62B187",
-            "minTicks": 212,
-            "solved": true
-        },
-        {
-            "id": "level-004",
-            "fileHash": "7A6D20512B3A7E88B88A51CA5C14A01C7A7C7AA7AC840363680C0FE3E50E843B",
+            "fileHash": "AD4B8DA93315ED2FBEF7DBB21E891DE3193B38EBF52CBCDB474654C1093643EE",
             "minTicks": 182,
             "solved": true
         },
         {
+            "id": "level-004",
+            "fileHash": "D2264418BB881F732E93D05BFFFF1B33A319ABDB14F61D9FF59EDCD26F8206AD",
+            "minTicks": 242,
+            "solved": true
+        },
+        {
             "id": "level-005",
-            "fileHash": "EDD975289D947303619E309ED63276FBEA4FEE9B3F63307FDBEF3C6BBBFE6A00",
-            "minTicks": 152,
+            "fileHash": "06C8A762AA15FC58581012CD8449B0CF4EBBC5B31B80C2DE29E1F6F6ACDB2FEB",
+            "minTicks": 332,
             "solved": true
         },
         {
             "id": "level-006",
-            "fileHash": "C19481BE3C998A9ED045E4DF8845231CD1C16E47D8E5A102F1143F0BC7288822",
-            "minTicks": 152,
+            "fileHash": "3B16D734D0BE76EB6BD2E26F4F55C125978F9D687596594BE3D650FB50161ED2",
+            "minTicks": 272,
             "solved": true
         },
         {
             "id": "level-007",
-            "fileHash": "16B0372A609F5A76104E06155441219C6CD8C61C7EA6CDBE59466B509AD4C287",
-            "minTicks": 283,
+            "fileHash": "28EBFAE0543855DF1D6F370ADE0A3DF91DB93BBA131D98FB6940B84F97D3B0A8",
+            "minTicks": 293,
             "solved": true
         },
         {
             "id": "level-008",
-            "fileHash": "E6DC3400CF778AEE96738A82C38BE7366FBBDB3A9219855EE314ED6E8353444C",
-            "minTicks": 299,
+            "fileHash": "4ABD688F20886786426C2CCD8423F5BA102B81FAC5F9106D90DEA8EB89345120",
+            "minTicks": 443,
             "solved": true
         },
         {
             "id": "level-009",
-            "fileHash": "69D6AE5196AEF3C119497E25756163808FF35DBDF594EA60ABAA1FC127B56B88",
-            "minTicks": 233,
+            "fileHash": "7517077B10203B95CFDC7C5E714C99408FFCA102325E3190B4098201AC25BB0D",
+            "minTicks": 583,
             "solved": true
         },
         {
             "id": "level-010",
-            "fileHash": "3A99243D99F8ECE5F77669EAAC87E6D87F4AB212A2CFF503AD6922803C3B43D1",
-            "minTicks": 275,
+            "fileHash": "D1FC8FB6A58FF526E2C82C0DB37BA52AE8C88F0DC5EE1007B9A038F5DBD54741",
+            "minTicks": 523,
             "solved": true
         },
         {
             "id": "level-011",
-            "fileHash": "C983015B7341CA51DC835D11FD6302DEFA5811D53ACD22C300BFC65E565F4592",
-            "minTicks": 1857,
+            "fileHash": "6A2A05CF5487D6899AFBDC4E06EF0699A107A649D4EBA00D93777D12FA4F6420",
+            "minTicks": 304,
             "solved": true
         },
         {
             "id": "level-012",
-            "fileHash": "1FF11701B602ACFEB2D21ACF53D22B9D52BBB1FF2F3E6DF759D6AE3AABAC72F0",
+            "fileHash": "DB94E0DDE5562057F480328E9C62B5867D38A8F2CD6C9D240F70E9B58C008C19",
             "minTicks": 593,
             "solved": true
         },
         {
             "id": "level-013",
-            "fileHash": "2EA051C7F29A87A8D5BF8311FE971AC7313F587F7FDBFCD579AFBAC6D52A6D77",
-            "minTicks": 282,
+            "fileHash": "43C21B10A228BAC0D93829A507A4F58DFF32FF0B7C97F90A084966BF2E79716D",
+            "minTicks": 614,
             "solved": true
         },
         {
             "id": "level-014",
-            "fileHash": "9A314302A4E8D45707B94022FC77199F7BEB401907DF6491D57B916D4FC6CC00",
-            "minTicks": 222,
+            "fileHash": "04B4B6735FA53B5E39C89DD53FBA9F6BA1292F280E9CD11DBE82AB11F10655FD",
+            "minTicks": 502,
             "solved": true
         },
         {
             "id": "level-015",
-            "fileHash": "9BC9081C6EB466BAA2D1565C9C0600201CCE9E5BB8E5A20390DCD78E8A0D3F06",
-            "minTicks": 337,
+            "fileHash": "29B8326B2BC97BD673B0794CA4CFE465F67EDCC5E1C6C5B08691A7875DB6A048",
+            "minTicks": 284,
             "solved": true
         },
         {
             "id": "level-016",
-            "fileHash": "9ACA72D5F949CF1D65B97B906C2AD7C6BA9EF527C799C1E8C3FCD18D2A13CBD9",
-            "minTicks": 1735,
+            "fileHash": "9137EDC991A4765E7DE4F6807CE6CE4B5258F121623D14E16C4A2A7C0B20F6A6",
+            "minTicks": 848,
             "solved": true
         },
         {
             "id": "level-017",
-            "fileHash": "389529C341F75597A0A22B3D3EF0DA3FAE3E3F4E023027653AA94E2C5D2F55EA",
-            "minTicks": 382,
+            "fileHash": "E853F64676E4CA9972E8ADDB69274E1F95594C6F152687C84CC8AD6742B20865",
+            "minTicks": 398,
             "solved": true
         },
         {
             "id": "level-018",
-            "fileHash": "7CBE29589062AA187D2B1EF40080762ADA5C1600E8A25A12E406C5F76E654445",
-            "minTicks": 486,
-            "solved": true
-        },
-        {
-            "id": "level-019",
-            "fileHash": "CBFB7BF0EB97A98E097B7A239E46A7F622293A7C609B0556C52B03A8547CC71E",
-            "minTicks": 353,
-            "solved": true
-        },
-        {
-            "id": "level-020",
-            "fileHash": "14916C9DF289DE7B6612ED4E301FFE2E11E93DB5A53DB84A1CDEB0AD12B1A4D2",
-            "minTicks": 422,
-            "solved": true
-        },
-        {
-            "id": "level-021",
-            "fileHash": "0DC3B77BD842FB5B79C0B80F44C17FE077F0DEC5A8955B97D914500D62492F7B",
-            "minTicks": 222,
-            "solved": true
-        },
-        {
-            "id": "level-022",
-            "fileHash": "E5BE5A86755201ACEC26C3CE01EBB3574C66A8E499305A0F591D650CDA1EF029",
-            "minTicks": 466,
-            "solved": true
-        },
-        {
-            "id": "level-023",
-            "fileHash": "38D6CD2C5CE7D0D55677A410C9BD16548F0733F4D8F56E8D63708D7162921094",
-            "minTicks": 777,
-            "solved": true
-        },
-        {
-            "id": "level-024",
-            "fileHash": "B58185A9FEE8514131271279CDAA38A000DDE817C21DD65BE1034C5A848A976D",
-            "minTicks": 339,
-            "solved": true
-        },
-        {
-            "id": "level-025",
-            "fileHash": "F5716E99EB4956A4A02F8D1DA97DED8A9F1E96002A53C0F78500B9D85AEFB6AC",
-            "minTicks": 2075,
-            "solved": true
-        },
-        {
-            "id": "level-026",
-            "fileHash": "A2EE0FE0D43F204DA4234071DF3FA0092D6DF588C4F65E55429282F3747DC1C9",
-            "minTicks": 567,
-            "solved": true
-        },
-        {
-            "id": "level-027",
-            "fileHash": "CBEA232A809C22F7157BDF0E56BF98E5E2A2075C93530AC9C4DC566D7870C552",
-            "minTicks": 1471,
-            "solved": true
-        },
-        {
-            "id": "level-028",
-            "fileHash": "A1A539751A08C07F572318523E5A417DB92027598877EBD3C750DAA4AF5717DF",
-            "minTicks": 441,
-            "solved": true
-        },
-        {
-            "id": "level-029",
-            "fileHash": "E7CA5724C12987468409243C91D22D18C0FBD86254B9E467CEF795F580D1BB9B",
-            "minTicks": 657,
-            "solved": true
-        },
-        {
-            "id": "level-030",
-            "fileHash": "82A0F4AD86246653FA4A89D2ABD4D5C49C2AC6F471E03246B6E126E1BF33D18D",
-            "minTicks": 451,
-            "solved": true
-        },
-        {
-            "id": "level-031",
-            "fileHash": "F34A361ECE9F363A80BA121262D83E72B499DD67242E4E1C27E65776674E0EC7",
-            "minTicks": 545,
-            "solved": true
-        },
-        {
-            "id": "level-032",
-            "fileHash": "93F7CF110F6684A488BFC6FD6EC53718F58AC93470AE63F7B95054A7EFA5310B",
-            "minTicks": 443,
-            "solved": true
-        },
-        {
-            "id": "level-033",
-            "fileHash": "13A76A4DBBB2B8211F40DC7F377E395CB049897023F8D9C3020F193F5F77E628",
-            "minTicks": 402,
-            "solved": true
-        },
-        {
-            "id": "level-034",
-            "fileHash": "794D774CFF5343BE6B11F162F3364BD3BC7753EA1B5953D99883361CBDE47BA2",
-            "minTicks": 393,
-            "solved": true
-        },
-        {
-            "id": "level-035",
-            "fileHash": "EDC2A80A26B75058D81AC3A1D9F7FFC5E22A280624449CD5D2EFEEA366C0376B",
-            "minTicks": 355,
-            "solved": true
-        },
-        {
-            "id": "level-036",
-            "fileHash": "84CBD8FDE86A6A65C5975F602907B1FAB709D5E8175297B757A9EB2A4E974567",
-            "minTicks": 457,
-            "solved": true
-        },
-        {
-            "id": "level-037",
-            "fileHash": "44A77531C7F166580763A44F698C27F35526AB4CD1C6D4A70F36C0CB52B0FA85",
-            "minTicks": 604,
-            "solved": true
-        },
-        {
-            "id": "level-038",
-            "fileHash": "F201BB253B7466AE359C7AF731E89179640A31A2DBCE5A300917B584D1829AC6",
-            "minTicks": 1000,
-            "solved": true
-        },
-        {
-            "id": "level-039",
-            "fileHash": "835A69E01BA422A71D388F8E9835E0532CEAEF2289FE0461BA0931466447B112",
-            "minTicks": 759,
-            "solved": true
-        },
-        {
-            "id": "level-040",
-            "fileHash": "3C66804A8AD03A1FB4ADDC684F31E0E2CA8FA3C65C99E44A13DBCEBD494680DF",
-            "minTicks": 1745,
-            "solved": true
-        },
-        {
-            "id": "level-041",
-            "fileHash": "BA81DFDBC3A09767C63C688D624FDE0AB8CBA2DE8BFC6EF0C43EEA088E465E85",
-            "minTicks": 498,
-            "solved": true
-        },
-        {
-            "id": "level-042",
-            "fileHash": "C60896CFC50F58F59803C108CC65D9BBA82DC22763237D303C261DEB4524783A",
-            "minTicks": 465,
-            "solved": true
-        },
-        {
-            "id": "level-043",
-            "fileHash": "362DFABDE23A8FCE4B506B76171905ADBD51AAAEA89FA2A87EE158330A7F4CEB",
-            "minTicks": 478,
-            "solved": true
-        },
-        {
-            "id": "level-044",
-            "fileHash": "6BCD523EB1466D893A904C301ED574FCE46893F8C73C44FAB949CCF082DC1681",
-            "minTicks": 605,
-            "solved": true
-        },
-        {
-            "id": "level-045",
-            "fileHash": "565E334BE77AE4292DDA700517D04BA9081099465A37D5F19F97E1803F4C5FF2",
-            "minTicks": 423,
-            "solved": true
-        },
-        {
-            "id": "level-046",
-            "fileHash": "C07AD233C8FE0CB85EA36E1C97A8C27EBB9AD6FBD2BBC90A9A111997A48B279E",
-            "minTicks": 787,
-            "solved": true
-        },
-        {
-            "id": "level-047",
-            "fileHash": "59EEEBFD8A7F12E0D52F145EAED158FFF9F4369E2AC2D0429E7AF5EC37CB85E7",
-            "minTicks": 1111,
-            "solved": true
-        },
-        {
-            "id": "level-048",
-            "fileHash": "95371E2E5DFD921061715133F74C44F5840E9D1142620B2B898CDC0E0BB8F6E9",
-            "minTicks": 791,
-            "solved": true
-        },
-        {
-            "id": "level-049",
-            "fileHash": "0594760BB0591037EAC7CB6A541188FF9DC2FECAACA60B0F60C2871F313F1374",
-            "minTicks": 620,
-            "solved": true
-        },
-        {
-            "id": "level-050",
-            "fileHash": "EF873C1242AB4E378084FD7012092D8D51E33CA7DF89470A4C084EEC561E59CD",
-            "minTicks": 542,
-            "solved": true
-        },
-        {
-            "id": "level-051",
-            "fileHash": "64C3BE73B60BC60A3D17BEDB97AF1AE3F8F6778E64B3D23CA59A9BE4E8FDB429",
-            "minTicks": 313,
-            "solved": true
-        },
-        {
-            "id": "level-052",
-            "fileHash": "42C48ED8896DB5BB3695F5F90A086D0D87A9FD695E5F9FFCB601881B76AA034C",
-            "minTicks": 353,
-            "solved": true
-        },
-        {
-            "id": "level-053",
-            "fileHash": "8971EA9D5B6C62E37A82C9BA2D74E9F7D01C8E5F7262F2B7B57B744FC4F7970D",
-            "minTicks": 700,
-            "solved": true
-        },
-        {
-            "id": "level-054",
-            "fileHash": "BE3BE007B7EFCD20AA2CB4F1A791AF7F77E9C9F719E8202DB32DFC846E55C945",
-            "minTicks": 517,
-            "solved": true
-        },
-        {
-            "id": "level-055",
-            "fileHash": "31EC2A29927A7CB80C354A7D77CE76E0B0E8D81BD79CCA854069337CE02D3615",
-            "minTicks": 485,
-            "solved": true
-        },
-        {
-            "id": "level-056",
-            "fileHash": "16F199DD82F794400FA5F8103356CFD010DFD27CC438571BF9C4B022527FA79E",
-            "minTicks": 480,
-            "solved": true
-        },
-        {
-            "id": "level-057",
-            "fileHash": "45C9AF9573B326C8ACF7717B82A0D3DFBE9691356B93E2DED83BAD73A8724584",
-            "minTicks": 528,
-            "solved": true
-        },
-        {
-            "id": "level-058",
-            "fileHash": "D0DDF4B16D0037D304E8609D2A7E628DABA906383A64F8AB8EC288F35DCE4587",
-            "minTicks": 576,
-            "solved": true
-        },
-        {
-            "id": "level-059",
-            "fileHash": "11F89AC72330BDD43EC5B4A58B7A9D623F0AFA54A834747FEA2BF6C10C2A88A0",
-            "minTicks": 748,
-            "solved": true
-        },
-        {
-            "id": "level-060",
-            "fileHash": "F84C37583536F74C5E574FEC8CF9AEB6F0F149207DD8DF0D55B87F01E2B3EEE8",
-            "minTicks": 594,
-            "solved": true
-        },
-        {
-            "id": "level-061",
-            "fileHash": "9B96EDF509A77D53928D894EDF4F6990729C400F2DF8CC60A978A5DC5022129A",
-            "minTicks": 453,
-            "solved": true
-        },
-        {
-            "id": "level-062",
-            "fileHash": "DD61EC86341535A776EB8C7C3BB909F119A9337185CF62C518067085EEF37D98",
-            "minTicks": 500,
-            "solved": true
-        },
-        {
-            "id": "level-063",
-            "fileHash": "5CB0C47EAAC42A10A1BE66F2899C2D76E7971F4F62593F202EFF9E7E562A3B4B",
-            "minTicks": 523,
-            "solved": true
-        },
-        {
-            "id": "level-064",
-            "fileHash": "8927269ACAABF56895D7733FB94A1877F662FB29C22BF5D93972DF13388791A2",
-            "minTicks": 679,
-            "solved": true
-        },
-        {
-            "id": "level-065",
-            "fileHash": "D824B01347C4A1ADA7CE28F67DF055D226FE9D979A8A8761262AC3E5EE3E1D0F",
-            "minTicks": 582,
-            "solved": true
-        },
-        {
-            "id": "level-066",
-            "fileHash": "16AFCF306A4FDF7D562383BB4A048FE4AC1626C87F1A466AE0156653E3AB60F6",
-            "minTicks": 997,
-            "solved": true
-        },
-        {
-            "id": "level-067",
-            "fileHash": "DE564B581AC3BDB732D55CE4442959FE5B60F1C5600118898CFC082B46967081",
-            "minTicks": 1072,
-            "solved": true
-        },
-        {
-            "id": "level-068",
-            "fileHash": "EE52F58DD69F1176FB56C21AAB64345E1ADE4FB4FEEE126DC5421FE8B46197F3",
-            "minTicks": 703,
-            "solved": true
-        },
-        {
-            "id": "level-069",
-            "fileHash": "75B2998508B5413EAEE881B22F80A977953BE4402C3D7D3F1BFF5B4D813FD571",
-            "minTicks": 1194,
-            "solved": true
-        },
-        {
-            "id": "level-070",
-            "fileHash": "AE9C64457373A8DA32F1E7B32A165D0D9A28AE919443A3270F30171403617CBE",
-            "minTicks": 795,
-            "solved": true
-        },
-        {
-            "id": "level-071",
-            "fileHash": "5824F90C57D47A0EBCF791F267AB21212C05A3171D0EE3999CF903A4CBE1DF6E",
-            "minTicks": 1317,
-            "solved": true
-        },
-        {
-            "id": "level-072",
-            "fileHash": "F5F28ECCB8CEBC4BAFDC6469DFE7C51686E5A0B07070A57DBB83456AE774AA9E",
-            "minTicks": 1155,
-            "solved": true
-        },
-        {
-            "id": "level-073",
-            "fileHash": "D8780099CAECD3D2D4D3B4674AD08AAB913B9DF8F8C4C3A008CB1503167DB598",
-            "minTicks": 935,
-            "solved": true
-        },
-        {
-            "id": "level-074",
-            "fileHash": "00494B31221619BA61C6F711AA34F4BE24FD2E1BE7FA9EA0377A96CB91EEFD03",
-            "minTicks": 588,
-            "solved": true
-        },
-        {
-            "id": "level-075",
-            "fileHash": "C3ED01CA3D88537C194533FD7CCA7DD677CA9524F3B0FC15FB6062834FA76629",
-            "minTicks": 654,
-            "solved": true
-        },
-        {
-            "id": "level-076",
-            "fileHash": "2A5DEFF41C0553ABE329055DEBB0FD9F5FA2DDCCE86ED52FD1F22D3A479081F0",
-            "minTicks": 1257,
-            "solved": true
-        },
-        {
-            "id": "level-077",
-            "fileHash": "5DEAD396A7AA9CC09EED5D004E3A0915B9DD6A9494EE43156ACC86E5B64FC93E",
-            "minTicks": 993,
-            "solved": true
-        },
-        {
-            "id": "level-078",
-            "fileHash": "3FCC3EA8BFC4ABC3DFFA8E39210F76F3292CEF88507B3938AF854252307899C0",
-            "minTicks": 1045,
-            "solved": true
-        },
-        {
-            "id": "level-079",
-            "fileHash": "CA2FCF529A4130C8F5B7BFAF8533FDCB9F71BB24609F18EA5742831D7B5CB18A",
-            "minTicks": 583,
-            "solved": true
-        },
-        {
-            "id": "level-080",
-            "fileHash": "6FFABD5683E17B596DC34C29FEA00CCC9BA12558D52060E95DC3AE7749E8EAAD",
-            "minTicks": 1135,
-            "solved": true
-        },
-        {
-            "id": "level-081",
-            "fileHash": "30E317FF58DD6A8C0F126D33A9EFB1A0006A72F49478B6400E71917DC50862AA",
-            "minTicks": 554,
-            "solved": true
-        },
-        {
-            "id": "level-082",
-            "fileHash": "82EBA785869664C8A6580D8F7D834A7360E7D88F0EEB5233FE6A16845DF646F8",
-            "minTicks": 606,
-            "solved": true
-        },
-        {
-            "id": "level-083",
-            "fileHash": "4D8E540118F33F4C16A341EF062C1F21DD69CA71763908653027FA963CB7A51D",
-            "minTicks": 1711,
-            "solved": true
-        },
-        {
-            "id": "level-084",
-            "fileHash": "0E3C852F50989352A635549A28EC1CB4822EAA64662D813552947515F4A2C2A2",
-            "minTicks": 1847,
-            "solved": true
-        },
-        {
-            "id": "level-085",
-            "fileHash": "92C430A60107764DA9AA34A40407BF6ABD6BA6D9AB092C6EE6DD80343CE275D3",
-            "minTicks": 788,
-            "solved": true
-        },
-        {
-            "id": "level-086",
-            "fileHash": "19A8A1CDEE1BAEA31E1D6D3BFC747D2E66CD1BAC28E76D2D23B3C5492AB49F35",
-            "minTicks": 725,
-            "solved": true
-        },
-        {
-            "id": "level-087",
-            "fileHash": "CDC936ACADD6DC775F7698288A77E574227C4C4B1E16513926E2D3B71A669135",
+            "fileHash": "AEE0102CF3C07187AAB0929A40DD85FB1142CEB5E72DADB541271F064FB74D86",
             "minTicks": 641,
             "solved": true
         },
         {
-            "id": "level-088",
-            "fileHash": "035F741E9BB3824EF5BF9EF1E8710DA8DF53E4BD6047D6B2201DA5C1263C7769",
-            "minTicks": 927,
+            "id": "level-019",
+            "fileHash": "74CEB9643A53694926EB27DD9968A4123CB5FC57B90DEDDA2D328E65074F661B",
+            "minTicks": 455,
             "solved": true
         },
         {
-            "id": "level-089",
-            "fileHash": "CD27DCED7E744D451232A20F4D74FA46EB47C951C306014B4B0200FAA1D011A0",
-            "minTicks": 654,
+            "id": "level-020",
+            "fileHash": "45D7591CB94F2F3CC1267BA2C2293E25C4D9685852D7076D112AA7C32BA75F38",
+            "minTicks": 749,
             "solved": true
         },
         {
-            "id": "level-090",
-            "fileHash": "88AB1315046B8B8C903D6E5138974A2D953F52091AE0998678375C4DA48CC36E",
-            "minTicks": 610,
+            "id": "level-021",
+            "fileHash": "155CF022192554021907178BA439D72F26790B07CB0C942136D3BD688BABE625",
+            "minTicks": 313,
             "solved": true
         },
         {
-            "id": "level-091",
-            "fileHash": "B6C60266490997FF69246AB81389F21219A8727FCE54ECFEFDF307CE394DD952",
-            "minTicks": 1799,
+            "id": "level-022",
+            "fileHash": "F606651906F4A19DBD3A63F47C32D74A04F8DF95109E2268A90B9F33A792B1DF",
+            "minTicks": 374,
             "solved": true
         },
         {
-            "id": "level-092",
-            "fileHash": "D015E650380BA68A5545E1CDBD2F062F44437F6D81804F98F1F17B436583F962",
-            "minTicks": 1197,
+            "id": "level-023",
+            "fileHash": "4C9991920B5CDE9FD1C2C3F1575B0171A27C34476F23F45E46B46B6957CAD11D",
+            "minTicks": 282,
             "solved": true
         },
         {
-            "id": "level-093",
-            "fileHash": "5B48D98ED5D07C88E0B6F5CCB65295B33AB47814E81FF49384836D28B63F9BF7",
-            "minTicks": 821,
+            "id": "level-024",
+            "fileHash": "0D888466CD762046E90FEF94320F0D2300A6BF1C50F64FB46C5CABF77200EA21",
+            "minTicks": 374,
             "solved": true
         },
         {
-            "id": "level-094",
-            "fileHash": "A9D7A20467F2326D55FC08A794DFEFD8B0A60281238BCE5C64C676DBDC02267A",
-            "minTicks": 761,
+            "id": "level-025",
+            "fileHash": "9CDE3B3DE0761C87026FC56BA3D913DEE9A054D3D885CB83FA5E92E3A9D58974",
+            "minTicks": 1026,
             "solved": true
         },
         {
-            "id": "level-095",
-            "fileHash": "F49A793E609AF89328786AAFCDE35A62076F4C2F56B77826BB03167ED732B0A1",
-            "minTicks": 1063,
+            "id": "level-026",
+            "fileHash": "139CF5FAB427B17C72E30CC1CD46E3FD2FC0EB244A5339F8941ECB0F533668F1",
+            "minTicks": 797,
             "solved": true
         },
         {
-            "id": "level-096",
-            "fileHash": "2C11F55BBF6B95A141805B049322AE2A77E36F0F1C8BBA9922EB3A42A9A4C7C1",
-            "minTicks": 1041,
+            "id": "level-027",
+            "fileHash": "3A0C94E4EFCD7FC44766FEC68C404FE692F176FB547C37F05404B4D9316362E9",
+            "minTicks": 837,
             "solved": true
         },
         {
-            "id": "level-097",
-            "fileHash": "E27744BA8A71B618073455FA4B57B67DDD74920568E872E8A487740361D93F17",
-            "minTicks": 1133,
+            "id": "level-028",
+            "fileHash": "BFAA6B8B5F1432F4B08DE136B87FE8D20B30AF00A169F38537BE133E6F64DF71",
+            "minTicks": 841,
             "solved": true
         },
         {
-            "id": "level-098",
-            "fileHash": "19171CC65BAA7CF90E068D32453811460CC92FB843C15928AA4F259E53C2D5DE",
+            "id": "level-029",
+            "fileHash": "D1A5AA7F95379E03CEAA8576E1C70B7B8761DEAB6B231D5620899FDFD051EA1A",
+            "minTicks": 519,
+            "solved": true
+        },
+        {
+            "id": "level-030",
+            "fileHash": "3B7446FA624A124B515EBDAE1639AA57469168A3027C9431FA89059E26EB2EBA",
+            "minTicks": 1235,
+            "solved": true
+        },
+        {
+            "id": "level-031",
+            "fileHash": "C2A728EC78539298D0A1F53D6EEDED5D97FD33829C1D1F07E4B98E485A27C806",
+            "minTicks": 362,
+            "solved": true
+        },
+        {
+            "id": "level-032",
+            "fileHash": "DED3F8F30C69B88CB52CE55715F4A8BCE425177400946150C85C84C1E4DA0AA0",
+            "minTicks": 1061,
+            "solved": true
+        },
+        {
+            "id": "level-033",
+            "fileHash": "86645D05C1FA8128A25308B7E0F4981EA7F2DB1E4BAED5CC005E2425362A0377",
+            "minTicks": 393,
+            "solved": true
+        },
+        {
+            "id": "level-034",
+            "fileHash": "91CE761B43452985BDFCC92A6D0D1BF94A31ED1D5DDD515F06D3AACA11E2BA99",
+            "minTicks": 539,
+            "solved": true
+        },
+        {
+            "id": "level-035",
+            "fileHash": "5B81D56B8BBB924A83E1796C701BC8083AA5974BCFA9EEA61ED4649C01909C54",
+            "minTicks": 785,
+            "solved": true
+        },
+        {
+            "id": "level-036",
+            "fileHash": "1BE275B520CB9BCCE78486384BCB715E639651B5819879F08991FF84BA3B3A69",
+            "minTicks": 575,
+            "solved": true
+        },
+        {
+            "id": "level-037",
+            "fileHash": "CB139C0B5FEEFC17FEB5A396B13531CB95112A107096ACB11A07F61CDCAB26C0",
+            "minTicks": 575,
+            "solved": true
+        },
+        {
+            "id": "level-038",
+            "fileHash": "6BCC3F62D06275601A507FBC1BE3DC7AE6EE4F6636EDFA6D4C8C1A795B9E18D5",
+            "minTicks": 730,
+            "solved": true
+        },
+        {
+            "id": "level-039",
+            "fileHash": "472270F881F93A61A106D3A120D57C152225EE3796EA302294C3DEB829A7CD4F",
+            "minTicks": 960,
+            "solved": true
+        },
+        {
+            "id": "level-040",
+            "fileHash": "9F49C7312501149F6442AECD9F308012745FD4819ADF0CF03E4905B903CFD44E",
+            "minTicks": 942,
+            "solved": true
+        },
+        {
+            "id": "level-041",
+            "fileHash": "B976BCB5D2F5F8562F2C203D70F06614BAC70D13E8BCEDD7FEDD4B80F651E534",
+            "minTicks": 403,
+            "solved": true
+        },
+        {
+            "id": "level-042",
+            "fileHash": "D66EC069F4F1018543D1DAD8F87EDE996AD9DABBFD04010C128ECD51796B0539",
+            "minTicks": 591,
+            "solved": true
+        },
+        {
+            "id": "level-043",
+            "fileHash": "DA50FBD0C8CBD406E2F5FA960CBD0B800E3445F33C1E67B04C24ED622F0F6548",
+            "minTicks": 1073,
+            "solved": true
+        },
+        {
+            "id": "level-044",
+            "fileHash": "D802E3E9487B92766C8BDE9187B1EBA1F3A2440CF0CED52945B3CEFC26C777AC",
+            "minTicks": 513,
+            "solved": true
+        },
+        {
+            "id": "level-045",
+            "fileHash": "637545DD809CEB3B25792F5D223EB6230E532FD49A26B15C4D19B213BFB550D4",
+            "minTicks": 605,
+            "solved": true
+        },
+        {
+            "id": "level-046",
+            "fileHash": "A27116D7B1D692E3593A88291DB5FBBFF1384C94F99A61D73452A96E14D7E69C",
+            "minTicks": 800,
+            "solved": true
+        },
+        {
+            "id": "level-047",
+            "fileHash": "9AE33D9B2F17A5C10C23CE42D9B205CD4EB7C387AAC8608CEEC768C4B7494764",
+            "minTicks": 960,
+            "solved": true
+        },
+        {
+            "id": "level-048",
+            "fileHash": "27AEBC2C63079D8F1593BF28A8034F396C8114E179D11056CF46B325D0AAD0CF",
+            "minTicks": 690,
+            "solved": true
+        },
+        {
+            "id": "level-049",
+            "fileHash": "CA238FEC7A522076DF2A0F95885387BEF538F96D7D685ADE3E673D7F1A4CABFC",
+            "minTicks": 787,
+            "solved": true
+        },
+        {
+            "id": "level-050",
+            "fileHash": "4EFD3C76F59424B70F2204DD9CE52CE8CECF5E75179DF2836E35C55AEFD84D18",
+            "minTicks": 1064,
+            "solved": true
+        },
+        {
+            "id": "level-051",
+            "fileHash": "B07EE03DFC14446800B801D1DF4BC308417434FE04FC18F7D1773914F772252C",
+            "minTicks": 523,
+            "solved": true
+        },
+        {
+            "id": "level-052",
+            "fileHash": "C6184E0AA845816C4C6DA88F438988144BF6C921396AD814D121E344AE251E7B",
+            "minTicks": 579,
+            "solved": true
+        },
+        {
+            "id": "level-053",
+            "fileHash": "E39BF139FEF3B0693966A97ED352C85F0CB85220855DBB9C84545AF7520387D4",
+            "minTicks": 632,
+            "solved": true
+        },
+        {
+            "id": "level-054",
+            "fileHash": "F05C6018D48D1D1105D06ED0249E8DF3871C730FBC39A5DECE819780022A7BCE",
+            "minTicks": 494,
+            "solved": true
+        },
+        {
+            "id": "level-055",
+            "fileHash": "491F51E41F9A0D683EFE5B8140B27F428F8C30AE314EA6903C25AF9F35B2C07A",
+            "minTicks": 659,
+            "solved": true
+        },
+        {
+            "id": "level-056",
+            "fileHash": "B32EC197B849F7EA9B8BF8B8233375AE5E64CE7FC4C0005713B1B7ACE0888CF0",
+            "minTicks": 923,
+            "solved": true
+        },
+        {
+            "id": "level-057",
+            "fileHash": "52F6F2E1598939AD7A70E0E23DC708E17C0A76A79316D2D35F57773031E2936B",
+            "minTicks": 854,
+            "solved": true
+        },
+        {
+            "id": "level-058",
+            "fileHash": "515140408BE6078B91C2BF29C18F24E1D46BCE617BD3A834839F831B06FE0813",
+            "minTicks": 754,
+            "solved": true
+        },
+        {
+            "id": "level-059",
+            "fileHash": "87E488F664044A0EFF128AF8966878B04F82773FBD09CD7DE0D1FAFCBA9A1F07",
+            "minTicks": 998,
+            "solved": true
+        },
+        {
+            "id": "level-060",
+            "fileHash": "9C05307D0A6E36657B6D7E545A5FB566B380332C8374095A74D9C91E0333CFB1",
+            "minTicks": 576,
+            "solved": true
+        },
+        {
+            "id": "level-061",
+            "fileHash": "67B12B9C509A32B4028E678A2F0BEE1B07DED431641D2B0411E3F38BF2881A30",
+            "minTicks": 791,
+            "solved": true
+        },
+        {
+            "id": "level-062",
+            "fileHash": "B9A22E61043A294C0C15B2A5F3BD18D0EE4F0D76DF4E69B0BA09201790A34644",
+            "minTicks": 721,
+            "solved": true
+        },
+        {
+            "id": "level-063",
+            "fileHash": "D4D4449DF422C43CF04A0BD34AE6EF111F395F016483009EBA9EF2CD067A4755",
+            "minTicks": 783,
+            "solved": true
+        },
+        {
+            "id": "level-064",
+            "fileHash": "76F4F91AFB7DEBDE7DEFFA5D971C856F996CDCDDB606409D3ED60476B6E2F94C",
+            "minTicks": 743,
+            "solved": true
+        },
+        {
+            "id": "level-065",
+            "fileHash": "FB6C2C2D0E057139AE03B81684D463E8D6FA9EC480A25F50D1F48608A882546F",
+            "minTicks": 696,
+            "solved": true
+        },
+        {
+            "id": "level-066",
+            "fileHash": "594114C9E63022C7ADF75FC454F4CEDD8B4734CC374A04EB368A2790E6B8C2BB",
+            "minTicks": 669,
+            "solved": true
+        },
+        {
+            "id": "level-067",
+            "fileHash": "F05F328EA809DCCC16B47A54616C79DAFF1C28D753D2E27A7C27C5D4EB8DDC75",
+            "minTicks": 1043,
+            "solved": true
+        },
+        {
+            "id": "level-068",
+            "fileHash": "F437F8F4B588680DC7BEC8D84F25EAEE796A53F9FC212099CFF662012BFEE913",
+            "minTicks": 934,
+            "solved": true
+        },
+        {
+            "id": "level-069",
+            "fileHash": "E3E558D4FE8E9C7C4C945388BE0EA7E80337405BAE94315C99C98FF27579896C",
+            "minTicks": 890,
+            "solved": true
+        },
+        {
+            "id": "level-070",
+            "fileHash": "21889463A0A664C408862626AAFF7FEED46994B57A8815A69BD77E7B2C7ACD4D",
+            "minTicks": 808,
+            "solved": true
+        },
+        {
+            "id": "level-071",
+            "fileHash": "615C870DBDA499BA76847B2115A1683FD4E56D12795C202B867FA4436778B4C3",
+            "minTicks": 949,
+            "solved": true
+        },
+        {
+            "id": "level-072",
+            "fileHash": "02505AAD199F9BDAB050595C935478B6B22F7A8B2251CE7BD72F1CB09FDCA02D",
+            "minTicks": 824,
+            "solved": true
+        },
+        {
+            "id": "level-073",
+            "fileHash": "19E35F5788B1F253FFB859F03B238EA678E325EC7166406A62AAFFD66615A065",
+            "minTicks": 768,
+            "solved": true
+        },
+        {
+            "id": "level-074",
+            "fileHash": "C9BCF59F2BB0C2BD9C165FB7A5B7368824ED904B5BC5657B722001A4C1694AC2",
+            "minTicks": 855,
+            "solved": true
+        },
+        {
+            "id": "level-075",
+            "fileHash": "A9DA676CC8C063748E2EABE2A925629B5401966DC34962E99A9A4DAE32524AE0",
+            "minTicks": 897,
+            "solved": true
+        },
+        {
+            "id": "level-076",
+            "fileHash": "56EA8B3EEBF75EF64FD596F5A21A6CFB988A1E83164FABD68B90390E1528C237",
+            "minTicks": 1031,
+            "solved": true
+        },
+        {
+            "id": "level-077",
+            "fileHash": "005A4575C12AA970853C64303FE8604DCAAE5786831083C3054A1EE69F9F02D3",
+            "minTicks": 875,
+            "solved": true
+        },
+        {
+            "id": "level-078",
+            "fileHash": "4ED92CA7D87DF129B56D7AA78F4B6A45E9ECD652E6C7BDDE78CD9EA50E089612",
+            "minTicks": 839,
+            "solved": true
+        },
+        {
+            "id": "level-079",
+            "fileHash": "05D6F2C412B9717F0528C8707333E7A9540E73969D21C560E4D2C74ADF6C97E4",
+            "minTicks": 889,
+            "solved": true
+        },
+        {
+            "id": "level-080",
+            "fileHash": "A943C13C6C173B0D9E5284B3F99973C2FB0765C798F911814EA591475916E682",
+            "minTicks": 920,
+            "solved": true
+        },
+        {
+            "id": "level-081",
+            "fileHash": "F9F3816E02337A64451AA2CC9D4FCE4DA1097EF7C12073B85B3300F729E80AAB",
+            "minTicks": 1579,
+            "solved": true
+        },
+        {
+            "id": "level-082",
+            "fileHash": "61C67D5EC8B050F78610E93D25D8D711C2287B96029CB59A7FE24D6846A57680",
+            "minTicks": 883,
+            "solved": true
+        },
+        {
+            "id": "level-083",
+            "fileHash": "BE7C09D16D53985A8A39C879EA9F0787763056ECD79246C9C7F20EF120BDD5D0",
+            "minTicks": 854,
+            "solved": true
+        },
+        {
+            "id": "level-084",
+            "fileHash": "C655C372D8AD79C410E62E19E3D2684FC964DB92B92B4A555310A68C6FBD6498",
             "minTicks": 871,
             "solved": true
         },
         {
+            "id": "level-085",
+            "fileHash": "E4B94A5D9A6C9FAD04B5EED6E58813AE2501C9557601070E8F3D4B9AD9EB569F",
+            "minTicks": 903,
+            "solved": true
+        },
+        {
+            "id": "level-086",
+            "fileHash": "B866C954405633CA93765C6172F875AC1F95A4DF30FF836D130216A753D98A04",
+            "minTicks": 1159,
+            "solved": true
+        },
+        {
+            "id": "level-087",
+            "fileHash": "15BD97CC6B3CED29085277B5C5EE821ED645D9ECA03E8D8112FB6B566D8537E6",
+            "minTicks": 685,
+            "solved": true
+        },
+        {
+            "id": "level-088",
+            "fileHash": "DF16781C35C3F76B6A2657CF622D823FDFE72BC29EA83E5E2236ABD364D57235",
+            "minTicks": 955,
+            "solved": true
+        },
+        {
+            "id": "level-089",
+            "fileHash": "B8D0654572DB387FB6A98D11099DBF3EDBDF5D2A859BF49A768488CC7F9A494C",
+            "minTicks": 873,
+            "solved": true
+        },
+        {
+            "id": "level-090",
+            "fileHash": "AD2CE16B968D8FD36F76F5FB69452F5F38CB2B191C0810DA3A83FABD8552369A",
+            "minTicks": 803,
+            "solved": true
+        },
+        {
+            "id": "level-091",
+            "fileHash": "02F2D374DDC24B3F3168E3E820896E8143BDA5648341A05CCA2EAAC7EC09535B",
+            "minTicks": 889,
+            "solved": true
+        },
+        {
+            "id": "level-092",
+            "fileHash": "CE471017CADA407CE85454684D51F9CE87D5BB661B61734A7F22FBA37815FBDB",
+            "minTicks": 868,
+            "solved": true
+        },
+        {
+            "id": "level-093",
+            "fileHash": "3C9892CE97F5A330989C92EA2A234B1B3FAFAF9C0B881A0C40A7E3B3216D90AC",
+            "minTicks": 979,
+            "solved": true
+        },
+        {
+            "id": "level-094",
+            "fileHash": "E8FAF3060F22DA84159EE12D13605309A7A859E8C70945702D09DE52E59B90CD",
+            "minTicks": 937,
+            "solved": true
+        },
+        {
+            "id": "level-095",
+            "fileHash": "20625A5AFECBF03DC456C907B5E353A2CF00A2FF712CE00ACE0C4576AA582CAE",
+            "minTicks": 2139,
+            "solved": true
+        },
+        {
+            "id": "level-096",
+            "fileHash": "2A5117B9D0EF8D5EE0383AC2654997F5C99571288A227D9942B0554A6325D049",
+            "minTicks": 1097,
+            "solved": true
+        },
+        {
+            "id": "level-097",
+            "fileHash": "CEB7D61C0E1E2D6D8AB21956A15DE370A0AA3883ED85BDD13212A574FAA343BC",
+            "minTicks": 797,
+            "solved": true
+        },
+        {
+            "id": "level-098",
+            "fileHash": "F9DCDB7ECE266D226B4030D0D86377768343CBE1FE9341F19989918BB660D634",
+            "minTicks": 941,
+            "solved": true
+        },
+        {
             "id": "level-099",
-            "fileHash": "C76301EEF28B1919597687E03B5BEBEB3018E1A277FE6030FDF3A97777551DF0",
-            "minTicks": 971,
+            "fileHash": "F8D0A1503BBC89BDABC103F369C827662979EBF37397CF4311EF53302B8BA8BA",
+            "minTicks": 867,
             "solved": true
         },
         {
             "id": "level-100",
-            "fileHash": "F7C6547CCFCD470EFCC7C2A222C3F9DD0C9771C350C199C48CAE04F3CBFBC53D",
-            "minTicks": 994,
+            "fileHash": "02C32C3DBA6294DFE88FB5FDDD9A20261F52E10621D7B294BE9B1FB926FE2E79",
+            "minTicks": 945,
             "solved": true
         }
     ]

--- a/Assets/Tests/EditMode/Sim/BoardWidthTests.cs
+++ b/Assets/Tests/EditMode/Sim/BoardWidthTests.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using FrogAcross.Levels;
+using FrogAcross.Pieces;
+using FrogAcross.Sim;
+using NUnit.Framework;
+
+namespace FrogAcross.Tests.EditMode.Sim
+{
+    /// <summary>
+    /// Owner, 2026-09-02: "why can't the player use the whole board? The player
+    /// should be able to go all the way to the edges." The movement rules are
+    /// not the limit — this pins that down, so the reachable width can only
+    /// ever be narrowed by level data or by the camera, never by the sim.
+    /// </summary>
+    public class BoardWidthTests
+    {
+        private static float WalkTo(GameSim sim, Move dir)
+        {
+            for (int i = 0; i < 400; i++)
+            {
+                sim.EnqueueMove(dir);
+                sim.Tick();
+            }
+            return sim.State.PlayerX;
+        }
+
+        [Test]
+        public void EveryLevel_LetsThePlayerReachBothEdgeColumns()
+        {
+            var registry = PieceRegistry.Load();
+            foreach (int n in Enumerable.Range(1, LevelCatalog.Count))
+            {
+                var level = LevelLoader.LoadFromResources(LevelCatalog.IdFor(n), registry);
+
+                var left = new GameSim(level);
+                Assert.That(WalkTo(left, Move.Left), Is.EqualTo(0f).Within(0.001f),
+                    $"level {n}: the player cannot reach column 0");
+
+                var right = new GameSim(level);
+                Assert.That(WalkTo(right, Move.Right), Is.EqualTo(level.Columns - 1).Within(0.001f),
+                    $"level {n}: the player cannot reach column {level.Columns - 1}");
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Sim/BoardWidthTests.cs.meta
+++ b/Assets/Tests/EditMode/Sim/BoardWidthTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2ff52fda50c22492a8db68b0578a90e2

--- a/Assets/Tests/PlayMode/BoardViewTests.cs
+++ b/Assets/Tests/PlayMode/BoardViewTests.cs
@@ -145,9 +145,10 @@ namespace FrogAcross.Tests.PlayMode
             // This should never happen, ever… same for disappearing." The
             // camera is far wider than the board, so culling objects at the
             // board margin popped them in and out in plain sight.
-            AppShell.PendingLevelId = "level-090"; // tall board: the more rows,
-            // the wider the fitted camera, and the further past the board margin
-            // it sees (a 5-row level hid the bug behind its own zoom)
+            // The level whose narrowest lane wrap sits furthest inside the
+            // camera frame — boards now fill most of the screen, so this is
+            // where a wrap is still visible and traffic could still pop.
+            AppShell.PendingLevelId = "level-058";
             SceneManager.LoadScene("Game");
             yield return null;
             yield return null;
@@ -164,11 +165,19 @@ namespace FrogAcross.Tests.PlayMode
             float camX = cam.transform.position.x;
             float left = camX - ext, right = camX + ext;
 
-            // Each ROW wraps at its own margin (a car lane's is 3 cells, a
-            // freight lane's is 10), while the camera reaches ~20 — so a car
-            // hit its wrap point in open view and jumped to the far side.
-            Assert.That(right, Is.GreaterThan(boot.Sim.Level.Columns + 3f),
-                "this level must be one where the camera sees past a car lane's wrap");
+            // Each ROW wraps at its own margin — a rider lane's is 2 cells, a
+            // freight lane's is 10 — so the narrowest one is where an object
+            // hits its wrap point soonest, in open view.
+            float narrowest = float.MaxValue;
+            foreach (var row in boot.Sim.Level.Rows)
+            {
+                if (row.Trains.Count == 0) continue;
+                float maxSize = 1f;
+                foreach (var t in row.Trains) maxSize = Mathf.Max(maxSize, t.Def.sizeCells);
+                narrowest = Mathf.Min(narrowest, FrogAcross.Levels.LaneGeometry.MarginFor(maxSize));
+            }
+            Assert.That(right, Is.GreaterThan(boot.Sim.Level.Columns - 1 + narrowest),
+                "this level must be one where the camera still sees past a lane's wrap");
 
             // Continuity: whatever is drawn fully on screen must still be drawn
             // within one frame of travel of where it was. Wrapping is allowed


### PR DESCRIPTION
Closes #106

Owner, v0.8.1: *"Why can't the player use the whole board? The player should be able to go all the way to the edges of the game board."*

**It was never the movement rules.** A new guard walks the player to column 0 and to the last column on all 100 levels — passes. The boards were just far narrower than the screen: the camera has to show every row at once, so its height comes from the row count, and on a 21:9 panel the width that falls out is about **2.2 cells for every row**. Against 9–13 columns that left only the middle strip playable, and the full-bleed lanes made the rest look like board.

| | before | after |
|---|---|---|
| playable share of screen width | **42% avg, 34% worst** | **85% avg, 73% worst, 90% best** |
| board columns | 9–13 | 14–35 |
| gold times | 4.1s / ~20s median | 4.1s / 28.5s median / 71.3s max |

**Changes**
- Column ranges scale with row count (~2.9 per row). All 100 levels regenerated from the curve, re-locked, medals recalibrated by the solver.
- **The camera fits both axes** — boards sized for 21:9 would run off the sides of a narrower phone, so when width binds it zooms out instead of cropping the edge columns. The apron rows already cover the extra space.
- Level 1 keeps a **bay window** of 3 columns so a 14-wide board doesn't make the first level a long sideways walk.
- **A per-band ceiling on optimal play time** (8s at level 1 → 36s at 100). Narrow boards had been bounding level length by accident; the first regeneration produced levels needing **173s and 168s** of perfect play at levels 23 and 11. Now 13.6s and 17.2s.
- Level schema column cap 30 → 48.

**Caught on the way:** the curve tests flagged a pre-existing dip at level 81 — combination-1 ends on 5 bays and combination-2 restarted at 4. Fixed; the narrower boards had masked it.

**Guards:** `BoardWidthTests` walks both edges on every level. The traffic-continuity guard retargets to level-058, now the level whose narrowest lane wrap still sits inside the camera frame.

EditMode **145/145** · PlayMode **31/31**.

⚠️ Progression on device is now against levels that no longer exist — best times and medals want wiping after install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeAv87tQK1G7qsTHK3dPc