### PR TITLE
fix: put the HUD in the board's dead wedges

### DIFF
--- a/Assets/Scripts/Runtime/UI/GameHud.cs
+++ b/Assets/Scripts/Runtime/UI/GameHud.cs
@@ -25,6 +25,11 @@ namespace FrogAcross.UI
         /// they are pressed mid-run with a thumb (owner, 2026-08-30).</summary>
         public const float ButtonSize = 148f;
 
+        /// <summary>The board's wedges are shallow, so the HUD hugs the edge
+        /// tighter than a menu screen does (it is already inside the safe area).</summary>
+        private const float Inset = 40f;
+        private const float ChipHeight = 80f;
+
         public void Build(float goldSeconds)
         {
             // Rebuilt per level: the gold target on the chip belongs to the
@@ -40,27 +45,33 @@ namespace FrogAcross.UI
             safe.offsetMin = safe.offsetMax = Vector2.zero;
             safeGo.AddComponent<SafeArea>();
 
-            // The HUD kept the design's raw sizes through the type-scale pass,
-            // so it stayed phone-tiny while every other screen doubled (owner:
-            // "timer is too small", 2026-08-30).
-            var movePill = UiKit.Panel(safe, "move-pill", new Color(0.02f, 0.078f, 0.157f, 0.72f), UiKit.PillRadius);
-            movePill.rectTransform.anchorMin = movePill.rectTransform.anchorMax = new Vector2(0f, 1f);
-            movePill.rectTransform.sizeDelta = new Vector2(560, 96);
-            movePill.rectTransform.anchoredPosition = new Vector2(UiKit.EdgePad + 280, -(UiKit.EdgePad + 48));
-            _moveLabel = UiKit.Label(movePill.transform, "SWIPE ▲ FORWARD", UiKit.Caption, UiKit.TextBlue,
-                Vector2.zero, new Vector2(540, 56));
-
+            // The board rolls -8°, so on screen BOTH its edges rise left to
+            // right: the free wedges are above its low left end and below its
+            // high right end. Everything the HUD draws goes in one of those
+            // two corners — the timer used to sit top-right, where the goal
+            // row reaches highest, and swallowed landing pads on a wide board
+            // (owner, 2026-09-02). Sizes are on the type scale since 2026-08-30.
             var timePill = UiKit.Panel(safe, "time-pill", new Color(0.02f, 0.078f, 0.157f, 0.72f), UiKit.PillRadius);
-            timePill.rectTransform.anchorMin = timePill.rectTransform.anchorMax = new Vector2(1f, 1f);
-            timePill.rectTransform.sizeDelta = new Vector2(600, 96);
-            timePill.rectTransform.anchoredPosition = new Vector2(-(UiKit.EdgePad + 300), -(UiKit.EdgePad + 48));
+            timePill.rectTransform.anchorMin = timePill.rectTransform.anchorMax = new Vector2(0f, 1f);
+            timePill.rectTransform.sizeDelta = new Vector2(540, ChipHeight);
+            timePill.rectTransform.anchoredPosition = new Vector2(Inset + 270, -(Inset + ChipHeight / 2f));
             _timer = UiKit.Label(timePill.transform, "0.0", UiKit.Title, UiKit.White,
-                new Vector2(-130, 0), new Vector2(280, 78));
+                new Vector2(-110, 0), new Vector2(260, 78));
             var dot = UiKit.Panel(timePill.transform, "gold-dot", UiKit.Gold, UiKit.PillRadius);
             dot.rectTransform.sizeDelta = new Vector2(26, 26);
-            dot.rectTransform.anchoredPosition = new Vector2(58, 0);
+            dot.rectTransform.anchoredPosition = new Vector2(48, 0);
             UiKit.Label(timePill.transform, $"{goldSeconds:0.0}s", UiKit.Caption, UiKit.TextBlue,
-                new Vector2(180, 0), new Vector2(200, 44));
+                new Vector2(160, 0), new Vector2(180, 44));
+
+            // The wedge is a triangle: widest along the very top edge and
+            // narrowing as you descend, so the hint goes BESIDE the clock, not
+            // under it — stacked, its second row ran into the goal row.
+            var movePill = UiKit.Panel(safe, "move-pill", new Color(0.02f, 0.078f, 0.157f, 0.72f), UiKit.PillRadius);
+            movePill.rectTransform.anchorMin = movePill.rectTransform.anchorMax = new Vector2(0f, 1f);
+            movePill.rectTransform.sizeDelta = new Vector2(340, ChipHeight);
+            movePill.rectTransform.anchoredPosition = new Vector2(Inset + 564 + 170, -(Inset + ChipHeight / 2f));
+            _moveLabel = UiKit.Label(movePill.transform, "▲ FORWARD", UiKit.Caption, UiKit.TextBlue,
+                Vector2.zero, new Vector2(320, 56));
 
             // corner buttons (owner amendment): dialogs freeze the sim
             var restart = UiKit.Button(safe, "↻", Vector2.zero, new Vector2(ButtonSize, ButtonSize), () =>
@@ -106,11 +117,11 @@ namespace FrogAcross.UI
             _timer.text = (sim.State.ClockTicks / (float)SimConfig.TicksPerSecond).ToString("0.0");
             _moveLabel.text = sim.State.Facing switch
             {
-                Move.Back => "SWIPE ▼ BACK",
-                Move.Left or Move.DiagForwardLeft or Move.DiagBackLeft => "SWIPE ◀ LEFT",
-                Move.Right or Move.DiagForwardRight or Move.DiagBackRight => "SWIPE ▶ RIGHT",
-                _ => "SWIPE ▲ FORWARD",
-            };
+                Move.Back => "▼ BACK",
+                Move.Left or Move.DiagForwardLeft or Move.DiagBackLeft => "◀ LEFT",
+                Move.Right or Move.DiagForwardRight or Move.DiagBackRight => "▶ RIGHT",
+                _ => "▲ FORWARD",
+            }; // it used to say SWIPE even with tap regions selected
         }
     }
 }

--- a/Assets/Tests/PlayMode/GameSceneTests.cs
+++ b/Assets/Tests/PlayMode/GameSceneTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.IO;
+using System.Linq;
 using FrogAcross.Pieces;
 using FrogAcross.Services;
 using FrogAcross.Sim;
@@ -8,6 +9,7 @@ using FrogAcross.View;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using UnityEngine.UI;
 using UnityEngine.TestTools;
 
 namespace FrogAcross.Tests.PlayMode
@@ -49,6 +51,54 @@ namespace FrogAcross.Tests.PlayMode
             SceneManager.LoadScene("Game");
             yield return null; // Start runs
             yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator HudChipsNeverCoverALandingPad()
+        {
+            // The board rolls -8°, so both its edges rise left to right: the
+            // free wedges are top-left and bottom-right, and that is where the
+            // HUD lives. The clock used to sit top-right — the corner where the
+            // goal row reaches highest — and hid landing pads once boards grew
+            // wide (owner, 2026-09-02).
+            foreach (string levelId in new[] { "level-001", "level-058", "level-090", "level-100" })
+            {
+                yield return LoadGame(levelId);
+                var boot = Object.FindAnyObjectByType<GameBootstrap>();
+                var cam = Camera.main;
+                cam.aspect = 3120f / 1440f; // the owner's panel
+                boot.SendMessage("FitCamera");
+                yield return null;
+
+                // Measure from the canvas EDGES, not its centre: the runner's
+                // canvas is as wide as its own screen, and we are asking about
+                // a 21:9 one. Height is always 1080 (the scaler matches height)
+                // and the chips are edge-anchored, so edge-relative coordinates
+                // carry across.
+                var canvasRt = (RectTransform)GameObject.Find("hud").GetComponent<Canvas>().transform;
+                float canvasH = 1080f, canvasW = canvasH * cam.aspect;
+
+                foreach (string chip in new[] { "time-pill", "move-pill" })
+                {
+                    var rt = (RectTransform)canvasRt.GetComponentsInChildren<Transform>(true)
+                        .First(t => t.name == chip);
+                    var box = RectTransformUtility.CalculateRelativeRectTransformBounds(canvasRt, rt);
+                    float fromLeft = box.center.x + canvasRt.rect.width / 2f;
+                    float fromTop = canvasRt.rect.height / 2f - box.center.y;
+
+                    foreach (int bay in boot.Sim.Level.BayColumns)
+                    {
+                        var vp = cam.WorldToViewportPoint(new Vector3(bay, 0f, 0f)); // goal row is row 0
+                        float padLeft = vp.x * canvasW, padTop = (1f - vp.y) * canvasH;
+                        // a pad is ~0.9 cells wide; clear it, with a little room
+                        bool overX = Mathf.Abs(padLeft - fromLeft) < box.size.x / 2f + 50f;
+                        bool overY = Mathf.Abs(padTop - fromTop) < box.size.y / 2f + 50f;
+                        Assert.That(overX && overY, Is.False,
+                            $"{levelId}: '{chip}' covers the landing pad at column {bay} "
+                            + $"(pad {padLeft:0},{padTop:0} vs chip {fromLeft:0},{fromTop:0})");
+                    }
+                }
+            }
         }
 
         [UnityTest]


### PR DESCRIPTION
Closes #108

Owner: *"Because of the orientation of the board, isn't the top-left the best place for the HUD, and the bottom right for the buttons? (Which is where the buttons are now)"*

Right — and the tilt is exactly why. The camera rolls −8°, so on screen the board turns counter-clockwise and **both its edges rise from left to right**, leaving two wedges of dead space: above the board's low left end, and below its high right end. The buttons were already in the second one. The clock was in the worst corner available — top-right, where the goal row reaches highest — which is how it ended up sitting on landing pads once boards were widened in #106.

**Changes**
- Clock to the **top-left**, move hint **beside** it rather than under it.
- Chips hug the edge (40px inset — they're already inside the safe area) and are 80px tall instead of 96.
- The hint reads `▲ FORWARD` rather than `SWIPE ▲ FORWARD`: shorter, and it no longer says "swipe" to players who chose tap regions.

**The guard did the design work.** `HudChipsNeverCoverALandingPad` checks every bay on levels 1, 58, 90 and 100 against every HUD chip at the 21:9 aspect, and it rejected two attempts before this one:

1. **Stacked** (clock above, hint below) — the wedge is a triangle that *narrows* as it descends, so the second row ran into the goal row on level-090.
2. **Side by side at the old size** — 6px of clearance on level-058, the level whose board covers least of the screen.

The number that settles the layout: at the far left the wedge is ~26% of screen height, closing to ~2% at the right edge. Everything the HUD draws has to fit inside that.

EditMode **145/145** · PlayMode **32/32**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeAv87tQK1G7qsTHK3dPc